### PR TITLE
improvement/task-1832: Wordmark in footer is not right aligned

### DIFF
--- a/components/src/patterns/footer/footer.scss
+++ b/components/src/patterns/footer/footer.scss
@@ -170,7 +170,7 @@
     );
     background-repeat: no-repeat;
     background-size: 117px;
-    background-position: center bottom;
+    background-position: right bottom;
     p {
       @include type-style('detail-02');
       color: var(--#{$prefix}-footer-main-copyright);


### PR DESCRIPTION
**Describe pull-request**  
This fixes the wordmark in the footer to always be right aligned.

**Solving issue**  
Fixes: #1832
