### PR TITLE
fix(storybook): using layout for arranging content in stories

### DIFF
--- a/components/.storybook/preview-body.html
+++ b/components/.storybook/preview-body.html
@@ -1,8 +1,0 @@
-<style>
-    .sb-show-main.sb-main-padded {
-        margin: 0;
-        padding: 0;
-        display: block;
-        box-sizing: border-box;
-    }
-</style>

--- a/components/.storybook/preview.js
+++ b/components/.storybook/preview.js
@@ -95,6 +95,7 @@ export const parameters = {
     default: 'grey',
     values: customBGvalues,
   },
+  layout: 'centered',
 };
 
 setCustomElements(customElements);

--- a/components/src/components/theme/colour.stories.js
+++ b/components/src/components/theme/colour.stories.js
@@ -1,5 +1,8 @@
 export default {
   title: 'Foundation/Colour',
+  parameters: {
+    layout: 'fullscreen',
+  },
 };
 
 const style = `

--- a/components/src/components/theme/fullpage.stories.js
+++ b/components/src/components/theme/fullpage.stories.js
@@ -1,5 +1,8 @@
 export default {
   title: 'Patterns/Fullpage',
+  parameters: {
+    layout: 'fullscreen',
+  },
 };
 
 const Template = ({ menuCollapse = false }) => {

--- a/components/src/components/theme/grid.stories.js
+++ b/components/src/components/theme/grid.stories.js
@@ -1,5 +1,8 @@
 export default {
   title: 'Foundation/Grid',
+  parameters: {
+    layout: 'fullscreen',
+  },
   args: {
     fluidContainer: false,
     padding: true,

--- a/components/src/components/theme/spacing.stories.js
+++ b/components/src/components/theme/spacing.stories.js
@@ -1,5 +1,8 @@
 export default {
   title: 'Foundation/Spacing',
+  parameters: {
+    layout: 'fullscreen',
+  },
 };
 
 const SpacingLayoutTemplate = () => `

--- a/components/src/components/theme/typography.stories.js
+++ b/components/src/components/theme/typography.stories.js
@@ -4,6 +4,7 @@ export default {
   title: 'Foundation/Typography',
   parameters: {
     notes: readme,
+    layout: 'fullscreen',
   },
 };
 

--- a/components/src/components/theme/utilites.stories.js
+++ b/components/src/components/theme/utilites.stories.js
@@ -1,5 +1,8 @@
 export default {
   title: 'utilities/Colours',
+  parameters: {
+    layout: 'fullscreen',
+  },
 };
 
 const TextColorTemplate = ({ color, text }) => `

--- a/components/src/patterns/footer/footer.stories.js
+++ b/components/src/patterns/footer/footer.stories.js
@@ -4,6 +4,7 @@ export default {
   title: 'Patterns/Footer',
   parameters: {
     notes: readme,
+    layout: 'fullscreen',
   },
 };
 

--- a/components/src/patterns/header/header.stories.js
+++ b/components/src/patterns/header/header.stories.js
@@ -11,6 +11,7 @@ export default {
   },
   parameters: {
     notes: readme,
+    layout: 'fullscreen',
   },
 };
 

--- a/components/src/patterns/side-menu/side-menu.stories.js
+++ b/components/src/patterns/side-menu/side-menu.stories.js
@@ -2,6 +2,9 @@ import { useArgs } from '@storybook/client-api';
 
 export default {
   title: 'Patterns/SideMenu',
+  parameters: {
+    layout: 'fullscreen',
+  },
 };
 
 const Template = (args) => {


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Solving issues with Storybook padding, margins, and centralizing content.

**Solving issue**  
We used tricks to remove padding or margins set by stories.
There is a layout attribute that can be used instead, a very elegant solution for this issue.
More about it: https://storybook.js.org/docs/react/configure/story-layout

**How to test**  
1. Open Storybook
2. All simple component stories need to be centralized
3. Other stories for full-screen components have set fullscreen layout property (header/footer/side menu/colors/....)


