### PR TITLE
docs(readme): readability update

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,9 @@ You can find everything in [NPM](https://www.npmjs.com/org/scania)
 ## Framework demos
 Clone this repo to run framework demo applications locally. Demos are available Angular, React, Vue and HTML. Each application needs to be installed individually before use. Installing creates a `node_modules` directory with modules needed to run the application as they're listed in the `package.json`-file of each app directory.
 
-Note: If you install and start from root level, you will access a local copy of SDDS UI library in Storybook.
+Note 1: If you install and start from root level, you will access a local copy of SDDS UI library in Storybook.
+
+Note 2: `npm start` not applicable for HTML demo 
 
 ```shell
 > git clone https://github.com/scania-digital-design-system/sdds.git

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ The design system supports the design and development of digital solutions at Sc
 
 - [Browser Support](#browser-support)
 - [Getting started](#getting-started)
-- [Demos](#demo)
+- [Framework demos](#framework-demos)
 - [Local environment](#run-local-environment)
   - [Commands](#commands-to-start)
   - [Debugging local environment](#debugging-local-environment)
@@ -42,14 +42,18 @@ You can also install a standalone package for different part. These are availabl
 
 You can find everything in [NPM](https://www.npmjs.com/org/scania)
 
-## Demo
+## Framework demos
+Clone this repo to run framework demo applications locally. Demos are available Angular, React, Vue and HTML. Each application needs to be installed individually before use. Installing creates a `node_modules` directory with modules needed to run the application as they're listed in the `package.json`-file of each app directory.
 
-Check the working demo on this repository.
+Note: If you install and start from root level, you will access a local copy of SDDS UI library in Storybook.
 
-- [Angular](./demo/angular)
-- [React](./demo/react)
-- [Vue](./demo/vue)
-- [HTML](./demo/HTML)
+```shell
+> git clone https://github.com/scania-digital-design-system/sdds.git
+> cd {app-directory}
+> npm i
+> npm start
+```
+
 
 ## Run local environment
 


### PR DESCRIPTION
Clarification that framework demos are run locally and how they're installed and run

<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Updated readme-file at root level. No longer a reference to repo directory, but a description on how to clone, install and run demos locally. 

**Solving issue**  
N/A

**How to test**  
1. Follow the steps on your local machine (clone, install and start) for each demo
2. Verify the described outcome, i.e. is able to open demos

**Screenshots**  
N/A

**Additional context**  
No official issue, but I was personally confused and not helped by the guide when I tried to find the demos. Have tried myself for all framework demos.
