### PR TITLE
feat: accordion-item toggle event emitter

### DIFF
--- a/components/src/components/accordion/accordion-item.tsx
+++ b/components/src/components/accordion/accordion-item.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Prop } from '@stencil/core';
+import { Component, Event, EventEmitter, h, Prop } from '@stencil/core';
 
 @Component({
   tag: 'sdds-accordion-item',
@@ -22,8 +22,19 @@ export class AccordionItem {
   /** When true 16px on right padding instead of 64px */
   @Prop() paddingReset: boolean = false;
 
+  /** Fires after the accordion item is closed or opened, emitting the value (as boolean) of the current state of the accordion */
+  @Event({
+    eventName: 'accordionItemToggle',
+    composed: true,
+    cancelable: true,
+    bubbles: true,
+  })
+  accordionItemToggle: EventEmitter<boolean>;
+
   openAccordion() {
     this.expanded = !this.expanded;
+
+    this.accordionItemToggle.emit(this.expanded);
   }
 
   render() {

--- a/components/src/components/accordion/readme.md
+++ b/components/src/components/accordion/readme.md
@@ -45,6 +45,13 @@
 | `paddingReset` | `padding-reset` | When true 16px on right padding instead of 64px                                                                      | `boolean` | `false`    |
 
 
+## Events
+
+| Event                 | Description                                                                                                               | Type                   |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `accordionItemToggle` | Fires after the accordion item is closed or opened, emitting the value (as boolean) of the current state of the accordion | `CustomEvent<boolean>` |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*


### PR DESCRIPTION
Added an event named "accordionItemToggle" on the accordion item component which emits a boolean each time after that accordion item is opened/closed.
