### PR TITLE
AB#688 Remove font load duplication in scania theme light

### DIFF
--- a/demo/HTML/html.css
+++ b/demo/HTML/html.css
@@ -1,6 +1,3 @@
-@import '~node_modules/@scania/grid/dist/scss/grid';
-@import '~node_modules/@scania/typography/dist/css/typography';
-
 body {
   background: var(--sdds-grey-50);
 }

--- a/demo/HTML/package-lock.json
+++ b/demo/HTML/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "html",
+  "name": "sdds-html-demo",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -19,9 +19,8 @@
       "integrity": "sha512-xxllzKGUuM5bcdLYtEOmPm6dLBH3IFr/vDleac0umi1M6Wv5vvzgeDf6bLQcwA6tmTIem+G/YWvtnb63dVJQpQ=="
     },
     "@scania/theme-light": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scania/theme-light/-/theme-light-2.0.0.tgz",
-      "integrity": "sha512-Klws9XVn/5i0lJwGGeMatEUw/sBXNu6OBM4onQ9vlDLJSe6KtThVBHbkTIWRXrgxAmgo6eb0r/RacKVSG1Aitw=="
+      "version": "file:../../theme/light/scania-theme-light-2.2.0.tgz",
+      "integrity": "sha512-8g2Yiw3j9TpAmbZWB2sO8jy9v2uT5k4YpcAe1bFXr4eZN5yc+O3PpaHW99VnMmTvG/g2JfKXapymbM7AwJlZNg=="
     },
     "@scania/typography": {
       "version": "1.1.0",

--- a/theme/core/typography/_selectors.scss
+++ b/theme/core/typography/_selectors.scss
@@ -1,0 +1,26 @@
+@import '../base-unit';
+@import '../prefix';
+@import './mixins';
+@import './tokens';
+
+// Generate class for tokens (.sdds-headline-01)
+@each $key, $value in $typography-sets {
+  .#{$prefix}-#{$key} {
+    @include type-style($key);
+  }
+}
+
+// Generate all headings
+@each $key, $value in $typography-sets {
+  $i : index(($typography-sets),($key $value) );
+  @if $i < 7 {
+    h#{$i} {
+      @include type-style($key);
+    }
+  }
+  @if $i == 7 {
+    .h#{$i} {
+      @include type-style($key);
+    }
+  }
+}

--- a/theme/core/typography/_typography.scss
+++ b/theme/core/typography/_typography.scss
@@ -1,30 +1,4 @@
 // Fonts - This file is generated and will exist in dist
 @import './dist/scss/fonts';
-
 @import './vars';
-@import '../base-unit';
-@import '../prefix';
-@import './mixins';
-@import './tokens';
-
-// Generate class for tokens (.sdds-headline-01)
-@each $key, $value in $typography-sets {
-  .#{$prefix}-#{$key} {
-    @include type-style($key);
-  }
-}
-
-// Generate all headings
-@each $key, $value in $typography-sets {
-  $i : index(($typography-sets),($key $value) );
-  @if $i < 7 {
-    h#{$i} {
-      @include type-style($key);
-    }
-  }
-  @if $i == 7 {
-    .h#{$i} {
-      @include type-style($key);
-    }
-  }
-}
+@import './selectors';

--- a/theme/light/src/_variables.scss
+++ b/theme/light/src/_variables.scss
@@ -1,6 +1,6 @@
+@import '../../core/prefix';
 @import '../../core/spacing/spacing';
 @import '../../core/colour/tokens';
-@import '../../core/typography/typography';
 @import '../../core/logotype/logotype';
 @import '../../core/base-unit';
 

--- a/theme/light/src/theme/sdds-theme.scss
+++ b/theme/light/src/theme/sdds-theme.scss
@@ -13,7 +13,8 @@
 @import '../core/prefix';
 @import '../core/grid/grid';
 @import '../core/colour/colour';
-@import '../core/typography/typography';
+@import '../core/typography/vars';
+@import '../core/typography/selectors';
 
 // Import css variables
 @import '../css-vars.scss';


### PR DESCRIPTION
- Restructure typography package
- Remove typography duplication in theme

Cause of bug:
- Error when importing theme light via script in the head
- relative path issues on duplicated font-face css

Fix #108 [AB#688](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/688)

**How to test**  
- Run HTML demo, see error appears
- branch on PR
- Npm run build on theme-light & typography package
- Npm pack to create local package
- Install local package in HTML demo with "npm i file: ..\..\theme\core\typography\scania-typography-1.1.0.tgz"
- Install local package in HTML demo with "npm i file: ..\..\theme\scania-theme-light-2.2.0.tgz"
- See error is gone
- Try in angular demo as well

**Note: Somehow npm link doesn't work with angular 11, some webpack config cause error for the code sourceMapping, that is why we need to try by installing local package of this branch**
