### PR TITLE
Improvement - Fix button story not showing icon in basic example

### DIFF
--- a/components/src/components/button/button.stories.js
+++ b/components/src/components/button/button.stories.js
@@ -69,7 +69,12 @@ const ButtonTemplate = ({
 
   return `
   <sdds-theme></sdds-theme>
-  
+  <style>
+    @import url('https://cdn.digitaldesign.scania.com/icons/dist/1.1.0/fonts/css/sdds-icons.css');
+    i {
+      font-size: 4rem;
+    }
+  </style>
   <button class="sdds-btn sdds-btn-${btnType} ${sizeValue} ${fbClass} ${
     disabled ? 'disabled' : ''
   } ${onlyIconCss}" ${inlineStyle}>


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
_Describe what the pull-request is about_
In the button story in storybook, when enabling icons in the basic example, the icon won't show. I have added the import for web-font icons.

**How to test**  
_Add description of how to test if possible_
1. Go to button story basic example
2. Try adding an icon with the control
3. Icon is now added

**Additional context**  
_Add any other context about the pull-request here._
There are some improvement that needs to be done with the icon inside the button.
