### PR TITLE
Improvement - expand and hide side menu on mobile view in React

### DIFF
--- a/demo/react/src/App.js
+++ b/demo/react/src/App.js
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import Header from './components/header/Header';
 import Form from './components/form/Form';
@@ -6,14 +7,15 @@ import Footer from './components/footer/Footer';
 import SideMenu from './components/sideMenu/SideMenu';
 
 function App() {
+  const [expand, setExpand] = useState(false);
   return (
     <div id="root" className="App">
       <Router>
         <sdds-theme />
-        <div className="sdds-navbar-overlay expanded" />
-        <Header />
+        <div className={`sdds-navbar-overlay ${expand ? 'expanded' : null}`} />
+        <Header onDrawerClick={() => setExpand(!expand)} expand={expand} />
         <div className="sdds-push sdds-demo-container">
-          <SideMenu />
+          <SideMenu expand={expand} />
           <div className={'sdds-content-push'}>
             <div className="sdds-container-fluid content-wrapper">
               <Switch>

--- a/demo/react/src/components/header/Header.js
+++ b/demo/react/src/components/header/Header.js
@@ -1,9 +1,14 @@
 import './Header.css';
 
-const Header = () => {
+const Header = ({ onDrawerClick, expand }) => {
   return (
     <nav className="sdds-navbar">
-      <button className="sdds-navbar-icon-button sdds-navbar-side-menu-drawer expanded">
+      <button
+        className={`sdds-navbar-icon-button sdds-navbar-side-menu-drawer ${
+          expand ? 'expanded' : null
+        }`}
+        onClick={onDrawerClick}
+      >
         <span className="sdds-icon-drawer" />
       </button>
       <div className="sdds-navbar-application-brand">SDDS DEMO REACT</div>

--- a/demo/react/src/components/sideMenu/SideMenu.js
+++ b/demo/react/src/components/sideMenu/SideMenu.js
@@ -3,7 +3,7 @@ import SideMenuItem from './components/sideMenuItem/SideMenuItem';
 import IconButton from './components/IconButton/IconButton';
 import SideMenuDropdownItem from './components/sideMenuDropdownItem/sideMenuDropdownItem';
 
-function SideMenu() {
+function SideMenu({ expand }) {
   const [collapse, setCollapse] = useState(false);
   const clickCollapse = () => setCollapse(!collapse);
 
@@ -13,7 +13,7 @@ function SideMenu() {
         collapse ? 'sdds-sidebar-collapse' : ''
       }`}
     >
-      <div className={`sdds-navbar-side-menu expanded`}>
+      <div className={`sdds-navbar-side-menu ${expand ? 'expanded' : null}`}>
         <ul className="sdds-navbar-menu-list">
           <SideMenuItem itemName={'Home'} link={'/'} collapse={collapse} />
           <SideMenuItem itemName={'Form'} link={'/form'} collapse={collapse} />


### PR DESCRIPTION


<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Expand or hide the side menu on mobile view in React demo

**Solving issue**  

Fixes: [AB#1263](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/1263)

**How to test**  
1. Go to React Demo
2. Check in mobile view
3. Try to expand and hide side menu
