### PR TITLE
port and text change to differentiate angular version in browser

### DIFF
--- a/demo/angular/angular11/README.md
+++ b/demo/angular/angular11/README.md
@@ -19,7 +19,7 @@ npm i
 npm start
 ```
 
-Open [http://localhost:4200](http://localhost:4200) to view it in the browser.
+Open [http://localhost:4211](http://localhost:4211) to view it in the browser.
 
 
 ## Project setup

--- a/demo/angular/angular11/package.json
+++ b/demo/angular/angular11/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --port 4211",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",

--- a/demo/angular/angular11/src/app/components/main/main.component.html
+++ b/demo/angular/angular11/src/app/components/main/main.component.html
@@ -2,8 +2,8 @@
   <div class="sdds-row">
     <div class="sdds-col-xlg-16 sdds-col-md-12 sdds-col-sm-12">
       <p class="lead-head sdds-paragraph-01">
-        This is a simple example how to implement the SDDS components in
-        Angular.
+        This is a simple example how to implement the SDDS components in Angular
+        11.
       </p>
       <p class="sub-lead">
         Check the

--- a/demo/angular/angular12/README.md
+++ b/demo/angular/angular12/README.md
@@ -4,7 +4,7 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 
 ## Development server
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
+Run `ng serve` for a dev server. Navigate to `http://localhost:4212/`. The app will automatically reload if you change any of the source files.
 
 ## Code scaffolding
 

--- a/demo/angular/angular12/package.json
+++ b/demo/angular/angular12/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --port 4212",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"

--- a/demo/angular/angular12/src/app/components/main/main.component.html
+++ b/demo/angular/angular12/src/app/components/main/main.component.html
@@ -2,8 +2,8 @@
   <div class="sdds-row">
     <div class="sdds-col-xlg-16 sdds-col-md-12 sdds-col-sm-12">
       <p class="lead-head sdds-paragraph-01">
-        This is a simple example how to implement the SDDS components in
-        Angular.
+        This is a simple example how to implement the SDDS components in Angular
+        12.
       </p>
       <p class="sub-lead">
         Check the

--- a/demo/angular/angular13/package.json
+++ b/demo/angular/angular13/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --port 4213",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"

--- a/demo/angular/angular13/src/app/components/main/main.component.html
+++ b/demo/angular/angular13/src/app/components/main/main.component.html
@@ -2,8 +2,8 @@
   <div class="sdds-row">
     <div class="sdds-col-xlg-16 sdds-col-md-12 sdds-col-sm-12">
       <p class="lead-head sdds-paragraph-01">
-        This is a simple example how to implement the SDDS components in
-        Angular.
+        This is a simple example how to implement the SDDS components in Angular
+        13.
       </p>
       <p class="sub-lead">
         Check the


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Adding difference in port number and main component file text to be able to easy spot which version of angular is running.

**How to test**  
1. Run each version of angular
2. angular 11 on port 4211, angular 12 on port 4212, angular 13 on 4213
