### PR TITLE
bug - Added back the banner import

### DIFF
--- a/components/src/components/theme/theme.scss
+++ b/components/src/components/theme/theme.scss
@@ -1,16 +1,17 @@
 // Components
-@import '../link/link.scss';
-@import '../button/button.scss';
-@import '../radio-button/radio-button.scss';
-@import '../breadcrumb/breadcrumb.scss';
-@import '../checkbox/checkbox.scss';
-@import '../textfield/textfield.scss';
-@import '../divider/divider.scss';
-@import '../toggle/toggle.scss';
 @import '../accordion/accordion.scss';
+@import '../banner/banner.scss';
+@import '../breadcrumb/breadcrumb.scss';
+@import '../button/button.scss';
 @import '../card/card.scss';
+@import '../checkbox/checkbox.scss';
+@import '../divider/divider.scss';
+@import '../link/link.scss';
 @import '../modal/modal.scss';
+@import '../radio-button/radio-button.scss';
+@import '../textfield/textfield.scss';
 @import '../toast/toast.scss';
+@import '../toggle/toggle.scss';
 
 // Patterns
 @import '../../patterns/header/header.scss';


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
_Describe what the pull-request is about_

Banner component doesn't work because import for it was removed.
Error can be found at digitaldesign.scania.com

added in alphabetical order

**Solving issue**  
_Add which issue this pull-request solves by adding # plus the number of the issue (for example #123)_
Fixes: #153 

**How to test**  
_Add description how to test if possible_
1. Go to storybook
2. Check banner
