### PR TITLE
Add typography package css & scss

### DIFF
--- a/theme/light/src/styles/core/typography/_tokens.scss
+++ b/theme/light/src/styles/core/typography/_tokens.scss
@@ -1,3 +1,4 @@
+@import './vars';
 // Typography tokens
 // FUNCTIONAL TYPE
 $headline-01: (

--- a/theme/light/src/styles/core/typography/compile.js
+++ b/theme/light/src/styles/core/typography/compile.js
@@ -26,7 +26,7 @@ function createFolders() {
   console.log('creating folders...')
   fs.mkdirSync(outputFolder);
   fs.mkdirSync(`${outputFolder}/css`);
-  // fs.mkdirSync(`${outputFolder}/scss`);
+  fs.mkdirSync(`${outputFolder}/scss`);
 }
 
 // Create a scss folder will all scss files in current folder
@@ -35,18 +35,34 @@ function generateScss(name, data) {
   fs.writeFileSync(`${outputFolder}/scss/${name}.scss`, data)
 }
 
+function importFile(data) {
+  const toMatch =/(@import '\.\.\/(.*)\')/gm;
+  const files = toMatch.exec(data);
+  
+  if(files!==null){
+    const filePath = path.join(__dirname, '../', '_' + files[2] + '.scss');
+    const output = `${outputFolder}/_${files[2]}.scss`;
+    fs.createReadStream(filePath).pipe(fs.createWriteStream(output));
+  }
+}
+
 // Creates a css file for each scss file in current folder
 function generateCss(file) {
   const name = path.parse(file).name;
   console.log(`file: ${file}`)
-  const data = fs.readFileSync(path.resolve(file), 'utf8');
+  
+  fs.readFile(path.resolve(file), 'utf8', function(err, data){
+    if(err) throw err;
 
-  const content = sass.renderSync({
-    data
-  });
+    importFile(data);
 
-  fs.writeFileSync(`${outputFolder}/css/${name.replace('_','')}.css`, content.css)
-  // generateScss(name,data);
+    const content = sass.renderSync({
+      data
+    });
+  
+    fs.writeFileSync(`${outputFolder}/css/${name.replace('_','')}.css`, content.css)
+    generateScss(name,data);
+  })
 }
 
 

--- a/theme/light/src/styles/core/typography/package.json
+++ b/theme/light/src/styles/core/typography/package.json
@@ -1,10 +1,14 @@
 {
-  "name": "@scania/typography",
+  "name": "@scania-sdds/typography",
   "version": "1.0.0-alpha.0",
   "description": "Scania Digital Design System Typography",
   "scripts": {
     "build": "node compile.js"
   },
+  "files": [
+    "dist"
+  ],
+  "main": "dist/scss/_typography.scss",
   "author": "",
   "license": "ISC",
   "dependencies": {},


### PR DESCRIPTION
- Add imported files needed for typography from compiler


**How to test**  
Run npm run build inside typography.
External file import is included in the package (Base_unit)

**Screenshots**  
![image](https://user-images.githubusercontent.com/1199101/101489135-ce8e2d80-3960-11eb-8db6-2e3ce35d46da.png)


**Additional context**  
_Add any other context about the pull-request here._
