### PR TITLE
fix(side-menu): side menu dropdown item opened border fix

### DIFF
--- a/components/src/components/dropdown/dropdown.scss
+++ b/components/src/components/dropdown/dropdown.scss
@@ -114,6 +114,9 @@
       pointer-events: none;
       color: var(--sdds-dropdown-text-disabled);
       border: none;
+      .#{$prefix}-dropdown-placeholder {
+        color: var(--sdds-dropdown-text-disabled);
+      }
     }
   }
 }

--- a/components/src/patterns/side-menu/side-menu.scss
+++ b/components/src/patterns/side-menu/side-menu.scss
@@ -13,10 +13,6 @@
     display: flex;
     flex-direction: column;
     border-left: 4px solid transparent;
-
-    &.opened {
-      border-left: 0;
-    }
   }
 }
 


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
1. Fixed the bug that opening the dropdown in side menu makes the option jump around. This is caused by border-left having 0.
 
2. Fixed Dropdown placeholder color on disabled state

**Solving issue**  
Fixes: #258 
Fixes: [AB#1312](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/1312)

**How to test**  
1. Go to Storybook 
2. Check in side menu dropdown item alignment on opened state(you can compare it with current storybook example) 

<img src="https://user-images.githubusercontent.com/23560351/150787522-062c6119-6e06-413d-bc82-58da8ba8ee67.png" alt="drawing" width="200"/> <- Current alignment     <img src="https://user-images.githubusercontent.com/23560351/150787371-2a6e7f56-dc6b-4391-9d69-af3c6f7012aa.png" alt="drawing" width="200"/> <- Fixed alignment

3. Check in dropdown component placeholder color when it is disabled state it should be screenshot below
![image](https://user-images.githubusercontent.com/23560351/151152334-696c27f2-6a42-4abb-9261-9713b995be35.png)

