### PR TITLE
Bug/Fix bug in textarea for condition if no label

### DIFF
--- a/components/src/components/textarea/readme.md
+++ b/components/src/components/textarea/readme.md
@@ -11,8 +11,8 @@
 | --------------- | ---------------- | --------------------------------------------------------- | --------- | ------------ |
 | `cols`          | `cols`           | Textarea cols attribute                                   | `number`  | `undefined`  |
 | `disabled`      | `disabled`       | Set input in disabled state                               | `boolean` | `false`      |
-| `helper`        | `helper`         | Helper text                                               | `string`  | `undefined`  |
-| `label`         | `label`          | Label text                                                | `string`  | `undefined`  |
+| `helper`        | `helper`         | Helper text                                               | `string`  | `''`         |
+| `label`         | `label`          | Label text                                                | `string`  | `''`         |
 | `labelPosition` | `label-position` | Label position: `no-label` (default), `inside`, `outside` | `string`  | `'no-label'` |
 | `maxlength`     | `maxlength`      | Max length of input                                       | `number`  | `undefined`  |
 | `placeholder`   | `placeholder`    | Placeholder text                                          | `string`  | `""`         |

--- a/components/src/components/textarea/textarea.tsx
+++ b/components/src/components/textarea/textarea.tsx
@@ -13,10 +13,10 @@ export class Textarea{
   textEl?: HTMLTextAreaElement;
 
   /** Label text */
-  @Prop() label: string;
+  @Prop() label: string='';
 
   /** Helper text */
-  @Prop() helper: string;
+  @Prop() helper: string='';
 
   /** Textarea cols attribute */
   @Prop() cols: number;


### PR DESCRIPTION
- Set default to label and helper text
- Previously, default was null, then it caused error if label and helper not set.

**How to test**  
1. build branch
2. link website to this build using npm link @scania/components
3. run website locally
4. see textarea works

**Screenshots**  
_If applicable, add screenshots to help explain_

**Additional context**  
_Add any other context about the pull-request here._
