### PR TITLE
test(chromatic): visual testing for buttons

### DIFF
--- a/components/.storybook/preview.js
+++ b/components/.storybook/preview.js
@@ -95,10 +95,10 @@ export const parameters = {
     default: 'grey',
     values: customBGvalues,
   },
-  layout: 'centered',
+  layout: 'centered', // center the component horizontally and vertically in the Canvas
+  chromatic: { disableSnapshot: true }, // disables snapshotting on a global level
 };
 
 setCustomElements(customElements);
-
 defineCustomElements();
 addTheme(theme);

--- a/components/package-lock.json
+++ b/components/package-lock.json
@@ -14742,6 +14742,12 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true
     },
+    "chromatic": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-6.5.1.tgz",
+      "integrity": "sha512-TASnx9apJAokwpnTZvmLzd0+xDMkByEa4i89rrP27cqriI0aLqvGt/ckocGOk6UrVBn/e2pdwPeTLtkGMxCQHQ==",
+      "dev": true
+    },
     "chrome-trace-event": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",

--- a/components/package.json
+++ b/components/package.json
@@ -28,7 +28,8 @@
     "new": "stencil generate",
     "prepublishOnly": "npm run build",
     "test": "stencil test --spec --verbose",
-    "test.watch": "stencil test --spec --e2e --watchAll"
+    "test.watch": "stencil test --spec --e2e --watchAll",
+    "chromatic": "npx chromatic --project-token=d732995e8c94"
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",
@@ -56,6 +57,7 @@
     "babel-loader": "^8.1.0",
     "babel-preset-es2015": "^6.24.1",
     "bootstrap": "4.3.1",
+    "chromatic": "^6.4.3",
     "highlight.js": "9.16.2",
     "jest": "^26.6.2",
     "jest-cli": "^26.6.2",

--- a/components/src/components/button/button.stories.js
+++ b/components/src/components/button/button.stories.js
@@ -1,23 +1,33 @@
+/**
+ * Default controls
+ */
+
 export default {
   title: 'Component/Button',
-  argTypes: {
-    size: {
-      control: {
-        type: 'select',
-        options: ['default', 'small', 'medium'],
-      },
-      defaultValue: 'default',
-      description: 'Size of the button',
+  parameters: {
+    layout: 'padded',
+    chromatic: {
+      disableSnapshot: false, // enables snapshotting for the component
     },
+  },
+  argTypes: {
     btnType: {
       name: 'type',
       defaultValue: 'primary',
       description:
         'Four different button types to help the user to distinguish the level of importance of the task they represent',
       control: {
-        type: 'select',
+        type: 'radio',
         options: ['primary', 'secondary', 'ghost', 'danger'],
       },
+    },
+    size: {
+      control: {
+        type: 'radio',
+        options: ['large', 'medium', 'small'],
+      },
+      defaultValue: 'large',
+      description: 'Size of the button',
     },
     fullbleed: {
       type: 'boolean',
@@ -26,6 +36,7 @@ export default {
     },
     disabled: {
       type: 'boolean',
+      defaultValue: false,
       description: 'Choose to disable the button',
     },
     onlyIcon: {
@@ -36,10 +47,17 @@ export default {
     },
     icon: {
       type: 'boolean',
+      defaultValue: false,
       description: 'Include icon',
     },
   },
 };
+
+/**
+ * Basic template
+ * @param {*} param0
+ * @returns Button HTML element
+ */
 
 const ButtonTemplate = ({
   size,
@@ -63,30 +81,30 @@ const ButtonTemplate = ({
       break;
   }
   const fbClass = fullbleed ? 'sdds-btn-fullbleed' : '';
-  const inlineStyle = fullbleed ? 'style="width:200px;"' : '';
-
+  const inlineStyle = fullbleed ? 'style="width:100%;"' : '';
   const onlyIconCss = onlyIcon ? 'sdds-btn-icon' : '';
 
+  // chromatic snapshot requires icon to be sdds-icon instead of font
   return `
   <sdds-theme></sdds-theme>
-  <style>
-    @import url('https://cdn.digitaldesign.scania.com/icons/dist/1.1.0/fonts/css/sdds-icons.css');
-    i {
-      font-size: 4rem;
-    }
-  </style>
   <button class="sdds-btn sdds-btn-${btnType} ${sizeValue} ${fbClass} ${
     disabled ? 'disabled' : ''
   } ${onlyIconCss}" ${inlineStyle}>
     <span>${text}</span>
     ${
       icon
-        ? "<span class='sdds-btn-icon'><i class='sdds-icon scania-cross'></i></span>"
+        ? "<span class='sdds-btn-icon'><sdds-icon name='scania-cross'></sdds-icon></span>"
         : ''
     }
   </button>
   `;
 };
+
+/**
+ * Basic template
+ * @param {*} param0
+ * @returns Button as a web component
+ */
 
 const ComponentBtn = ({
   size,
@@ -98,18 +116,18 @@ const ComponentBtn = ({
 }) => {
   let sizeValue = '';
   switch (size) {
-    case 'small':
-      sizeValue = 'sm';
+    default:
+      sizeValue = '';
       break;
     case 'medium':
       sizeValue = 'md';
       break;
-    default:
-      sizeValue = '';
+    case 'small':
+      sizeValue = 'sm';
       break;
   }
 
-  const inlineStyle = fullbleed ? 'style="width:200px;"' : '';
+  const inlineStyle = fullbleed ? 'style="width:100%;"' : '';
 
   return `
   <sdds-theme></sdds-theme>
@@ -121,22 +139,45 @@ const ComponentBtn = ({
   `;
 };
 
-export const Basic = ButtonTemplate.bind({});
-Basic.args = {
+/** Stories exported to Storybook */
+
+/** Button type representatives (equivalence classes) */
+
+export const Primary = ButtonTemplate.bind({});
+Primary.args = {
   text: 'Button',
 };
 
-export const WithIcon = ButtonTemplate.bind({});
-WithIcon.args = {
-  text: 'Button with Icon',
-  icon: true,
+export const Secondary = ButtonTemplate.bind({});
+Secondary.args = {
+  btnType: 'secondary',
+  text: 'Button',
+};
+
+export const Ghost = ButtonTemplate.bind({});
+Ghost.args = {
+  btnType: 'ghost',
+  text: 'Button',
+};
+
+export const Danger = ButtonTemplate.bind({});
+Danger.args = {
+  btnType: 'danger',
+  text: 'Button',
 };
 
 export const Disabled = ButtonTemplate.bind({});
 Disabled.args = {
   disabled: 'disabled',
-  text: 'Button Disabled',
-  icon: false,
+  text: 'Button',
+};
+
+/** Variants of button. Shown only on primary button */
+
+export const withIcon = ButtonTemplate.bind({});
+withIcon.args = {
+  text: 'Button',
+  icon: true,
 };
 
 export const onlyIcon = ButtonTemplate.bind({});
@@ -153,6 +194,28 @@ onlyIcon.argTypes = {
   },
 };
 
+export const Medium_Size_W_Icon = ButtonTemplate.bind({});
+Medium_Size_W_Icon.args = {
+  size: 'medium',
+  text: 'Button',
+  icon: true,
+};
+
+export const Small_Size_W_Icon = ButtonTemplate.bind({});
+Small_Size_W_Icon.args = {
+  size: 'small',
+  text: 'Button',
+  icon: true,
+};
+
+export const Fullbleed = ButtonTemplate.bind({});
+Fullbleed.args = {
+  text: 'Button',
+  fullbleed: true,
+  icon: true,
+};
+
+/** Button as web component */
 export const sddsButton = ComponentBtn.bind({});
 sddsButton.args = {
   text: 'Button',

--- a/components/src/components/button/button.stories.js
+++ b/components/src/components/button/button.stories.js
@@ -1,6 +1,4 @@
-/**
- * Default controls
- */
+/* Default controls */
 
 export default {
   title: 'Component/Button',


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->
> A retry on this PR since last PR https://github.com/scania-digital-design-system/sdds/pull/308 included edits of irrelevant files. 

**Describe pull-request**  
_Describe what the pull-request is about_

- As a pilot project, only buttons are being snapshotted by chromatic. More stories can be added later by adding parameter to each story, read more here https://www.chromatic.com/docs/ignoring-elements
- Chromatic snapshot individual stories, so I've refactored button stories to represent all existing button variations (currently ~900).



**Solving issue**  
_In case of GitHub issue add # plus the number of the issue (for example #123) OR if it is Azure then AB# and number of ticket_
Fixes: [AB#1335](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/1335)

**How to test**  
_Add description how to test if possible_

Please see if this still works as previous PR
1. Open branch in your local environment
2. Run chromatic from sdds/components with CLI npm run chromatic

Chromatic seems to be running a "pre-test" to see if there are changes before it starts to make new snapshots. If there are no changes, there won't be any new snapshots.

Build should be accessible https://www.chromatic.com/build?appId=620cc1abd4e7e7003aa19d3e&number=3