### PR TITLE
AB#818 Add unique id for each dropdown event listener

### DIFF
--- a/components/src/components/dropdown/dropdown.tsx
+++ b/components/src/components/dropdown/dropdown.tsx
@@ -48,6 +48,8 @@ export class Dropdown {
 
   @State() selected:string='';
 
+  @State() uuid;
+
   @Element() host: HTMLElement;
 
   componentWillLoad(){
@@ -64,19 +66,27 @@ export class Dropdown {
     }
   }
 
+  componentDidLoad() {
+    // generate UUID for unique event listener
+    this.uuid = new Date().getTime() + Math.random();
+  }
+
   @Listen('click', { target: 'document' })
-  handleClick(ev) {
+  handleDocClick(ev) {
     // To stop bubble click
-    ev.stopPropagation();
-
+    ev.stopPropagation();       
+    
     const target = ev ? ev.composedPath()[0] : window.event.target[0];
-
     if(this.node!==undefined && this.node.contains(target)) {
       if(typeof this.textInput !== 'undefined' || this.textInput === null) this.textInput.focus();
       this.open = !this.open;
-    } else {
+    } else {      
       this.open = false;
-    }
+    }    
+  }
+
+  handleClick(id) {
+    if(id !== this.uuid) this.open = false;
   }
 
   @Listen('selectOption')
@@ -115,7 +125,7 @@ export class Dropdown {
         <button
         class={`sdds-dropdown-toggle ${this.type==='filter' ? 'is-filter' : ''}`}
         type="button"
-        onClick={(ev)=>this.handleClick(ev)}
+        onClick={()=>this.handleClick(this.uuid)}
         ref={(node) => this.node = node}>
           <div class='sdds-dropdown-label'>
             {


### PR DESCRIPTION
- Added unique event listener
- Separate docs event listener and dropdown button event listener

Fix bug #141 [AB#818](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/818)

<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->



**How to test**  
_Add description how to test if possible_
1. Checkout to the branch
2. Go to dropdown storybook (dropdown.stories.js) and add one more dropdown in Basic template (just copy paste, put it below the current dropdown)
3. Click the 2nd dropdown, while it's open, click the first one. The 2nd dropdown should close when clicking on the 1st one.
