### PR TITLE
style(dropdown): restyling dropdown to fit along with other inputs

### DIFF
--- a/components/src/components/dropdown/_dropdown-core.scss
+++ b/components/src/components/dropdown/_dropdown-core.scss
@@ -1,31 +1,37 @@
 @mixin dropdown-wrapper {
   @include type-style('detail-02');
+
   color: var(--sdds-dropdown-text);
   display: flex;
   align-items: center;
   background-color: var(--sdds-dropdown-bg);
   cursor: pointer;
-  border: 1px solid var(--sdds-dropdown-border);
   transition: box-shadow 0.1s ease-in;
-  border-radius: var(--sdds-dropdown-border-radius);
+  border-radius: 1rem 1rem 0 0;
+  border: 0;
+  border-bottom: 1px solid var(--sdds-dropdown-border-bottom);
   box-shadow: 0;
   width: 100%;
   text-align: left;
   outline: none;
-  padding: var(--#{$prefix}-dropdown-padding-top-large)
+  padding:
+ var(--#{$prefix}-dropdown-padding-top-large)
     var(--#{$prefix}-dropdown-padding-left);
 
   &:hover {
-    border-color: var(--sdds-dropdown-toggle-border-hover);
+    border-bottom-color: var(--sdds-dropdown-toggle-border-hover);
   }
+
   &:focus {
-    border-color: var(--sdds-dropdown-toggle-border-focus);
+    border-width: 2px;
+    border-bottom-color: var(--sdds-dropdown-toggle-border-focus);
   }
+
   &:active,
   &.active &.selected {
-    border-color: var(--sdds-dropdown-toggle-border-selected);
-    background-color: var(--sdds-dropdown-bg-selected);
+    border-bottom-color: var(--sdds-dropdown-toggle-border-selected);
   }
+
   &.is-filter {
     transition: border 0.1s ease-in 0.1s;
     cursor: text;
@@ -34,6 +40,7 @@
 
 .#{$prefix}-dropdown-helper {
   @include type-style('detail-05');
+
   display: block;
   color: var(--sdds-dropdown-helper-text);
   margin-top: var(--sdds-spacing-element-4);
@@ -46,9 +53,11 @@
 }
 .#{$prefix}-dropdown-label-inside {
   @include type-style('detail-07');
+
   color: var(--sdds-dropdown-label-inside);
 }
 .#{$prefix}-dropdown-label-outside {
   @include type-style('detail-05');
+
   color: var(--sdds-dropdown-label-outside);
 }

--- a/components/src/components/dropdown/_dropdown-core.scss
+++ b/components/src/components/dropdown/_dropdown-core.scss
@@ -8,7 +8,7 @@
   cursor: pointer;
   transition: box-shadow 0.1s ease-in;
   border-radius: 1rem 1rem 0 0;
-  border: 0;
+  border: none;
   border-bottom: 1px solid var(--sdds-dropdown-border-bottom);
   box-shadow: 0;
   width: 100%;

--- a/components/src/components/dropdown/dropdown.scss
+++ b/components/src/components/dropdown/dropdown.scss
@@ -245,3 +245,6 @@
     opacity: 1;
   }
 }
+.#{$prefix}-dropdown-placeholder {
+  color: var(--sdds-dropdown-placeholder);
+}

--- a/components/src/components/dropdown/dropdown.scss
+++ b/components/src/components/dropdown/dropdown.scss
@@ -9,6 +9,7 @@
   --sdds-link-text-decoration: none;
 
   @include type-style('detail-02');
+
   color: var(--sdds-dropdown-text);
   box-sizing: border-box;
 }
@@ -24,6 +25,7 @@
   flex-flow: column wrap;
   width: 100%;
   border: 0;
+
   &,
   * {
     box-sizing: border-box;
@@ -45,23 +47,30 @@
   .#{$prefix}-dropdown-filter {
     border: 0;
     outline: none;
+
     @include type-style('detail-02');
+
     color: var(--sdds-dropdown-text);
     width: 100%;
     background: transparent;
+
     &:focus {
       outline: none;
     }
+
     &::placeholder {
       color: var(--sdds-dropdown-placeholder);
     }
+
     &::-webkit-input-placeholder {
       color: var(--sdds-dropdown-placeholder);
     }
+
     &::-moz-placeholder {
       color: var(--sdds-dropdown-placeholder);
       opacity: 1;
     }
+
     &::-ms-placeholder {
       color: var(--sdds-dropdown-placeholder);
     }
@@ -78,8 +87,6 @@
     border-color: transparent;
     border-style: solid;
     border-width: 0 1px 0;
-    border-bottom-left-radius: var(--sdds-dropdown-border-radius);
-    border-bottom-right-radius: var(--sdds-dropdown-border-radius);
   }
 
   // Size medium
@@ -92,7 +99,8 @@
   // Size small
   &.#{$prefix}-dropdown-small {
     .#{$prefix}-dropdown-toggle {
-      padding: var(--#{$prefix}-dropdown-padding-top-small)
+      padding:
+ var(--#{$prefix}-dropdown-padding-top-small)
         var(--sdds-spacing-element-16);
     }
   }
@@ -105,7 +113,7 @@
     .#{$prefix}-dropdown-toggle {
       pointer-events: none;
       color: var(--sdds-dropdown-text-disabled);
-      border-color: var(--sdds-dropdown-border-disabled);
+      border: none;
     }
   }
 }
@@ -134,18 +142,22 @@
     cursor: pointer;
     box-sizing: border-box;
   }
+
   ::slotted(sdds-dropdown-option:last-child) {
     border-bottom-color: transparent;
     border-bottom-left-radius: var(--sdds-dropdown-border-radius);
     border-bottom-right-radius: var(--sdds-dropdown-border-radius);
   }
+
   ::slotted(sdds-dropdown-option:hover) {
     background-color: var(--sdds-dropdown-bg-hover);
   }
+
   ::slotted(sdds-dropdown-option:focus) {
     border: 1px solid var(--sdds-dropdown-border-focus);
     outline: none;
   }
+
   ::slotted(sdds-dropdown-option.selected),
   ::slotted(sdds-dropdown-option.active),
   ::slotted(sdds-dropdown-option:active) {
@@ -174,7 +186,7 @@
 :host(.is-open) {
   .#{$prefix}-dropdown {
     .#{$prefix}-dropdown-toggle {
-      box-shadow: 0px -1px 3px -1px rgba(0, 0, 0, 0.1);
+      box-shadow: 0 -1px 3px -1px rgba(0, 0, 0, 0.1);
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
 
@@ -184,7 +196,7 @@
     }
     .#{$prefix}-dropdown-menu {
       max-height: 90rem; // max 7 option items, then add scroll
-      box-shadow: 0px 2px 3px 0px rgba(0, 0, 0, 0.1);
+      box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.1);
       border-left-color: var(--sdds-dropdown-border);
       border-right-color: var(--sdds-dropdown-border);
       overflow-x: hidden;

--- a/components/src/components/dropdown/dropdown.tsx
+++ b/components/src/components/dropdown/dropdown.tsx
@@ -161,7 +161,11 @@ export class Dropdown {
                   onInput={(event) => this.handleSearch(event)}
                 />
               ) : (
-                <span class="sdds-dropdown-label-main">
+                <span
+                  class={`sdds-dropdown-label-main ${
+                    this.selected.length === 0 && 'sdds-dropdown-placeholder'
+                  }`}
+                >
                   {this.selected.length > 0 ? this.selected : this.placeholder}
                 </span>
               )}

--- a/theme/light/src/components/_dropdowns.scss
+++ b/theme/light/src/components/_dropdowns.scss
@@ -8,23 +8,21 @@ html {
   --#{$prefix}-dropdown-padding-top-medium: 4rem;
   --#{$prefix}-dropdown-padding-top-small: 3rem;
   --#{$prefix}-dropdown-padding-left: 4rem;
-
   --#{$prefix}-dropdown-label-outside: #{get-colour(grey-958)};
   --#{$prefix}-dropdown-label-inside: #{get-colour(grey-700)};
   --#{$prefix}-dropdown-text: #{get-colour(grey-958)};
   --#{$prefix}-dropdown-helper-text: #{get-colour(grey-700)};
-
   --#{$prefix}-dropdown-placeholder: #{get-colour(grey-700)};
+  --#{$prefix}-dropdown-border-bottom: #{get-colour(grey-400)};
   --#{$prefix}-dropdown-filter-border: #{get-colour(blue-400)};
-
-  --#{$prefix}-dropdown-error: #{get-colour(red-500)};
+  --#{$prefix}-dropdown-error: #{get-colour(negative)};
 
   // Only applied to toggle button
   //TODO: change name of the variable toggle
-  --#{$prefix}-dropdown-toggle-border-hover: #{get-colour(grey-500)};
-  --#{$prefix}-dropdown-toggle-border-selected: #{get-colour(grey-400)};
-  --#{$prefix}-dropdown-toggle-border-focus: #{get-colour(blue-300)};
-  --#{$prefix}-dropdown-toggle-border-error: #{get-colour(red-500)};
+  --#{$prefix}-dropdown-toggle-border-hover: #{get-colour(grey-600)};
+  --#{$prefix}-dropdown-toggle-border-selected: #{get-colour(grey-800)};
+  --#{$prefix}-dropdown-toggle-border-focus: #{get-colour(blue-400)};
+  --#{$prefix}-dropdown-toggle-border-error: #{get-colour(negative)};
 
   // Applied to both toggle and option
   --#{$prefix}-dropdown-text-disabled: #{get-colour(grey-400)};
@@ -35,7 +33,6 @@ html {
   --#{$prefix}-dropdown-border: #{get-colour(grey-100)};
   --#{$prefix}-dropdown-border-focus: #{get-colour(blue-400)};
   --#{$prefix}-dropdown-border-selected: #{get-colour(grey-300)};
-  --#{$prefix}-dropdown-border-disabled: #{get-colour(grey-300)};
 
   .#{$prefix}-on-white-bg {
     --#{$prefix}-dropdown-bg: #{get-colour(grey-50)};


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Restyle dropdown to fit along with other inputs
- No border radius on bottom edges
- Border only on the bottom 
- Border color on different states
  - default state: change to grey400
  - hover state: change to grey600
  - error state: change to semantic negative
  - focus state: change to blue400 and width 2px
  - active state: change to grey800
  - disabled state: no border 

Figma: https://www.figma.com/file/jZONFYFlckRROjSVPPu2DD/Dropdown-exploration?node-id=2%3A163

**Solving issue**  
Fixes: [AB#1114](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/1114)

**How to test**  
1. Go to storybook dropdown example
2. Check the look of dropdown in different state
