### PR TITLE
Improvement - Fix for push grid non fluid having max-width

### DIFF
--- a/theme/core/grid/_mixins.scss
+++ b/theme/core/grid/_mixins.scss
@@ -171,7 +171,7 @@
   @each $key, $values in $breakpoints {
     $breakpoint: map-get($values, 'breakpoint');
     $container-margin: map-get($values, 'margin');
-    $container-width: map-get($values, 'content');
+    $container-width: map-get($values, 'container');
     $display-sidebar: map-get($values, 'sidebar');
 
     @media (min-width:  $breakpoint) {


### PR DESCRIPTION
Fix for push grid non fluid having max-width

<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
_Describe what the pull-request is about_

Fixing issue with push non fluid grid not having a max-width

**How to test**  
_Add description how to test if possible_
1. Run storybook
2. Look at push grid with non-fluid
3. Container should have a max-width set now
