### PR TITLE
fix(accordion): reset prop for right-padding

### DIFF
--- a/components/package-lock.json
+++ b/components/package-lock.json
@@ -2390,6 +2390,30 @@
         "react-lifecycles-compat": "^3.0.4"
       }
     },
+    "@scania/grid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@scania/grid/-/grid-2.0.1.tgz",
+      "integrity": "sha512-uSo1zb4Jp91vQ908ilHHOGFX1MSLSd2J6iOMvrO9yOcPNn9b5/DzNnFs4rCGtaXQyQc9AcKSbffkMRzEV7Feog==",
+      "dev": true
+    },
+    "@scania/icons": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@scania/icons/-/icons-1.1.1.tgz",
+      "integrity": "sha512-JSqyrbAeNHlLTAdxOyUHIV523Sb6DToCiDyx5ZQJQu/UN/gxknNIZI5AUINBAV5pERKdHcH1maoqi+Tdfn45mA==",
+      "dev": true
+    },
+    "@scania/theme-light": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@scania/theme-light/-/theme-light-3.6.3.tgz",
+      "integrity": "sha512-FkvQWU8l5s69pPUJhz4rwxZ5vRNS1b+xj54Qm6jEawLWTPNfowgYvhidaYyaVCVejR31zhJSRk2myxgqT4ufXA==",
+      "dev": true
+    },
+    "@scania/typography": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@scania/typography/-/typography-1.2.1.tgz",
+      "integrity": "sha512-iAg2rL+1b7rHkX9U9LpV+wXiTTmZBjMJoDD4luRj/2Hl7S8e5lv5teiD8aWTXBXIP7zUEAw96WtgYLDaN9Ck/Q==",
+      "dev": true
+    },
     "@sinonjs/commons": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",

--- a/components/package.json
+++ b/components/package.json
@@ -21,7 +21,7 @@
     "watch-stencil": "npm run build -- --watch",
     "stencil": "stencil build --docs-json dist/data/docs.json",
     "babel": "mkdirp .build && babel src/helpers/index.js --out-file .build/index.js",
-    "watch-sb": "start-storybook -p 1339 --no-dll",
+    "watch-sb": "start-storybook -p 1339 --no-dll --no-manager-cache",
     "build-sb": "build-storybook",
     "publish-sb": "npm run build && npm run build-sb",
     "readme": "stencil build --docs-readme",

--- a/components/src/components/accordion/accordion-item.tsx
+++ b/components/src/components/accordion/accordion-item.tsx
@@ -19,6 +19,9 @@ export class AccordionItem {
   /** Set to true to expand panel open */
   @Prop() expanded: boolean = false;
 
+  /** When true 16px on right padding instead of 64px */
+  @Prop() paddingReset: boolean = false;
+
   openAccordion() {
     this.expanded = !this.expanded;
   }
@@ -54,7 +57,13 @@ export class AccordionItem {
             </svg>
           </div>
         </div>
-        <div class="sdds-accordion-panel">
+        <div
+          class={`sdds-accordion-panel 
+            ${
+              this.paddingReset ? 'sdds-accordion-panel--padding-reset ' : ''
+            }         
+            `}
+        >
           <slot></slot>
         </div>
       </div>

--- a/components/src/components/accordion/accordion.scss
+++ b/components/src/components/accordion/accordion.scss
@@ -61,6 +61,9 @@
       margin: 0;
       padding: 0;
     }
+    &--padding-reset {
+      padding-right: var(--sdds-spacing-element-16);
+    }
   }
 
   .#{$prefix}-accordion-header-suffix {

--- a/components/src/components/accordion/accordion.stories.js
+++ b/components/src/components/accordion/accordion.stories.js
@@ -20,6 +20,12 @@ export default {
         defaultValue: { summary: false },
       },
     },
+    paddingReset: {
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: false },
+      },
+    },
   },
   parameters: {
     previewTabs: {
@@ -31,22 +37,23 @@ export default {
   },
   args: {
     disabled: false,
+    paddingReset: false,
     affix: 'suffix',
   },
 };
 
-const Template = ({ disabled, affix }) => {
+const Template = ({ disabled, affix, paddingReset }) => {
   return `
   <sdds-theme></sdds-theme>
   <div class="container-demo" style="width:500px; padding:var(--sdds-spacing-layout-48);">
     <sdds-accordion>
-      <sdds-accordion-item header="First item" affix="${affix}" disabled="${disabled}" tabindex="1">
+      <sdds-accordion-item header="First item" affix="${affix}" disabled="${disabled}" tabindex="1" padding-reset="${paddingReset}">
         This is the panel, which contains associated information with the header. Usually it contains text, set in the same size as the header. Lorem ipsum doler sit amet.
       </sdds-accordion-item>
-      <sdds-accordion-item header="Second item" affix="${affix}" disabled="${disabled}" expanded="true"  tabindex="2">
+      <sdds-accordion-item header="Second item" affix="${affix}" disabled="${disabled}" expanded="true"  tabindex="2" padding-reset="${paddingReset}">
         This is the panel, which contains associated information with the header. Usually it contains text, set in the same size as the header. Lorem ipsum doler sit amet.
       </sdds-accordion-item>
-      <sdds-accordion-item header="Third item" affix="${affix}" disabled="${disabled}" tabindex="3">
+      <sdds-accordion-item header="Third item" affix="${affix}" disabled="${disabled}" tabindex="3" padding-reset="${paddingReset}">
          This is the panel, which contains associated information with the header. Usually it contains text, set in the same size as the header. Lorem ipsum doler sit amet.
        </sdds-accordion-item>
     </sdds-accordion>
@@ -67,4 +74,9 @@ Prefix.args = {
 export const Disabled = Template.bind({});
 Disabled.args = {
   disabled: true,
+};
+
+export const PaddingReset = Template.bind({});
+PaddingReset.args = {
+  paddingReset: false,
 };

--- a/components/src/components/accordion/readme.md
+++ b/components/src/components/accordion/readme.md
@@ -36,12 +36,13 @@
 
 ## Properties
 
-| Property   | Attribute  | Description                                                                                                          | Type      | Default    |
-| ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------- | --------- | ---------- |
-| `affix`    | `affix`    | Icon can be placed after or before accordion header. Values accepted: `prefix` or `suffix` Default value is `suffix` | `string`  | `'suffix'` |
-| `disabled` | `disabled` | Disabled option in `boolean`.                                                                                        | `boolean` | `false`    |
-| `expanded` | `expanded` | Set to true to expand panel open                                                                                     | `boolean` | `false`    |
-| `header`   | `header`   | The header gives users the context about the additional information available inside the panel                       | `string`  | `''`       |
+| Property       | Attribute       | Description                                                                                                          | Type      | Default    |
+| -------------- | --------------- | -------------------------------------------------------------------------------------------------------------------- | --------- | ---------- |
+| `affix`        | `affix`         | Icon can be placed after or before accordion header. Values accepted: `prefix` or `suffix` Default value is `suffix` | `string`  | `'suffix'` |
+| `disabled`     | `disabled`      | Disabled option in `boolean`.                                                                                        | `boolean` | `false`    |
+| `expanded`     | `expanded`      | Set to true to expand panel open                                                                                     | `boolean` | `false`    |
+| `header`       | `header`        | The header gives users the context about the additional information available inside the panel                       | `string`  | `''`       |
+| `paddingReset` | `padding-reset` | When true 16px on right padding instead of 64px                                                                      | `boolean` | `false`    |
 
 
 ----------------------------------------------


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Fixing issue for right padding in accordion component

**Solving issue**  
Fixes: [AB#1023](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/1023)

**How to test**  

1. Branch out branch OR open storybook from Netlify
2. Check Accordion component
3. There is a new Prop added called "paddingReset" 
4.  When "true" it resets right padding to 16px instead of 64px which is default


