### PR TITLE
AB#520 Fix dropdown behaviour

### DIFF
--- a/components/src/components/dropdown/dropdown-option.tsx
+++ b/components/src/components/dropdown/dropdown-option.tsx
@@ -1,6 +1,6 @@
 import {
     Component, h, Prop, State, Element, Host,
-    Event, EventEmitter, Listen
+    Event, EventEmitter
   } from '@stencil/core';
   
   @Component({
@@ -12,12 +12,14 @@ import {
     
     @Element() host: HTMLElement;
 
-    @State() selected:boolean=false;
     // Used as a fallback if value prop is not recognized to match handleClick
     @State() innerValue:string;
 
+    /** Selected set to true if selected */
+    @Prop() selected:boolean=false;
+
     /** Value is a unique string that will be used for application logic */
-    @Prop() value:string;    
+    @Prop({ reflect:true }) value:string;    
 
     @Event({
       eventName: 'selectOption',
@@ -30,24 +32,18 @@ import {
       this.innerValue = this.value;
     }
 
-    @Listen('click', { target: 'document' })
-    handleClick(ev) {
-      // To stop bubble click
-      ev.stopPropagation();
-      
-      const target = ev.target.getAttribute('value');
-      if(target !== this.innerValue) this.selected = false;
-    }
-
     selectOptionHandler(value) {
       this.selectOption.emit(value);
+      value.parent.children.forEach(optionEl => {
+        optionEl.selected = false;
+      });
       this.selected = true;
     }    
   
     render() {
       return (
         <Host 
-        onClick={()=>this.selectOptionHandler({value: this.value, label: this.host.innerHTML})}
+        onClick={(ev)=>this.selectOptionHandler({value: this.value, label: this.host.innerHTML, parent: ev.target.parentNode})}
         class={{
           'selected': this.selected
         }}>

--- a/components/src/components/dropdown/dropdown.stories.js
+++ b/components/src/components/dropdown/dropdown.stories.js
@@ -45,6 +45,12 @@ export default {
       defaultValue: 'default',
       description: 'Support error state'
     },
+    defaultOption: {
+      control: {
+        type: 'select',
+        options:['no-default', 'option-1', 'option-2', 'option-3']
+      }
+    }
   }
 };
   
@@ -56,7 +62,8 @@ const Template = ({
   labelPosition,
   helper='',
   state='default',
-  placeholder}) => {
+  placeholder,
+  defaultOption}) => {
   return `
   <c-theme name="scania"></c-theme>
   
@@ -71,14 +78,14 @@ const Template = ({
           label="${label}"
           helper="${helper}"
           state="${state}"
-          type="${type}">
+          type="${type}"
+          default-option="${defaultOption}">
           <sdds-dropdown-option value="option-1">Option 1</sdds-dropdown-option>
           <sdds-dropdown-option value="option-2">Option 2</sdds-dropdown-option>
           <sdds-dropdown-option value="option-3">Option 3</sdds-dropdown-option>
         </sdds-dropdown>
       </div>
     </div>
-  </div>
   `
 };
 
@@ -115,7 +122,8 @@ const FilterTemplate = ({
   size,
   disabled=false,
   helper='',
-  placeholder}) => {
+  placeholder,
+  defaultOption}) => {
   return `
     <c-theme name="scania"></c-theme>
     <div class="sdds-container" style="margin-top:10rem;">
@@ -126,7 +134,8 @@ const FilterTemplate = ({
         placeholder="${placeholder}"
         disabled="${disabled}"
         helper="${helper}"
-        data='[{"value":"opt-1","label":"Jakarta"},{"value":"opt-2","label":"Stockholm"},{"value":"opt-3","label":"Barcelona"}]'
+        default-option="${defaultOption}"
+        data='[{"value":"option-1","label":"Jakarta"},{"value":"option-2","label":"Stockholm"},{"value":"option-3","label":"Barcelona"}]'
         ></sdds-dropdown-filter>
       </div>
       </div>

--- a/components/src/components/dropdown/dropdown.tsx
+++ b/components/src/components/dropdown/dropdown.tsx
@@ -50,6 +50,20 @@ export class Dropdown {
 
   @Element() host: HTMLElement;
 
+  componentWillLoad(){
+    // If default option is set, update the default selected value
+    // this.host.children is a HTMLCollection type, cannot use forEach
+    if(this.defaultOption) {
+      for (let i=0; i<this.host.children.length; i++){
+        const el = this.host.children[i];
+        if(el['value'] === this.defaultOption){
+          this.selected = el.innerHTML;
+          el.setAttribute('selected','true');
+        }
+      }
+    }
+  }
+
   @Listen('click', { target: 'document' })
   handleClick(ev) {
     // To stop bubble click
@@ -57,7 +71,7 @@ export class Dropdown {
     
     const target = ev ? ev.composedPath()[0] : window.event.target[0];
 
-    if(this.node.contains(target)) {
+    if(this.node!==undefined && this.node.contains(target)) {
       if(typeof this.textInput !== 'undefined' || this.textInput === null) this.textInput.focus();
       this.open = !this.open;
     } else {

--- a/components/src/components/dropdown/readme.md
+++ b/components/src/components/dropdown/readme.md
@@ -3,11 +3,13 @@
 ```html
 <sdds-dropdown 
     size="large"
-    label="Select option"
+    placeholder="Select option"
+    label="Label text"
     disabled="false"
     label-position="no-label"
     helper="Helper text"
-    state="default">
+    state="default"
+    default-option="option-1">
     <sdds-dropdown-option value="option-1">Option 1</sdds-dropdown-option>
     <sdds-dropdown-option value="option-2">Option 2</sdds-dropdown-option>
     <sdds-dropdown-option value="option-3">Option 3</sdds-dropdown-option>
@@ -19,9 +21,10 @@
 
 ## Properties
 
-| Property | Attribute | Description                                                      | Type     | Default     |
-| -------- | --------- | ---------------------------------------------------------------- | -------- | ----------- |
-| `value`  | `value`   | Value is a unique string that will be used for application logic | `string` | `undefined` |
+| Property   | Attribute  | Description                                                      | Type      | Default     |
+| ---------- | ---------- | ---------------------------------------------------------------- | --------- | ----------- |
+| `selected` | `selected` | Selected set to true if selected                                 | `boolean` | `false`     |
+| `value`    | `value`    | Value is a unique string that will be used for application logic | `string`  | `undefined` |
 
 
 ## Events

--- a/components/src/patterns/dropdown-filter/dropdown-filter.tsx
+++ b/components/src/patterns/dropdown-filter/dropdown-filter.tsx
@@ -46,6 +46,10 @@ export class DropdownFilter {
 
   componentWillLoad(){
     this.parseData(this.data);
+
+    if(this.defaultOption) {
+      this.selectedOption = this.defaultOption;
+    }
   }
 
   @Watch('data')
@@ -85,7 +89,8 @@ export class DropdownFilter {
 
   setOptionsContent(){
     return (this.filteredContent.map((obj) =>
-      <sdds-dropdown-option value={obj.value} class={`${(this.selectedOption === obj.value ? 'selected':'')}`}>{obj.label}</sdds-dropdown-option>
+      <sdds-dropdown-option value={obj.value}
+      class={`${(this.selectedOption === obj.value ? 'selected':'')}`}>{obj.label}</sdds-dropdown-option>
     ))
   }
 
@@ -95,10 +100,11 @@ export class DropdownFilter {
         size={this.size}
         label={this.label}
         disabled={this.disabled}
-        label-position={this.labelPosition}
+        labelPosition={this.labelPosition}
         helper={this.helper}
         state={this.state}        
         placeholder={this.placeholder}
+        defaultOption={this.defaultOption}
         type="filter">
           {this.setOptionsContent()}
       </sdds-dropdown>


### PR DESCRIPTION
**Describe pull-request**  
- When click outside, keep selected value
- Set default option to work


**Solving issue**  
_Add which issue this pull-request solves by adding # plus the number of the issue (for example #123)_
Fixes: #90 [AB#520](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/520)

**How to test**  

### **1. Initial bug**
- Open storybook
- Go to dropdown
- Select one of the option
- Click outside
- See the selected option is still selected

### **2. Test if 2 dropdown exist**
- Previously, selected will lose classes if 2 dropdown exist, and if we click on the other dropdown
- Now it should only detect click based on parent dropdown
- So, we can have multiple dropdown in one page and select will work based on its own parent
- Add (copy paste) dropdown html in storybook
- see selected work for both dropdown

### **3. Test default-option**
- Go to storybook control
- See defaultOption in control
- Pick one of the option as default
- See it changes in the dropdown
- Check in Dropdown filter as well

**Screenshots**  
_If applicable, add screenshots to help explain_

**Additional context**  
_Add any other context about the pull-request here._
