### PR TITLE
fix(sdds-theme): fixing but related with text and background classes

### DIFF
--- a/components/src/components/theme/utilites.stories.js
+++ b/components/src/components/theme/utilites.stories.js
@@ -1,0 +1,53 @@
+export default {
+  title: 'utilities/Colours',
+};
+
+const TextColorTemplate = ({ color, text }) => {
+  return `
+  <sdds-theme></sdds-theme>
+  <h1 class="sdds-text-${color}">${text}</h1>
+  <p class="sdds-text-${color}">${text}</p>
+  `;
+};
+
+export const textColor = TextColorTemplate.bind({});
+textColor.args = {
+  color: 'grey-900',
+  text: 'A text block',
+};
+
+const BackgroundColorTemplate = ({ height, width, backgroundColor }) => {
+  return `
+  <sdds-theme></sdds-theme>
+    <div class="sdds-background-${backgroundColor}" style="height:${height}px; width:${width}px; display:block"> <h1>background-color:${backgroundColor}</h1></div>
+  `;
+};
+
+export const backgroundColor = BackgroundColorTemplate.bind({});
+
+backgroundColor.argTypes = {
+  height: {
+    name: 'Height',
+    control: {
+      type: 'range',
+      min: 10,
+      max: 1000,
+      step: 10,
+    },
+  },
+  width: {
+    name: 'Width',
+    control: {
+      type: 'range',
+      min: 10,
+      max: 1000,
+      step: 10,
+    },
+  },
+};
+
+backgroundColor.args = {
+  backgroundColor: 'blue-100',
+  height: 500,
+  width: 500,
+};

--- a/theme/light/src/_core.scss
+++ b/theme/light/src/_core.scss
@@ -9,6 +9,7 @@ Import foundation into theme components
 @import '../../core/typography/selectors';
 @import '../../core/colour/vars';
 @import '../../core/spacing/spacing-vars.scss';
+@import '../../core/colour/colour';
 
 //TODO: remove. Old colors are not used, only imported because of old setup
 @import 'old/core/old-colors.scss';


### PR DESCRIPTION
Added import missing to be able to use sdds-text and background classes

<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
_Describe what the pull-request is about_
Fixing issue with not being able to use for example `.sdds-text-blue-100`
- Added import missing from colour package
- Added new story to show off these options

**How to test**  
_Add description of how to test if possible_
1. Go to storybook
2. Go to story under utilities/colours
3. Check text example story, try and change colours
4. check background story, try and change colours

**Additional context**  
_Add any other context about the pull-request here._
You can try and link these package on website repo 
Need to create a release for this fix
