### PR TITLE
AB#507 Fix#88 Use document readyState to fix FoUC

### DIFF
--- a/components/src/helpers/core.js
+++ b/components/src/helpers/core.js
@@ -24,15 +24,17 @@ function fixFouc() {
   document.head.insertBefore(elm, document.head.firstChild);
   elm.appendChild(style);
 
-  document.addEventListener('DOMContentLoaded', function () {
-    // This timeout is to make sure that IE has time to load
-    setTimeout(function () {
-      if (document.querySelector('sdds-theme')) return;
-
-      // Used in case a theme element is not rendered
-      style.nodeValue = 'body { visibility: visible; }';
-    });
-  });
+  document.onreadystatechange = function () {
+    if (document.readyState == 'interactive') {
+      // This timeout is to make sure that IE has time to load
+      setTimeout(() => {
+        if(document.querySelector('sdds-theme')) return;
+  
+        // Used in case a theme element is not rendered
+        style.nodeValue = 'body { visibility: visible; }';
+      });
+    }
+  }
 }
 
 

--- a/components/src/helpers/index.js
+++ b/components/src/helpers/index.js
@@ -39,13 +39,16 @@ function fixFouc() {
   document.head.insertBefore(elm, document.head.firstChild);
   elm.appendChild(style);
 
-  document.addEventListener('DOMContentLoaded', () => {
-    // This timeout is to make sure that IE has time to load
-    setTimeout(() => {
-      if(document.querySelector('sdds-theme')) return;
-
-      // Used in case a theme element is not rendered
-      style.nodeValue = 'body { visibility: visible; }';
-    });
-  })
+  document.onreadystatechange = function () {
+    if (document.readyState == 'interactive') {
+      // This timeout is to make sure that IE has time to load
+      setTimeout(() => {
+        if(document.querySelector('sdds-theme')) return;
+  
+        // Used in case a theme element is not rendered
+        style.nodeValue = 'body { visibility: visible; }';
+      });
+    }
+  }
+  
 }


### PR DESCRIPTION
- Use document.onreadystatechange which always fired instead of DOMContentLoaded event which sometimes fired in uncertain time.
- See docs: https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState

**Describe pull-request**  
_Describe what the pull-request is about_

**Solving issue**  
[AB#507](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/507) Fix #88

**How to test**  
- Clone branch
- Build @scania/components
- Npm link to components from demo/angular or demo/react
- See styles being loaded after component loaded (no flash of unstyled content occured)
- Check in sdds-website, use npm link to check

**Screenshots**  
_If applicable, add screenshots to help explain_

**Additional context**  
_Add any other context about the pull-request here._
