### PR TITLE
feat(link): add class for controling underline

### DIFF
--- a/components/src/components/card/card.stories.js
+++ b/components/src/components/card/card.stories.js
@@ -94,7 +94,8 @@ link.argTypes = {};
 link.args = {
   divider: true,
   text: 'This is a short and consist detail text describing for the user what this text is really about.',
-  footer: '<a href="#">Link text</a><a href="#">Link text</a>',
+  footer:
+    '<a class="sdds-link sdds-link--no-underline" href="#">Link text</a><a class="sdds-link sdds-link--no-underline" href="#">Link text</a>',
 };
 
 export const button = CardTemplate.bind({});

--- a/components/src/components/link/link.scss
+++ b/components/src/components/link/link.scss
@@ -32,4 +32,8 @@ a,
     color: var(--sdds-link-disabled);
     pointer-events: none;
   }
+
+  &--no-underline {
+    text-decoration: none;
+  }
 }

--- a/components/src/components/link/link.scss
+++ b/components/src/components/link/link.scss
@@ -10,15 +10,18 @@ a,
   &:active {
     color: var(--sdds-link);
     text-decoration: var(--sdds-link-text-decoration);
+    text-decoration-color: var(--sdds-link);
   }
 
   &:hover {
     color: var(--sdds-link-hover);
     text-decoration: var(--sdds-link-text-decoration);
+    text-decoration-color: var(--sdds-link-hover);
   }
 
   &:visited {
     color: var(--sdds-link-visited);
+    text-decoration-color: var(--sdds-link-visited);
   }
 
   &:focus {
@@ -30,10 +33,15 @@ a,
   &:disabled,
   &.disabled {
     color: var(--sdds-link-disabled);
+    text-decoration-color: var(--sdds-link-disabled);
     pointer-events: none;
   }
 
   &--no-underline {
     text-decoration: none;
+
+    &:hover {
+      text-decoration: none;
+    }
   }
 }

--- a/components/src/components/link/link.stories.js
+++ b/components/src/components/link/link.stories.js
@@ -2,12 +2,13 @@ export default {
   title: 'Component/Link',
 };
 
-const Template = ({ disabled = false }) => {
+const Template = ({ disabled = false, noUnderline = false }) => {
   const disabledClass = disabled ? 'disabled' : '';
+  const underlineClass = noUnderline ? 'sdds-link--no-underline' : '';
   return `
   <sdds-theme></sdds-theme>
   <p>
-  This is an example of <a class="${disabledClass}" href="#">a link</a> inside a paragraph.
+  This is an example of <a class="sdds-link ${disabledClass} ${underlineClass}" href="#">a link</a> inside a paragraph.
   </p>
   `;
 };
@@ -15,4 +16,5 @@ const Template = ({ disabled = false }) => {
 export const Basic = Template.bind({});
 Basic.args = {
   disabled: false,
+  noUnderline: false,
 };


### PR DESCRIPTION
**Describe pull-request**  
Introducing CSS class for controlling link underline appearance.


**Solving issue**  
Fixes: [AB#982](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/982)  #187 


**How to test**  
1. Go to Strotybook
2. Open Card component, select Link variation
3. Links in the Card component should not be underlined anymore
4. Now open Link component, select a Basic variation
5. In Storybook controls it should be "noUnderline" knob to test component with/without Underline


