### PR TITLE
Scale up for second level values of utility classes

### DIFF
--- a/components/src/helpers/_utility-classes.scss
+++ b/components/src/helpers/_utility-classes.scss
@@ -83,23 +83,23 @@
 }
 
 .#{$prefix}-u-p2 {
-  padding: var(--sdds-spacing-layout-8) !important;
+  padding: var(--sdds-spacing-layout-16) !important;
 }
 
 .#{$prefix}-u-pt2 {
-  padding-top: var(--sdds-spacing-layout-8) !important;
+  padding-top: var(--sdds-spacing-layout-16) !important;
 }
 
 .#{$prefix}-u-pr2 {
-  padding-right: var(--sdds-spacing-layout-8) !important;
+  padding-right: var(--sdds-spacing-layout-16) !important;
 }
 
 .#{$prefix}-u-pb2 {
-  padding-bottom: var(--sdds-spacing-layout-8) !important;
+  padding-bottom: var(--sdds-spacing-layout-16) !important;
 }
 
 .#{$prefix}-u-pl2 {
-  padding-left: var(--sdds-spacing-layout-8) !important;
+  padding-left: var(--sdds-spacing-layout-16) !important;
 }
 
 .#{$prefix}-u-p3 {
@@ -165,23 +165,23 @@
 }
 
 .#{$prefix}-u-m2 {
-  margin: var(--sdds-spacing-layout-8) !important;
+  margin: var(--sdds-spacing-layout-16) !important;
 }
 
 .#{$prefix}-u-mt2 {
-  margin-top: var(--sdds-spacing-layout-8) !important;
+  margin-top: var(--sdds-spacing-layout-16) !important;
 }
 
 .#{$prefix}-u-mr2 {
-  margin-right: var(--sdds-spacing-layout-8) !important;
+  margin-right: var(--sdds-spacing-layout-16) !important;
 }
 
 .#{$prefix}-u-mb2 {
-  margin-bottom: var(--sdds-spacing-layout-8) !important;
+  margin-bottom: var(--sdds-spacing-layout-16) !important;
 }
 
 .#{$prefix}-u-ml2 {
-  margin-left: var(--sdds-spacing-layout-8) !important;
+  margin-left: var(--sdds-spacing-layout-16) !important;
 }
 
 .#{$prefix}-u-m3 {


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Scaling up the second level of utility classes for padding and margin

**Solving issue**  
By mistake values for second-level remaind on value of 8px instead of 16px.

