### PR TITLE
Improvement/remove_old_links

### DIFF
--- a/demo/angular/README.md
+++ b/demo/angular/README.md
@@ -2,7 +2,6 @@
 
 To run this project locally you will need to NodeJS and npm.
 
-See the running example on [this link](https://scania.github.io/corporate-ui-angular/).
 
 ## Scania Digital Design System
 


### PR DESCRIPTION
In Angular demo docs, there is still a link to old example page.

**Solving issue**  
_Add which issue this pull-request solves by adding # plus the number of the issue (for example #123)_
Fixes: #

**How to test**  
_Add description how to test if possible_

**Screenshots**  
_If applicable, add screenshots to help explain_

**Additional context**  
_Add any other context about the pull-request here._
