### PR TITLE
Mobile breakpoint is now below 1056px instead of 672px

### DIFF
--- a/theme/light/src/styles/core/grid/_breakpoints.scss
+++ b/theme/light/src/styles/core/grid/_breakpoints.scss
@@ -97,9 +97,7 @@ $sdds-grid-breakpoints-push: (
     margin: $spacing-layout-16,
     padding: $spacing-layout-8,
     gutter: $spacing-layout-16,
-    content: 432px,
-    sidebar: 240px,
-    display: block
+    display: none
   ),
   lg: (
     width: 1056px,


### PR DESCRIPTION
**Describe pull-request**  
_Describe what the pull-request is about_
Mobile breakpoint is now below 1056px instead of 672px

**Solving issue**  
_Add which issue this pull-request solves by adding # plus the number of the issue (for example #123)_
Fixes: Breakpoint change in figma from sm to md for mobile view

**How to test**  
_Add description how to test if possible_
Run grid and and sidebar should be removed at 1055px and below
