### PR TITLE
fix(starting-sdds): bug running sdds the first time

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "js-lint-fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "lint-check": "npx stylelint **/*.scss && eslint . --ext .js,.jsx,.ts,.tsx && prettier --check .",
     "lint-all": "npx stylelint **/*.scss && eslint . --ext .js,.jsx,.ts,.tsx && prettier --write .",
-    "prepare": "husky install",
+    "prepare": "husky install && npm run build",
     "commit": "cz"
   },
   "changelog": {


### PR DESCRIPTION
Running sdds first time right after install won't work since the core packages hasn't been built,
this makes it run build right after install under prepare phase

<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
_Describe what the pull-request is about_
If you clone a fresh sdds repo and run
- Npm i 
- npm start

It won't start, on master, because the theme will fail, reason for this is because the core packages hasn't been built yet. The core package don't have watchers, so every changes in those core packages needs to be built. Lerna start only starts the npm start command, which those packages doesn't have. Issue related with this #111 

**Solving issue**  
_In case of GitHub issue add # plus the number of the issue (for example #123) OR if it is Azure then AB# and number of ticket_
This solves the issue so you don't have to run build right before you start up sdds, so this will make it run build during prepare phase in npm

**How to test**  
_Add description how to test if possible_
1. Clone new
2. npm i  (during prepare with husky, build will run also)
3. npm start

Try the same commands on master

**Additional context**  
_Add any other context about the pull-request here._
#111  Related issue
