### PR TITLE
AB#519 Add spacing vars into grid package

### DIFF
--- a/theme/core/grid/_grid.scss
+++ b/theme/core/grid/_grid.scss
@@ -1,7 +1,7 @@
 @import '../prefix';
 @import 'breakpoints';
 @import 'mixins';
-@import '../spacing/spacing-vars.scss';
+@import '../spacing/spacing-vars';
 
 /*
 Mixin file for create grid layout, container, rows and columns

--- a/theme/core/grid/_grid.scss
+++ b/theme/core/grid/_grid.scss
@@ -1,6 +1,7 @@
 @import '../prefix';
 @import 'breakpoints';
 @import 'mixins';
+@import '../spacing/spacing-vars.scss';
 
 /*
 Mixin file for create grid layout, container, rows and columns


### PR DESCRIPTION
- Spacing scss is included in the grid package
- Added CSS vars for spacing in the main grid.css to be able to be used through css as well

Fix: #27 [AB#519](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/519)

How to test:

Compile grid package
Use / import in a bare new app
See spacing CSS vars is added in the root html
