### PR TITLE
Push grid collapse and fix for non fluid push

### DIFF
--- a/components/src/components/theme/grid.stories.js
+++ b/components/src/components/theme/grid.stories.js
@@ -1,5 +1,8 @@
 export default {
   title: 'Foundation/Grid',
+  args: {
+    fluidContainer: true
+  }
 };
 
 //Styling for grid templates
@@ -73,7 +76,7 @@ const style = `
 
   </style>`;
 
-const GridTemplate = ({fluidContainer}) => {
+const GridTemplate = ({fluidContainer,padding,gutter}) => {
   return `
   ${style}
   <sdds-theme name="scania" global=""></sdds-theme>
@@ -191,13 +194,13 @@ const GridTemplate = ({fluidContainer}) => {
   `
 };
 
-const GridPushTemplate = ({fluidContainer}) => {
+const GridPushTemplate = ({fluidContainer, collapse}) => {
   return `
   ${style}
   <sdds-theme name="scania" global="true"></sdds-theme>
   <h4>Grid Push</h4>
   <div class="sdds-push">
-    <div class="sdds-sidebar">
+    <div class="sdds-sidebar ${collapse ? `sdds-sidebar-collapse` : ``}">
     </div>
     <div class="${fluidContainer == true ? 'sdds-container-fluid': 'sdds-container'}">
     <div class="sdds-row">
@@ -350,7 +353,7 @@ const GridAutoColTemplate = ({fluidContainer}) => {
   `
 }
 
-const GridGutterless = ({fluidContainer}) => {
+const GridGutterless = ({fluidContainer,gutter}) => {
   return `
     ${style}
     <sdds-theme name="scania" global="true"></sdds-theme>
@@ -363,10 +366,10 @@ const GridGutterless = ({fluidContainer}) => {
         <div class="gutterless sdds-col-xxlg-8 sdds-col-xlg-8 sdds-col-lg-8 sdds-col-md-4 sdds-col-sm-2">
           <div>.gutterless</div>
         </div>
-        <div class="sdds-col-xxlg-8 sdds-col-xlg-8 sdds-col-lg-8 sdds-col-md-4 sdds-col-sm-2">
+        <div class="${gutter ? 'gutterless' : ''} sdds-col-xxlg-8 sdds-col-xlg-8 sdds-col-lg-8 sdds-col-md-4 sdds-col-sm-2">
           <div>gutter</div>
         </div>
-        <div class="sdds-col-xxlg-8 sdds-col-xlg-8 sdds-col-lg-8 sdds-col-md-4 sdds-col-sm-2">
+        <div class="${gutter ? 'gutterless' : ''} sdds-col-xxlg-8 sdds-col-xlg-8 sdds-col-lg-8 sdds-col-md-4 sdds-col-sm-2">
           <div>gutter</div>
         </div>
       </div>
@@ -374,7 +377,7 @@ const GridGutterless = ({fluidContainer}) => {
   `
 }
 
-const GridNoPadding = ({fluidContainer}) => {
+const GridNoPadding = ({fluidContainer,padding}) => {
   return `
     ${style}
     <sdds-theme name="scania" global="true"></sdds-theme>
@@ -387,10 +390,10 @@ const GridNoPadding = ({fluidContainer}) => {
         <div class="no-padding sdds-col-xxlg-8 sdds-col-xlg-8 sdds-col-lg-8 sdds-col-md-4 sdds-col-sm-2">
           <div>.no-padding</div>
         </div>
-        <div class="sdds-col-xxlg-8 sdds-col-xlg-8 sdds-col-lg-8 sdds-col-md-4 sdds-col-sm-2">
+        <div class="${padding ? '' : 'no-padding' } sdds-col-xxlg-8 sdds-col-xlg-8 sdds-col-lg-8 sdds-col-md-4 sdds-col-sm-2">
           <div>With padding</div>
         </div>
-        <div class="sdds-col-xxlg-8 sdds-col-xlg-8 sdds-col-lg-8 sdds-col-md-4 sdds-col-sm-2">
+        <div class="${padding ? '' : 'no-padding' } sdds-col-xxlg-8 sdds-col-xlg-8 sdds-col-lg-8 sdds-col-md-4 sdds-col-sm-2">
           <div>With padding</div>
         </div>
       </div>
@@ -398,7 +401,7 @@ const GridNoPadding = ({fluidContainer}) => {
   `
 }
 
-const GridFluid = () => {
+const GridFluid = ({fluidContainer}) => {
   return `
     ${style}
     <sdds-theme name="scania" global="true"></sdds-theme>
@@ -409,7 +412,7 @@ const GridFluid = () => {
       </div>
     </div>
 
-    <div class="sdds-container container-demo">
+    <div class="${fluidContainer ? 'sdds-container-fluid': 'sdds-container'} container-demo">
       <div class="sdds-row">
         <div class="sdds-col-xxlg-16 sdds-col-xlg-16 sdds-col-lg-16 sdds-col-md-8 sdds-col-sm-2">sdds-container</div>
       </div>
@@ -418,74 +421,36 @@ const GridFluid = () => {
 }
 
 
-//Grid default controls for all grid
-const defaultOptions = {
-  fluidContainer: {control: { type: 'boolean'}, description: "Set the container as fluid, set fullscreen", name: 'Fluid container'},
-}
-
-//Grid default values for control for all grid
-const defaultOptionsValues = {
-  fluidContainer: false,
-}
-
 //Controls for the grid
 export const Basic = GridTemplate.bind({});
 
-Basic.argTypes = {
- ...defaultOptions
-}
-
-Basic.args = {
- ...defaultOptionsValues
-}
-
 export const Push = GridPushTemplate.bind({});
 
-Push.argTypes = {
-  ...defaultOptions,
-}
-
 Push.args = {
-  ...defaultOptionsValues,
+  collapse: false
 }
 
 export const Offset = GridOffsetTemplate.bind({})
 
-Offset.argTypes = {}
-Offset.argTypes.fluidContainer = defaultOptions.fluidContainer
-
-Offset.args = {
-  fluidContainer: false
-}
-
 export const Auto = GridAutoColTemplate.bind({});
-
-Auto.argTypes = {}
-Auto.argTypes.fluidContainer = defaultOptions.fluidContainer
-
-Auto.args = {
-  fluidContainer: false
-}
 
 export const Gutterless = GridGutterless.bind({});
 
-Gutterless.argTypes = {}
-Gutterless.argTypes.fluidContainer = defaultOptions.fluidContainer
-
 Gutterless.args = {
-  fluidContainer: false
+  gutter: false
 }
 
 export const NoPadding = GridNoPadding.bind({});
 
-NoPadding.argTypes = {}
-NoPadding.argTypes.fluidContainer = defaultOptions.fluidContainer
-
 NoPadding.args = {
-  fluidContainer: false
+  padding: true
 }
 
 export const Fluid = GridFluid.bind({});
+
+Fluid.args = {
+  fluidContainer: false
+}
 
 
 

--- a/theme/core/grid/_mixins.scss
+++ b/theme/core/grid/_mixins.scss
@@ -3,17 +3,16 @@
 
 // Containers
 @mixin grid-container($prefix) {
-  .#{$prefix}-container {
-    margin-left: auto;
-    margin-right: auto;
-    width: 100%;
-    max-width: $screen-xxl;
-  }
 
+  .#{$prefix}-container,
   .#{$prefix}-container-fluid {
     margin-left: auto;
     margin-right: auto;
     width: 100%;
+  }
+
+  .#{$prefix}-container {
+    max-width: $screen-xxl;
   }
 
 }
@@ -84,7 +83,7 @@
 
 @mixin grid-make-col-auto($prefix, $sizes, $width, $padding, $gutter) {
 
-  @media (min-width:  $width) {
+  @media (min-width: $width) {
     .#{$prefix}-col ,.#{$prefix}-col-#{$sizes} {
       flex-grow: 1;
       flex-basis: 0;
@@ -141,7 +140,6 @@ Gutters
         .#{$prefix}-col-#{$sizes}-#{$i}.gutterless {
           @include grid-col-size($breakpoint-columns, $i);
           @include grid-gutters($breakpoint-gutter, $breakpoint-padding);
-          margin: 0;
         }
       }
     }
@@ -183,7 +181,12 @@ Gutters
   @include grid-push-container($breakpoints);
   .#{$prefix}-push {
     display: flex;
-    @include grid-make-col($breakpoints)
+    justify-content: center;
+    @include grid-make-col($breakpoints);
+
+    .#{$prefix}-container {
+      margin: 0;
+    }
   }
 
   .#{$prefix}-content-push {
@@ -191,6 +194,10 @@ Gutters
   }
 }
 
+
+/*
+No padding option
+*/
 @mixin grid-push-no-padding($breakpoints) {
   @each $sizes, $values in $breakpoints {
     $breakpoint-columns: map-get($values, 'columns');
@@ -199,23 +206,27 @@ Gutters
     $breakpoint-width: map-get($values, 'width');
 
    // Create columns that doesn't need a number, it bases it spacing on the area available
-   @include grid-make-col-auto($prefix,$sizes ,$breakpoint-width ,$breakpoint-padding , $breakpoint-gutter);
+    @include grid-make-col-auto($prefix,$sizes ,$breakpoint-width ,$breakpoint-padding , $breakpoint-gutter);
 
-   //  Each column for everysize
-   @for $i from 1 through $breakpoint-columns {
+    //  Each column for everysize
+    @for $i from 1 through $breakpoint-columns {
 
-     @include grid-col-size-full-width($prefix, $sizes, $i);
+      @include grid-col-size-full-width($prefix, $sizes, $i);
 
-     @media (min-width:  $breakpoint-width ) {
-       .#{$prefix}-col-#{$sizes}-#{$i}.no-padding {
-         @include grid-col-size($breakpoint-columns, $i);
-         @include grid-gutters($breakpoint-gutter, $breakpoint-padding);
-       }
-     }
-   }
- }
+      @media (min-width:  $breakpoint-width ) {
+        .#{$prefix}-col-#{$sizes}-#{$i}.no-padding {
+          @include grid-col-size($breakpoint-columns, $i);
+          @include grid-gutters($breakpoint-gutter, $breakpoint-padding);
+        }
+      }
+    }
+  }
 }
 
+
+/*
+Pushed grid
+*/
 @mixin grid-push-container($breakpoints) {
   @each $key, $values in $breakpoints {
 
@@ -226,10 +237,15 @@ Gutters
     $breakpoint-display: map-get($values, 'display');
 
     @media (min-width:  $breakpoint-width ) {
-      .sdds-sidebar {
+      .#{$prefix}-sidebar {
         flex-basis: $breakpoint-sidebar;
         min-width: $breakpoint-sidebar;
         display: $breakpoint-display;
+
+        &.sdds-sidebar-collapse {
+          flex-basis: 68px;
+          min-width: 68px;
+        }
       }
 
       .#{$prefix}-container-push {

--- a/theme/core/grid/_mixins.scss
+++ b/theme/core/grid/_mixins.scss
@@ -242,9 +242,9 @@ Pushed grid
         min-width: $breakpoint-sidebar;
         display: $breakpoint-display;
 
-        &.sdds-sidebar-collapse {
-          flex-basis: 68px;
-          min-width: 68px;
+        &.#{$prefix}-sidebar-collapse {
+          flex-basis: 17rem;
+          min-width: 17rem;
         }
       }
 

--- a/theme/core/grid/_mixins.scss
+++ b/theme/core/grid/_mixins.scss
@@ -181,7 +181,7 @@ Gutters
   @include grid-push-container($breakpoints);
   .#{$prefix}-push {
     display: flex;
-    justify-content: center;
+
     @include grid-make-col($breakpoints);
 
     .#{$prefix}-container {


### PR DESCRIPTION

**Describe pull-request**  
_Describe what the pull-request is about_

- Added collapse option for push grid
- Added fix for push grid with non fluid container-putting the side-menu on the left of the entire window instead of next to the grid it self

**Solving issue**  
_Add which issue this pull-request solves by adding # plus the number of the issue (for example #123)_
Fixes: [AB#502](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/502)

**How to test**  
_Add description how to test if possible_
- Run storybook
- Go to push grid
- Try and click collapse action and see it change the size of the side menu
- Zoom out

Compare with https://sdds-storybook.netlify.app/
- Zoom out and try non fluid and fluid
