### PR TITLE
mobile navigation menu in header fix

### DIFF
--- a/components/src/patterns/header/_navbar-collapsible.scss
+++ b/components/src/patterns/header/_navbar-collapsible.scss
@@ -18,6 +18,13 @@
   overflow-y: auto;
   opacity: 0;
 
+  .#{$prefix}-navbar-menu-item-dropdown {
+    flex-direction: column;
+    .#{$prefix}-navbar-menu-item-link {
+      height: 67px;
+    }
+  }
+
   &.expanded {
     visibility: visible;
     left: 0;


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Fix for issue in header mobile menu

**Solving issue**  
Fixes: #
No official ticket, fixed on the fly.

**How to test**  
1. Go to Storybook
2. Open Header component
3. Make sure to have TRUE next to show mobile menu in Storybook settings
4. Check if menu dropdown items look OK (position & padding)