### PR TITLE
AB#252 - Added custom event to trigger change in a web component

### DIFF
--- a/components/src/components/textarea/readme.md
+++ b/components/src/components/textarea/readme.md
@@ -9,6 +9,7 @@
 
 | Property        | Attribute        | Description                                               | Type      | Default      |
 | --------------- | ---------------- | --------------------------------------------------------- | --------- | ------------ |
+| `autofocus`     | `autofocus`      |                                                           | `boolean` | `false`      |
 | `cols`          | `cols`           | Textarea cols attribute                                   | `number`  | `undefined`  |
 | `disabled`      | `disabled`       | Set input in disabled state                               | `boolean` | `false`      |
 | `helper`        | `helper`         | Helper text                                               | `string`  | `''`         |
@@ -19,6 +20,13 @@
 | `rows`          | `rows`           | Textarea rows attribute                                   | `number`  | `undefined`  |
 | `state`         | `state`          | Error state of input                                      | `string`  | `undefined`  |
 | `value`         | `value`          | Value of the input text                                   | `string`  | `""`         |
+
+
+## Events
+
+| Event          | Description                   | Type               |
+| -------------- | ----------------------------- | ------------------ |
+| `customChange` | Change event for the textarea | `CustomEvent<any>` |
 
 
 ----------------------------------------------

--- a/components/src/components/textarea/textarea.tsx
+++ b/components/src/components/textarea/textarea.tsx
@@ -1,5 +1,11 @@
 import {
-  Component, h, Listen, Prop, State
+  Component,
+  h,
+  Listen,
+  Prop,
+  State,
+  Event,
+  EventEmitter
 } from '@stencil/core';
 
 @Component({
@@ -23,7 +29,7 @@ export class Textarea{
 
   /** Textarea rows attribute */
   @Prop() rows: number;
-  
+
   /** Label position: `no-label` (default), `inside`, `outside` */
   @Prop() labelPosition = 'no-label';
 
@@ -42,8 +48,19 @@ export class Textarea{
   /** Max length of input */
   @Prop() maxlength:number;
 
+  @Prop() autofocus: boolean = false;
+
   /** Listen to the focus state of the input */
   @State() focusInput;
+
+  /** Change event for the textarea */
+  @Event(
+    {
+     composed: true,
+      bubbles: true,
+      cancelable: true
+    }
+  ) customChange: EventEmitter
 
   //Listener if input enters focus state
   @Listen('focus')
@@ -58,13 +75,17 @@ export class Textarea{
   }
 
   //Data input event in value prop
-  handleInputChange(e): void {
+  handleInput(e): void {
     this.value = e.target.value;
   }
 
   //** Set the input as focus when clicking the whole textfield with suffix/prefix */
   handleFocusClick(): void {
     this.textEl.focus();
+  }
+
+  handleChange(e): void {
+    this.customChange.emit(e);
   }
 
   render() {
@@ -78,7 +99,7 @@ export class Textarea{
         `}
         onClick={() => this.handleFocusClick()}
       >
-        {this.label.length > 0 && 
+        {this.label.length > 0 &&
           <span class={`sdds-textarea-label`}>
             {this.label}
           </span>
@@ -90,10 +111,12 @@ export class Textarea{
             disabled={this.disabled}
             placeholder={this.placeholder}
             value={this.value}
+            autofocus={this.autofocus}
             maxlength={this.maxlength}
             cols={this.cols}
             rows={this.rows}
-            onInput={(e) => this.handleInputChange(e)}
+            onInput={(e) => this.handleInput(e)}
+            onChange={(e) => this.handleChange(e)}
           ></textarea>
           <span class='sdds-textarea-resizer-icon'>
             <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -101,15 +124,15 @@ export class Textarea{
             </svg>
           </span>
         </div>
-        {this.helper.length > 0 && 
+        {this.helper.length > 0 &&
           <span class={`sdds-textarea-helper`}>
             {this.helper}
           </span>
         }
-        {this.maxlength > 0 && 
+        {this.maxlength > 0 &&
           <div class={`sdds-textarea-textcounter`}>
             {this.value.length} <span class="sdds-textfield-textcounter-divider"> / </span> {this.maxlength}
-          </div> 
+          </div>
         }
       </div>
     )}

--- a/components/src/components/textfield/readme.md
+++ b/components/src/components/textfield/readme.md
@@ -7,16 +7,24 @@
 
 ## Properties
 
-| Property      | Attribute     | Description                                 | Type      | Default     |
-| ------------- | ------------- | ------------------------------------------- | --------- | ----------- |
-| `disabled`    | `disabled`    | Set input in disabled state                 | `boolean` | `false`     |
-| `labelinside` | `labelinside` | Label that will be put inside the input     | `string`  | `""`        |
-| `maxlength`   | `maxlength`   | Max length of input                         | `number`  | `undefined` |
-| `placeholder` | `placeholder` | Placeholder text                            | `string`  | `""`        |
-| `size`        | `size`        | Size of the input                           | `string`  | `""`        |
-| `state`       | `state`       | Error state of input                        | `string`  | `undefined` |
-| `type`        | `type`        | Which input type, text, password or similar | `string`  | `'text'`    |
-| `value`       | `value`       | Value of the input text                     | `string`  | `""`        |
+| Property      | Attribute      | Description                                 | Type      | Default     |
+| ------------- | -------------- | ------------------------------------------- | --------- | ----------- |
+| `autofocus`   | `autofocus`    | Autofocus for input                         | `boolean` | `false`     |
+| `disabled`    | `disabled`     | Set input in disabled state                 | `boolean` | `false`     |
+| `labelInside` | `label-inside` | Label that will be put inside the input     | `string`  | `""`        |
+| `maxlength`   | `maxlength`    | Max length of input                         | `number`  | `undefined` |
+| `placeholder` | `placeholder`  | Placeholder text                            | `string`  | `""`        |
+| `size`        | `size`         | Size of the input                           | `string`  | `""`        |
+| `state`       | `state`        | Error state of input                        | `string`  | `undefined` |
+| `type`        | `type`         | Which input type, text, password or similar | `string`  | `'text'`    |
+| `value`       | `value`        | Value of the input text                     | `string`  | `""`        |
+
+
+## Events
+
+| Event          | Description                    | Type               |
+| -------------- | ------------------------------ | ------------------ |
+| `customChange` | Change event for the textfield | `CustomEvent<any>` |
 
 
 ----------------------------------------------

--- a/components/src/components/textfield/textfield.stories.js
+++ b/components/src/components/textfield/textfield.stories.js
@@ -125,7 +125,7 @@ const textfieldTemplate = ({type, placeholderText,size,disabled,label,labelplace
       size="${sizeValue}"
       state="${state}"
       maxlength="${textcounter}"
-      ${label && labelplacement ? `labelinside="${label}"` : ''}
+      ${label && labelplacement ? `label-inside="${label}"` : ''}
       ${disabled ? 'disabled' : ''}
       placeholder="${placeholderText}" >
         ${prefix}

--- a/components/src/components/textfield/textfield.tsx
+++ b/components/src/components/textfield/textfield.tsx
@@ -1,5 +1,11 @@
 import {
-  Component, h, State, Prop, Listen,
+  Component,
+  h,
+  State,
+  Prop,
+  Listen,
+  Event,
+  EventEmitter
 } from '@stencil/core';
 @Component({
   tag: 'sdds-textfield',
@@ -12,16 +18,16 @@ export class Textfield {
   textInput?: HTMLInputElement;
 
   /** Which input type, text, password or similar */
-  @Prop() type: string = 'text';
+  @Prop({reflect: true}) type: string = 'text';
 
    /** Label that will be put inside the input */
-  @Prop() labelinside: string = "";
+  @Prop() labelInside: string = "";
 
   /** Placeholder text */
   @Prop() placeholder: string = "";
 
   /** Value of the input text */
-  @Prop() value = "";
+  @Prop({reflect: true}) value = "";
 
   /** Set input in disabled state */
   @Prop() disabled: boolean = false;
@@ -35,8 +41,20 @@ export class Textfield {
   /** Max length of input */
   @Prop() maxlength: number;
 
+  /** Autofocus for input */
+  @Prop() autofocus: boolean = false;
+
   /** Listen to the focus state of the input */
   @State() focusInput;
+
+  /** Change event for the textfield */
+  @Event(
+    {
+      composed: true,
+      bubbles: true,
+      cancelable: true
+    }
+  ) customChange: EventEmitter
 
   //Listener if input enters focus state
   @Listen('focus')
@@ -51,8 +69,13 @@ export class Textfield {
   }
 
   //Data input event in value prop
-  handleInputChange(e): void {
+  handleInput(e): void {
     this.value = e.target.value;
+  }
+
+  //Change event isn't a composed:true by default in for input
+  handleChange(e): void {
+   this.customChange.emit(e);
   }
 
   //** Set the input as focus when clicking the whole textfield with suffix/prefix */
@@ -65,7 +88,7 @@ export class Textfield {
       <div class={`
         ${this.focusInput ? 'sdds-form-textfield sdds-textfield-focus':' sdds-form-textfield'}
         ${this.value.length > 0 ? 'sdds-textfield-data' : ''}
-        ${this.labelinside.length > 0 ? 'sdds-textfield-container-label-inside' : ''}
+        ${this.labelInside.length > 0 ? 'sdds-textfield-container-label-inside' : ''}
         ${this.disabled ? 'sdds-form-textfield-disabled': ''}
         ${this.size == 'md' ? 'sdds-form-textfield-md' : ''}
         ${this.state == 'error' || this.state == 'success' ? `sdds-form-textfield-${this.state}` : ''}
@@ -86,12 +109,14 @@ export class Textfield {
               disabled={this.disabled}
               placeholder={this.placeholder}
               value={this.value}
+              autofocus={this.autofocus}
               maxlength={this.maxlength}
-              onInput={(e) => this.handleInputChange(e)}
+              onInput={(e) => this.handleInput(e)}
+              onChange={(e) => this.handleChange(e)}
             />
 
-            {this.labelinside.length > 0 &&
-              <label class="sdds-textfield-label-inside">{this.labelinside}</label>
+            {this.labelInside.length > 0 &&
+              <label class="sdds-textfield-label-inside">{this.labelInside}</label>
             }
 
           </div>

--- a/demo/HTML/package-lock.json
+++ b/demo/HTML/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "html",
+  "name": "sdds-html-demo",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/demo/angular/package-lock.json
+++ b/demo/angular/package-lock.json
@@ -2643,6 +2643,16 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -5463,6 +5473,13 @@
         }
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -8199,6 +8216,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanoid": {
       "version": "3.1.22",
@@ -13752,7 +13776,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -14511,7 +14539,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/demo/angular/src/app/app.module.ts
+++ b/demo/angular/src/app/app.module.ts
@@ -1,20 +1,27 @@
 import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { HeaderComponent } from './components/header/header.component';
 import { MainComponent } from './components/main/main.component';
+import { FormComponent } from './components/form/form.component';
+import { CustomInput } from './components/form/input/input-component';
 
 @NgModule({
   declarations: [
     AppComponent,
     HeaderComponent,
     MainComponent,
+    FormComponent,
+    CustomInput
   ],
   imports: [
     BrowserModule,
-    AppRoutingModule
+    AppRoutingModule,
+    FormsModule,
+    ReactiveFormsModule
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/demo/angular/src/app/components/form/form.component.html
+++ b/demo/angular/src/app/components/form/form.component.html
@@ -1,0 +1,125 @@
+
+<!-- FormGroup Basic form -->
+<h3>Basic form - Template driven form</h3>
+<!-- https://stackoverflow.com/questions/46465891/what-is-ngdefaultcontrol-in-angular -->
+
+<form (ngSubmit)="onSubmit(usernameInput,userPassword,userComment)">
+
+  <div style="width:208px">
+    <div> value: {{usernameInput.value}}</div>
+    <div> dirty: {{usernameInput.dirty}}</div>
+    <div> untouched: {{usernameInput.untouched}}</div>
+
+    <sdds-textfield
+      type="text"
+      ngModel
+      ngDefaultControl
+      name="usernameInput"
+      #usernameInput="ngModel"
+      placeholder="Enter Username"
+      state="{{!usernameInput.untouched && !usernameInput.value ? 'error' : ''}}"
+      (click)="clickEvent()"
+      (customChange)="logNgModel(usernameInput)"
+    >
+      <span *ngIf="!usernameInput.untouched && !usernameInput.value" slot="sdds-helper">Username required</span>
+    </sdds-textfield>
+  </div>
+
+  <div style="width:208px">
+    <div>  value: {{userPassword.value}}</div>
+    <div> dirty: {{userPassword.dirty}}</div>
+    <div> untouched: {{userPassword.untouched}}</div>
+    <sdds-textfield
+        type="password"
+        placeholder="Enter password"
+        label-inside="Password"
+        ngModel
+        ngDefaultControl
+        name="userPassword"
+        #userPassword="ngModel"
+        (click)="clickEvent()"
+        (customChange)="logNgModel(userPassword)"
+        state="{{!userPassword.untouched && !userPassword.value ? 'error' : ''}}"
+      >
+      <span *ngIf="!userPassword.untouched && !userPassword.value" slot="sdds-helper">Password required</span>
+    </sdds-textfield>
+  </div>
+
+
+  <div style="width:208px">
+    <div> value: {{userComment.value}}</div>
+    <div> dirty: {{userComment.dirty}}</div>
+    <div> untouched: {{userComment.untouched}}</div>
+    <sdds-textarea
+      placeholder="Placeholder"
+      helper="Add your comment"
+      ngModel
+      ngDefaultControl
+      name="userComment"
+      #userComment="ngModel"
+      (click)="clickEvent()"
+      (customChange)="logNgModel(userComment)"
+    >
+    </sdds-textarea>
+  </div>
+
+  <button type="submit" class="sdds-btn sdds-btn-primary"> Submit</button>
+</form>
+
+<!-- Formgroup works -->
+<h3>Advanced form - Reactive form</h3>
+<form [formGroup]="myForm" (ngSubmit)="onSubmit(myForm)">
+
+  <div style="width:208px">
+    <sdds-textfield
+      ngDefaultControl
+      formControlName="username"
+      placeholder="Username"
+    >
+    </sdds-textfield>
+  </div>
+
+  <div style="width:208px">
+    <sdds-textarea
+      label="Label text"
+      ngDefaultControl
+      formControlName="textarea"
+      helper="Helper text"
+      placeholder="Placeholder">
+    </sdds-textarea>
+  </div>
+
+  <div style="width:208px">
+    <!-- Custom Angular component -->
+    <custom-input
+      ngDefaultControl
+      id="customEl"
+      formControlName="customInput">
+    </custom-input>
+  </div>
+
+  <div class="sdds-checkbox-item">
+    <input
+      id="cb-option-1"
+      class="sdds-form-input"
+      type="checkbox"
+      checked="checked"
+      name="cb-example"
+      formControlName="CustomCheck"
+    />
+     <label class="sdds-form-label" for="cb-option-1">
+        Check if true
+     </label>
+  </div>
+
+  <button type="submit" class="sdds-btn sdds-btn-primary"> Submit</button>
+
+</form>
+
+<h6>Values in the form:</h6>
+<div>Values: {{myForm.value | json}}</div>
+<div>Touched: {{myForm.touched}}</div>
+<div>pristine: {{myForm.pristine | json}}</div>
+<div>Valid: {{myForm.valid | json}}</div>
+
+

--- a/demo/angular/src/app/components/form/form.component.ts
+++ b/demo/angular/src/app/components/form/form.component.ts
@@ -1,0 +1,42 @@
+import { Component, OnInit } from '@angular/core';
+import {FormBuilder, FormGroup  } from '@angular/forms';
+
+@Component({
+  selector: 'basic-form',
+  templateUrl: './form.component.html',
+  styleUrls: ['./form.component.scss']
+})
+
+export class FormComponent implements OnInit {
+  username = 'Add username';
+  myForm: FormGroup;
+
+  constructor(private fb: FormBuilder) {}
+
+  ngOnInit() {
+    //Formcontrol
+    this.myForm = this.fb.group({
+      username: '',
+      textarea: '',
+      customInput: 'Default value',
+      CustomCheck: true,
+
+    })
+    this.myForm.valueChanges.subscribe(console.log)
+  }
+
+  onSubmit(...formTest){
+    console.log(formTest)
+  }
+  clickEvent() {
+    console.log('click')
+    const input = document.querySelector('sdds-textfield');
+  }
+  logNgModel(model) {
+    console.log('Change:',model.viewModel, model)
+  }
+
+  logInput(model){
+    console.log('Input:',model.viewModel, model)
+  }
+}

--- a/demo/angular/src/app/components/form/input/input-component.html
+++ b/demo/angular/src/app/components/form/input/input-component.html
@@ -1,0 +1,3 @@
+
+
+<sdds-textfield (blur)="onTouched()" (input)="handleInput($event)" [disabled]="onDisabled" [value]="value"></sdds-textfield>

--- a/demo/angular/src/app/components/form/input/input-component.ts
+++ b/demo/angular/src/app/components/form/input/input-component.ts
@@ -1,0 +1,44 @@
+import { Component, forwardRef } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+// https://angular.io/api/forms/ControlValueAccessor
+
+@Component({
+  selector:'custom-input',
+  templateUrl: './input-component.html',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => CustomInput),
+      multi: true
+    }
+  ]
+})
+
+export class CustomInput implements ControlValueAccessor {
+  value: string;
+  onChange: (value: string) => {};
+  onTouched: () => {};
+  onDisabled: boolean;
+  constructor() {
+
+  }
+  writeValue(value: string) {
+    this.value = value ? value : '';
+    console.log(this.value)
+  }
+  registerOnChange(onChange: any)  {
+    this.onChange = onChange;
+  }
+  registerOnTouched(fn: any)  {
+    this.onTouched = fn;
+  }
+  setDisabledState?(isDisabled: boolean)  {
+    this.onDisabled = isDisabled;
+  }
+
+  handleInput(event) {
+    this.onChange(event.target.value)
+  }
+
+}

--- a/demo/angular/src/app/components/main/main.component.html
+++ b/demo/angular/src/app/components/main/main.component.html
@@ -1,3 +1,4 @@
+
 <div class="sdds-container-fluid content-wrapper">
   <div class="sdds-row">
     <div class="sdds-col-xlg-16 sdds-col-md-8 sdds-col-sm-4">
@@ -154,6 +155,12 @@
           <button class="sdds-btn sdds-btn-primary" id="right-1">Button</button>
       </div>
 
+    </div>
+  </div>
+
+  <div class="sdds-row">
+    <div class="sdds-col-xlg-8 sdds-col-md-4 sdds-col-sm-4">
+      <basic-form></basic-form>
     </div>
   </div>
 </div>


### PR DESCRIPTION
**Describe pull-request**  
_Describe what the pull-request is about_

Created a Custom event that is composed=true to be able to use a change event in for example angular forms
There are multiple ways to add a web-component that contains an input in angular, but one thing that is a most is the attribute ngDefaultControl https://stackoverflow.com/questions/46465891/what-is-ngdefaultcontrol-in-angular

The custom event is called  customChange`(customChange)="logNgModel(usernameInput)"`

- Create template driven form in angular
- Created a reactive form in angular
- Added custom-input using Control Value Accessor

Additional fixes
Added autofocus on textfield and textarea
- Autofocus added on textfield and textarea
- Changed prop name for labelinside

**Solving issue**  
_Add which issue this pull-request solves by adding # plus the number of the issue (for example #123)_
Fixes: #91
Fixes: [AB#252](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/252)
Added autofocus to web-component  #132 

**How to test**  
_Add description how to test if possible_
- Start angular project
- Go to the form
- Open the console
- Try and change the value and it should trigger an event that is calling another function inside the form
- Also created a custom-input component example in angular that uses control value accessor (testing purpose) https://angular.io/api/forms/ControlValueAccessor

Autofocus
- Added attr autofocus on textfield or textarea

Label inside attribute changed name


**Additional context**  
_Add any other context about the pull-request here._
