### PR TITLE
fix(storybook): set global sdds-theme instead of in every story

### DIFF
--- a/components/.storybook/preview-body.html
+++ b/components/.storybook/preview-body.html
@@ -4,3 +4,6 @@
         max-width: 460px;
     }
 </style>
+
+<!-- Importing sdds-theme on global level instead of ever single story -->
+<sdds-theme></sdds-theme>

--- a/components/.storybook/preview.js
+++ b/components/.storybook/preview.js
@@ -1,8 +1,8 @@
-import { setCustomElements } from '@storybook/web-components';
-import customElements from '../dist/collection/custom-elements.json';
+import { addTheme } from '../dist/collection/index';
+import { theme } from '../node_modules/@scania/theme-light';
 
-import { addTheme, defineCustomElements } from '../dist/collection/index';
-import { theme } from '@scania/theme-light';
+import { defineCustomElements } from '../dist/esm/loader';
+defineCustomElements();
 
 const customViewports = {
   xs: {
@@ -72,10 +72,6 @@ const customBGvalues = [
     name: 'white',
     value: '#FFFFFF',
   },
-  // {
-  //   name: 'dark',
-  //   value: '#3A3B3F',
-  // },
 ];
 
 //Storybook settings
@@ -87,7 +83,6 @@ export const parameters = {
     list: [
       { name: 'on-white', class: 'sdds-on-white-bg', color: '#FFFFFF' },
       { name: 'on-grey', class: 'sdds-on-grey-bg', color: '#F6F6F7' },
-      // { name: 'on-dark', class: 'sdds-on-grey', color: '#3A3B3F' }
     ],
   },
   backgrounds: {
@@ -99,6 +94,4 @@ export const parameters = {
   chromatic: { disableSnapshot: true }, // disables snapshotting on a global level
 };
 
-setCustomElements(customElements);
-defineCustomElements();
 addTheme(theme);

--- a/components/package.json
+++ b/components/package.json
@@ -29,7 +29,10 @@
     "prepublishOnly": "npm run build",
     "test": "stencil test --spec --verbose",
     "test.watch": "stencil test --spec --e2e --watchAll",
-    "chromatic": "npx chromatic --project-token=d732995e8c94"
+    "chromatic": "npx chromatic --project-token=d732995e8c94",
+
+    "stencil:watch": "stencil build --watch",
+    "storybook": "start-storybook -s dist"
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",

--- a/components/package.json
+++ b/components/package.json
@@ -32,7 +32,7 @@
     "chromatic": "npx chromatic --project-token=d732995e8c94",
 
     "stencil:watch": "stencil build --watch",
-    "storybook": "start-storybook -s dist"
+    "storybook": "start-storybook -s dist -p 1339"
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",

--- a/components/src/components/accordion/accordion.stories.js
+++ b/components/src/components/accordion/accordion.stories.js
@@ -43,7 +43,6 @@ export default {
 };
 
 const Template = ({ disabled, affix, paddingReset }) => `
-  <sdds-theme></sdds-theme>
     <sdds-accordion class="sdds-storybook-wrapper">
       <sdds-accordion-item header="First item" affix="${affix}" disabled="${disabled}" tabindex="1" padding-reset="${paddingReset}">
         This is the panel, which contains associated information with the header. Usually it contains text, set in the same size as the header. 

--- a/components/src/components/badges/badges.stories.js
+++ b/components/src/components/badges/badges.stories.js
@@ -16,8 +16,7 @@ export default {
 
 const basicTemplate = ({ value }) => {
   const valueString = value != null ? value.toString() : ''; // convert to string
-  return `      
-    ${basicStyle}     
+  return ` 
       <sdds-badges value=${valueString}>       
       </sdds-badges>
     `;

--- a/components/src/components/badges/badges.stories.js
+++ b/components/src/components/badges/badges.stories.js
@@ -16,8 +16,8 @@ export default {
 
 const basicTemplate = ({ value }) => {
   const valueString = value != null ? value.toString() : ''; // convert to string
-  return `
-      <sdds-theme></sdds-theme>
+  return `      
+    ${basicStyle}     
       <sdds-badges value=${valueString}>       
       </sdds-badges>
     `;
@@ -43,7 +43,6 @@ const badgesTemplate = ({ value }) => {
   const valueString = value != null ? value.toString() : ''; // convert to string
   return `
     ${style}
-      <sdds-theme></sdds-theme>
       <div class="demo">
       <sdds-badges class="demo-badges" value=${valueString}>       
       </sdds-badges> 

--- a/components/src/components/banner/banner.stories.js
+++ b/components/src/components/banner/banner.stories.js
@@ -23,7 +23,6 @@ export default {
 };
 
 const Template = ({ state, prefix, header, subheader, link }) => `
-  <sdds-theme></sdds-theme>
     <div class="sdds-banner sdds-banner-${state}">
       ${prefix}
       <div class="sdds-banner-body">

--- a/components/src/components/breadcrumb/breadcrumb.stories.js
+++ b/components/src/components/breadcrumb/breadcrumb.stories.js
@@ -2,8 +2,7 @@ export default {
   title: 'Component/Breadcrumb',
 };
 
-const Template = () => `
-    <sdds-theme></sdds-theme>
+const Template = () => `   
     <div class="sdds-breadcrumb">
       <div class="sdds-breadcrumb-item"><a href="#">Page 1</a></div>
       <div class="sdds-breadcrumb-item"><a href="#">Page 2</a></div>

--- a/components/src/components/button/button.stories.js
+++ b/components/src/components/button/button.stories.js
@@ -84,7 +84,6 @@ const ButtonTemplate = ({
 
   // chromatic snapshot requires icon to be sdds-icon instead of font
   return `
-  <sdds-theme></sdds-theme>
   <button class="sdds-btn sdds-btn-${btnType} ${sizeValue} ${fbClass} ${
     disabled ? 'disabled' : ''
   } ${onlyIconCss}" ${inlineStyle}>
@@ -128,7 +127,6 @@ const ComponentBtn = ({
   const inlineStyle = fullbleed ? 'style="width:100%;"' : '';
 
   return `
-  <sdds-theme></sdds-theme>
   <sdds-button type="${btnType}" size="${sizeValue}" ${
     disabled ? 'disabled' : ''
   } ${fullbleed ? 'fullbleed' : ''} text="${text}" ${inlineStyle}> ${

--- a/components/src/components/card/card.stories.js
+++ b/components/src/components/card/card.stories.js
@@ -20,7 +20,6 @@ const CardTemplate = ({
   divider,
   imageTop,
 }) => `
-    <sdds-theme></sdds-theme>
     <div class="sdds-storybook-wrapper">
           <div class="sdds-card${clickable ? ' sdds-clickable' : ''}">
             ${
@@ -118,8 +117,7 @@ const AvatarTemplate = ({
   divider,
   imageTop,
   avatar,
-}) => `
-    <sdds-theme></sdds-theme>
+}) => `  
     <div class="sdds-storybook-wrapper">
       <div class="sdds-card ${clickable ? 'sdds-clickable' : ''}">
       ${

--- a/components/src/components/checkbox/checkbox.stories.js
+++ b/components/src/components/checkbox/checkbox.stories.js
@@ -3,7 +3,6 @@ export default {
 };
 
 const Template = () => `
-      <sdds-theme></sdds-theme>
       <div>
         <div class="sdds-checkbox-item">
           <input class="sdds-form-input" type="checkbox" name="cb-example" id="cb-option-1">

--- a/components/src/components/divider/divider.stories.js
+++ b/components/src/components/divider/divider.stories.js
@@ -20,7 +20,6 @@ const style = `<style>
 
 const dividerTemplate = ({ ...Basic }) => `
   ${style}
-    <sdds-theme></sdds-theme>
     <div style="width: ${Basic.width}px;" class="sdds-divider-${Basic.type}"></div>
   `;
 
@@ -45,7 +44,6 @@ Basic.argTypes = {
 
 const dividerVerticalTemplate = ({ ...Vertical }) => `
   ${style}
-    <sdds-theme></sdds-theme>
     <div style="height:${Vertical.height}px;" class="sdds-divider-${Vertical.type}-vertical"></div>
   `;
 
@@ -70,7 +68,6 @@ Vertical.args = {
 
 const dividerBorderTemplate = ({ ...Border }) => `
   ${style}
-    <sdds-theme></sdds-theme>
       <div style="width: ${Border.width}px; background-color: ${Border.bgColor}; height:${Border.height}px;" class="divider-border-demo sdds-divider-${Border.type}-border-${Border.direction}">Demo</div>
     `;
 

--- a/components/src/components/dropdown/dropdown.stories.js
+++ b/components/src/components/dropdown/dropdown.stories.js
@@ -76,7 +76,6 @@ const Template = ({
   dropdownOptions,
   width,
 }) => `
-  <sdds-theme></sdds-theme>
     <div style="width:${width}px">
         <sdds-dropdown 
           size="${size}"
@@ -133,7 +132,6 @@ const FilterTemplate = ({
   defaultOption,
   width,
 }) => `
-    <sdds-theme></sdds-theme>
     <div style="width:${width}px">
         <sdds-dropdown-filter
         size="${size}"
@@ -173,7 +171,6 @@ const NativeTemplate = ({
   state,
   width,
 }) => `
-  <sdds-theme></sdds-theme>
     <div style="width:${width}px">
         <div class="sdds-dropdown ${
           size !== 'large' ? `sdds-dropdown-${size}` : ''

--- a/components/src/components/icon/icon.stories.js
+++ b/components/src/components/icon/icon.stories.js
@@ -19,7 +19,6 @@ const IconTemplate = ({ icon, size }) => `
       font-size: ${size}rem;
     }
   </style>
-  <sdds-theme></sdds-theme>
   <sdds-icon name="${icon}">sdds-icon</sdds-icon>
   `;
 
@@ -35,7 +34,6 @@ const IconCssTemplate = ({ icon, size }) => `
     @import url('https://cdn.digitaldesign.scania.com/icons/dist/1.1.0/fonts/css/sdds-icons.css');
     i {font-size: ${size}rem;}
   </style>
-  <sdds-theme></sdds-theme>
   <i class="sdds-icon ${icon}"></i>
   `;
 

--- a/components/src/components/link/link.stories.js
+++ b/components/src/components/link/link.stories.js
@@ -6,7 +6,6 @@ const Template = ({ disabled = false, noUnderline = false }) => {
   const disabledClass = disabled ? 'disabled' : '';
   const underlineClass = noUnderline ? 'sdds-link--no-underline' : '';
   return `
-  <sdds-theme></sdds-theme>
   <a class="sdds-link ${disabledClass} ${underlineClass}" href="#">a link</a>
   `;
 };

--- a/components/src/components/modal/modal.stories.js
+++ b/components/src/components/modal/modal.stories.js
@@ -15,8 +15,6 @@ export default {
 };
 
 const ModalTemplate = ({ ...Modal }) => `
-  
-  <sdds-theme></sdds-theme>
   <button onclick="console.log('Open modal 1')" class="sdds-btn sdds-btn-primary modal1">Open modal 1</button>
   <button onclick="console.log('Open modal 1')" class="sdds-btn sdds-btn-secondary modal1">Open modal 1</button>
   <sdds-modal size="${Modal.size}" selector=".modal1" ${
@@ -55,7 +53,6 @@ Modal.args = {
 };
 
 const ModalCssTemplate = ({ ...ModalCSS }) => `
-  <sdds-theme></sdds-theme>
   <div class="sdds-modal-backdrop show">
     <div class="sdds-modal sdds-modal-${ModalCSS.size}">
       <div class="sdds-modal-header">

--- a/components/src/components/radio-button/radio-button.stories.js
+++ b/components/src/components/radio-button/radio-button.stories.js
@@ -3,7 +3,6 @@ export default {
 };
 
 const Template = () => `
-    <sdds-theme></sdds-theme>
     <div class="sdds-radio-button-group">
       <div class="sdds-radio-item">
         <input class="sdds-form-input" type="radio" name="rb-example" id="rb-option-1">

--- a/components/src/components/slider/slider.stories.js
+++ b/components/src/components/slider/slider.stories.js
@@ -43,7 +43,6 @@ export default {
 const Template = ({ type, min, max, value, valueTwo }) => {
   type = type === 'default' ? 'basic' : type;
   return `
-  <sdds-theme></sdds-theme>
   <div class="sdds-storybook-wrapper">
   <sdds-slider type="${type}" min="${min}" max="${max}" value="${value}" value-two="${valueTwo}">
   </sdds-slider>

--- a/components/src/components/spinner/spinner.stories.js
+++ b/components/src/components/spinner/spinner.stories.js
@@ -46,7 +46,6 @@ const Template = ({ size, type }) => {
 
   return `
   ${style}
-  <sdds-theme></sdds-theme>
   <div class="demo">
   <sdds-spinner size="${sizeValue}" type="${type}">
   </sdds-spinner>

--- a/components/src/components/spinner/spinner.stories.js
+++ b/components/src/components/spinner/spinner.stories.js
@@ -1,5 +1,8 @@
 export default {
   title: 'Component/Spinner',
+  parameters: {
+    layout: 'centered', // Center the component horizontally and vertically in the Canvas
+  },
   argTypes: {
     size: {
       control: {
@@ -55,6 +58,3 @@ const Template = ({ size, type }) => {
 };
 
 export const Basic = Template.bind({});
-Basic.parameters = {
-  layout: 'centered', // Center the component horizontally and vertically in the Canvas
-};

--- a/components/src/components/table/table.stories.js
+++ b/components/src/components/table/table.stories.js
@@ -2,7 +2,6 @@ export default {
   title: 'Component/Table',
 };
 const Template = ({ type, divider }) => `
-    <sdds-theme></sdds-theme>
     <table class="sdds-table sdds-table-${type} sdds-table-${divider}">
     <caption>Table caption</caption>       
     <thead>
@@ -61,8 +60,7 @@ CompactDividers.args = {
   type: 'compact',
   divider: 'divider',
 };
-const Table = ({ type, divider }) => `
-    <sdds-theme></sdds-theme>
+const Table = ({ type, divider }) => ` 
     <table class="sdds-table sdds-table-${type} sdds-table-${divider}">   
       <thead>
         <tr>

--- a/components/src/components/textarea/textarea.stories.js
+++ b/components/src/components/textarea/textarea.stories.js
@@ -80,7 +80,6 @@ const textfieldTemplate = ({
 }) => {
   const maxlength = textcounter > 0 ? `maxlength="${textcounter}"` : '';
   return `
-  <sdds-theme></sdds-theme>
   <div class="sdds-storybook-wrapper">
         <sdds-textarea
           state="${state}"

--- a/components/src/components/textfield/textfield.stories.js
+++ b/components/src/components/textfield/textfield.stories.js
@@ -112,7 +112,6 @@ const textfieldTemplate = ({
   }
 
   return `
-  <sdds-theme></sdds-theme>
   <div style="width: 208px">
     <sdds-textfield
       type="${type}"

--- a/components/src/components/theme/colour.stories.js
+++ b/components/src/components/theme/colour.stories.js
@@ -6,7 +6,6 @@ export default {
 };
 
 const style = `
-  <sdds-theme></sdds-theme>
   <style>
     .colour-div {
       height: 90px;

--- a/components/src/components/theme/grid.stories.js
+++ b/components/src/components/theme/grid.stories.js
@@ -12,9 +12,6 @@ export default {
 // Styling for grid templates
 const style = `
   <style>
-    .sb-show-main.sb-main-padded {
-      padding: 0;
-    }
     .sdds-container,
     .sdds-container-fluid {
       background-color: #ff00009e;
@@ -46,7 +43,6 @@ const style = `
 
 const GridTemplate = ({ fluidContainer, padding }) => `
   ${style}
-  <sdds-theme global=""></sdds-theme>
   <h4>Grid</h4>
   <div class="${
     fluidContainer == true ? 'sdds-container-fluid' : 'sdds-container'
@@ -131,7 +127,6 @@ export const Basic = GridTemplate.bind({});
 
 const GridAutoColTemplate = ({ fluidContainer, padding }) => `
   ${style}
-  <sdds-theme></sdds-theme>
   <h4>Grid Auto columns</h4>
   <h5>Container 1</h5>
 
@@ -214,7 +209,6 @@ export const Auto = GridAutoColTemplate.bind({});
 
 const GridPushTemplate = ({ fluidContainer, collapse, padding }) => `
   ${style}
-  <sdds-theme></sdds-theme>
   <h4>Grid Push</h4>
   <div class="sdds-push">
     <div class="sdds-sidebar ${collapse ? 'sdds-sidebar-collapse' : ''}">
@@ -272,7 +266,6 @@ Push.args = {
 
 const GridOffsetTemplate = ({ fluidContainer, padding }) => `
   ${style}
-  <sdds-theme></sdds-theme>
   <h4>Grid Offset</h4>
     <div class="${
       fluidContainer == true ? 'sdds-container-fluid' : 'sdds-container'
@@ -295,7 +288,6 @@ export const Offset = GridOffsetTemplate.bind({});
 
 const GridNoPaddingTemplate = ({ fluidContainer, padding }) => `
     ${style}
-    <sdds-theme></sdds-theme>
     <h4>Grid no-padding</h4>
     <div class="${
       fluidContainer == true ? 'sdds-container-fluid' : 'sdds-container'
@@ -329,7 +321,6 @@ NoPadding.args = {
 
 const GridFluidTemplate = ({ fluidContainer = true, padding }) => `
     ${style}
-    <sdds-theme></sdds-theme>
     <h4>Grid fluid</h4>
     <div class="sdds-container-fluid ${
       padding == false ? 'sdds-no-padding' : ''
@@ -356,7 +347,6 @@ export const Fluid = GridFluidTemplate.bind({});
 
 const GridNestedTemplate = ({ fluidContainer, padding }) => `
  ${style}
- <sdds-theme></sdds-theme>
  <h4>Nested</h4>
  <div class="${
    fluidContainer == true ? 'sdds-container-fluid' : 'sdds-container'
@@ -404,7 +394,6 @@ export const Nested = GridNestedTemplate.bind({});
 
 const GridHideShow = ({ fluidContainer }) => `
   ${style}
-  <sdds-theme></sdds-theme>
   <h4>Hide/show element</h4>
   <div class="${
     fluidContainer == true ? 'sdds-container-fluid' : 'sdds-container'

--- a/components/src/components/theme/spacing.stories.js
+++ b/components/src/components/theme/spacing.stories.js
@@ -6,7 +6,6 @@ export default {
 };
 
 const SpacingLayoutTemplate = () => `
-  <sdds-theme></sdds-theme>
   <style>
     .sdds-spacing-layout-demo-box {
       background-color: var(--sdds-blue-500);
@@ -99,8 +98,7 @@ const SpacingLayoutTemplate = () => `
   </table>
   `;
 
-const SpacingElementTemplate = ({}) => `
-  <sdds-theme></sdds-theme>
+const SpacingElementTemplate = () => `
   <style>
     .sdds-spacing-element-demo-box {
       background-color: var(--sdds-red-500);

--- a/components/src/components/theme/typography.stories.js
+++ b/components/src/components/theme/typography.stories.js
@@ -9,7 +9,6 @@ export default {
 };
 
 const Template = ({ content }) => `
-  <sdds-theme></sdds-theme>
   ${content}
   `;
 

--- a/components/src/components/theme/utilites.stories.js
+++ b/components/src/components/theme/utilites.stories.js
@@ -6,7 +6,6 @@ export default {
 };
 
 const TextColorTemplate = ({ color, text }) => `
-  <sdds-theme></sdds-theme>
   <h1 class="sdds-text-${color}">${text}</h1>
   <p class="sdds-text-${color}">${text}</p>
   `;
@@ -18,7 +17,6 @@ textColor.args = {
 };
 
 const BackgroundColorTemplate = ({ height, width, backgroundColor }) => `
-  <sdds-theme></sdds-theme>
     <div class="sdds-background-${backgroundColor}" style="height:${height}px; width:${width}px; display:block"> <h1>background-color:${backgroundColor}</h1></div>
   `;
 

--- a/components/src/components/toast/toast.stories.js
+++ b/components/src/components/toast/toast.stories.js
@@ -29,8 +29,6 @@ const ToastTemplate = ({
   subtext,
   linktext,
 }) => `
-  <sdds-theme></sdds-theme>
-
   <div class="sdds-toast sdds-toast-${toastType}">
     <div class="sdds-toast-icon">
       <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/components/src/components/toggle/toggle.stories.js
+++ b/components/src/components/toggle/toggle.stories.js
@@ -43,8 +43,7 @@ const Template = ({ size, disabled = '', headline = '' }) => {
       ? `<div class="sdds-toggle-headline">${headline}</div>`
       : '';
 
-  return `
-    <sdds-theme></sdds-theme>
+  return `  
       <div class="sdds-toggle ${sizeValue} ${disabled}" tabindex="0">
         ${headlineDiv}
         <input type="checkbox" class="sdds-toggle-input" id="customSwitch1">

--- a/components/src/components/tooltips/tooltip.stories.js
+++ b/components/src/components/tooltips/tooltip.stories.js
@@ -1,5 +1,8 @@
 export default {
   title: 'Component/Tooltip',
+  parameters: {
+    layout: 'centered',
+  },
   argTypes: {
     tooltipPosition: {
       control: {
@@ -49,7 +52,4 @@ export const Basic = ComponentTooltip.bind({});
 Basic.args = {
   text: 'Text that will be displayed in tooltip',
   mouseOverTooltip: false,
-};
-Basic.parameters = {
-  layout: 'centered',
 };

--- a/components/src/components/tooltips/tooltip.stories.js
+++ b/components/src/components/tooltips/tooltip.stories.js
@@ -26,7 +26,6 @@ export default {
 };
 
 const ComponentTooltip = ({ ...Basic }) => `
-  <sdds-theme></sdds-theme>
     <sdds-tooltip 
       placement="${Basic.tooltipPosition}"
       selector="#button-1" 

--- a/components/src/patterns/footer/footer.stories.js
+++ b/components/src/patterns/footer/footer.stories.js
@@ -15,7 +15,6 @@ const Template = ({ topPart = false }) => `
     margin: 0;
   }
   </style>
-  <sdds-theme></sdds-theme>
 
   <div class="sdds-footer">
     ${

--- a/components/src/patterns/fullpage/fullpage.stories.js
+++ b/components/src/patterns/fullpage/fullpage.stories.js
@@ -9,22 +9,7 @@ const Template = ({ menuCollapse = false }) => {
   document.body.classList.add('sdds');
 
   return `
-    <style>
-    #root {
-      height:100%;
-    }
-    .sb-show-main.sb-main-padded {
-      padding: 0;
-      margin: 0;
-    }
-    html, body, #root, #storybook-addon-themes {
-      height: 100%;
-      padding:0;
-      background: var(--sdds-white);
-    }
-    
-    </style>
-    <sdds-theme></sdds-theme>
+
     
      <nav class='sdds-nav'>     
       <div class='sdds-nav__left'>

--- a/components/src/patterns/header/header.stories.js
+++ b/components/src/patterns/header/header.stories.js
@@ -16,7 +16,6 @@ export default {
 };
 
 const BasicTemplate = ({ siteName }) => `
-    <sdds-theme></sdds-theme>
 
     <nav class='sdds-nav'>     
       <div class='sdds-nav__left'>
@@ -61,9 +60,6 @@ const InlineMenuTemplate = (args) => {
   };
 
   return `
-
-  <sdds-theme></sdds-theme>
-
   <nav class='sdds-nav  
     ${openMobileMenu && 'sdds-nav__mob-menu--opened'} 
      '>     
@@ -183,9 +179,6 @@ const ToolbarMenuTemplate = (args) => {
   };
 
   return `
-
-  <sdds-theme></sdds-theme>
-
   <nav class='sdds-nav  
     ${openMobileMenu && 'sdds-nav__mob-menu--opened'} 
     ${openAvatarMenu && 'sdds-nav__avatar--opened'}
@@ -388,9 +381,6 @@ const AllMenusTemplate = (args) => {
   };
 
   return `
-
-  <sdds-theme></sdds-theme>
-
   <nav class='sdds-nav  
     ${openMobileMenu && 'sdds-nav__mob-menu--opened'} 
     ${openAvatarMenu && 'sdds-nav__avatar--opened'}

--- a/components/src/patterns/side-menu/side-menu.stories.js
+++ b/components/src/patterns/side-menu/side-menu.stories.js
@@ -75,7 +75,6 @@ const Template = (args) => {
   `;
 
   return `
-  <sdds-theme></sdds-theme>
   ${style}
    <nav class='sdds-nav'>     
       <div class='sdds-nav__left'>      


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Moving <sdds-theme> to the global import in Storybook

**Solving issue**  
No ticket for this one I think.
This is dev-ex improvement: Story file no longer needs <sdds-theme> to be imported just above component code. Now it is globally consumed - pretty much the same way as our users do when they set up their code to consume our design system..

PS: Added tow commands in package.json of components to test lighter start up.

**How to test**  
1. Just check if all stories render as usual.
