### PR TITLE
feat(dropdown): change selected option from outside

### DIFF
--- a/components/package-lock.json
+++ b/components/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@scania/components",
-	"version": "3.0.0",
+	"version": "4.0.1-beta.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scania/components",
-  "version": "4.0.0",
+  "version": "4.0.1-beta.0",
   "description": "In this repository we're developing the next generation components for Scania Digital Design System",
   "repository": {
     "type": "git",

--- a/components/src/components/dropdown/dropdown-filter.tsx
+++ b/components/src/components/dropdown/dropdown-filter.tsx
@@ -11,7 +11,7 @@ export class DropdownFilter {
 
   @State() searchTerm = '';
 
-  @State() selectedOption: any;
+  @State() selectedOptionState: any;
 
   /** Placeholder text for dropdown with no selected item */
   @Prop() placeholder: string = '';
@@ -21,6 +21,9 @@ export class DropdownFilter {
 
   /** Add the value of the option to set it as default */
   @Prop() defaultOption: string;
+
+  /** Add the value of the option as string to set it as new selected value */
+  @Prop() selectedOption: string;
 
   /** Add the value of the option to set it as default */
   @Prop() disabled: boolean;
@@ -53,7 +56,7 @@ export class DropdownFilter {
     this.parseData(this.data);
 
     if (this.defaultOption) {
-      this.selectedOption = this.defaultOption;
+      this.selectedOptionState = this.defaultOption;
     }
   }
 
@@ -71,7 +74,7 @@ export class DropdownFilter {
 
   @Listen('selectOption')
   selectOptionHandler(event: CustomEvent<any>) {
-    this.selectedOption = event.detail.value;
+    this.selectedOptionState = event.detail.value;
     this.selectedLabel = event.detail.label;
     this.selectedValue = event.detail.value;
 
@@ -91,7 +94,7 @@ export class DropdownFilter {
         if (searchResultList) {
           return searchResultList;
         }
-        this.selectedOption = null;
+        this.selectedOptionState = null;
         this.selectedLabel = 'no-result';
         this.selectedValue = 'no-result';
       }
@@ -103,7 +106,7 @@ export class DropdownFilter {
       <sdds-dropdown-option
         tabindex="0"
         value={obj.value}
-        class={`${this.selectedOption === obj.value ? 'selected' : ''}`}
+        class={`${this.selectedOptionState === obj.value ? 'selected' : ''}`}
       >
         {obj.label}
       </sdds-dropdown-option>
@@ -137,6 +140,7 @@ export class DropdownFilter {
           state={this.state}
           placeholder={this.placeholder}
           defaultOption={this.defaultOption}
+          selectedOption={this.selectedOption}
           type="filter"
         >
           {this.setOptionsContent()}

--- a/components/src/components/dropdown/dropdown.stories.js
+++ b/components/src/components/dropdown/dropdown.stories.js
@@ -109,7 +109,6 @@ const Template = ({
   defaultOption,
   width,
   extraDropdownOptions,
-  selectedOption,
 }) => `
     <div style="width:${width}px">
         <sdds-dropdown   
@@ -122,7 +121,7 @@ const Template = ({
           helper="${helper}"
           state="${state}"
           type="${type}"
-          default-option="${defaultOption}"         
+          default-option="${defaultOption}">     
           <sdds-dropdown-option value="option-1" tabindex="0">Stockholm & Stockholm</sdds-dropdown-option>
           <sdds-dropdown-option value="option-2" tabindex="0">Hello 2</sdds-dropdown-option>
           <sdds-dropdown-option value="option-3" tabindex="0">Option 3</sdds-dropdown-option>          

--- a/components/src/components/dropdown/dropdown.stories.js
+++ b/components/src/components/dropdown/dropdown.stories.js
@@ -109,9 +109,11 @@ const Template = ({
   defaultOption,
   width,
   extraDropdownOptions,
+  selectedOption,
 }) => `
     <div style="width:${width}px">
-        <sdds-dropdown           
+        <sdds-dropdown   
+          id="sdds-dropdown-reg"        
           size="${size}"
           placeholder="${placeholder}"
           disabled="${disabled}"
@@ -120,7 +122,7 @@ const Template = ({
           helper="${helper}"
           state="${state}"
           type="${type}"
-          default-option="${defaultOption}">
+          default-option="${defaultOption}"         
           <sdds-dropdown-option value="option-1" tabindex="0">Stockholm & Stockholm</sdds-dropdown-option>
           <sdds-dropdown-option value="option-2" tabindex="0">Hello 2</sdds-dropdown-option>
           <sdds-dropdown-option value="option-3" tabindex="0">Option 3</sdds-dropdown-option>          
@@ -171,11 +173,12 @@ const FilterTemplate = ({
 }) => `
     <div style="width:${width}px">
         <sdds-dropdown-filter
+         id="sdds-dropdown-filter" 
         size="${size}"
         placeholder="${placeholder}"
         disabled="${disabled}"
         helper="${helper}"
-        default-option="${defaultOption}"
+        default-option="${defaultOption}"       
         data=${`[{"value":"option-1","label":"Jakarta"},{"value":"option-2","label":"Stockholm"},{"value":"option-3","label":"Barcelona"}]`}
         ></sdds-dropdown-filter>
       </div>

--- a/components/src/components/dropdown/dropdown.tsx
+++ b/components/src/components/dropdown/dropdown.tsx
@@ -25,7 +25,7 @@ export class Dropdown {
   /** Add the value of the option as string to set it as default */
   @Prop() defaultOption: string;
 
-  /** Add the value of the option as string to set it as new selected value **/
+  /** Add the value of the option as string to set it as new selected value */
   @Prop() selectedOption: string;
 
   /** Add the value of the option to set it as default */

--- a/components/src/components/dropdown/dropdown.tsx
+++ b/components/src/components/dropdown/dropdown.tsx
@@ -8,6 +8,7 @@ import {
   Host,
   Event,
   EventEmitter,
+  Watch,
 } from '@stencil/core';
 
 @Component({
@@ -23,6 +24,9 @@ export class Dropdown {
 
   /** Add the value of the option as string to set it as default */
   @Prop() defaultOption: string;
+
+  /** Add the value of the option as string to set it as new selected value **/
+  @Prop() selectedOption: string;
 
   /** Add the value of the option to set it as default */
   @Prop() disabled: boolean;
@@ -88,6 +92,20 @@ export class Dropdown {
   componentDidLoad() {
     // generate UUID for unique event listener
     this.uuid = new Date().getTime() + Math.random();
+  }
+
+  @Watch('selectedOption')
+  changeSelectedOption() {
+    if (this.selectedOption) {
+      for (let i = 0; i < this.host.children.length; i++) {
+        const el = this.host.children[i];
+        if (el['value'] === this.selectedOption) {
+          this.selectedLabel = el.textContent;
+          this.selectedValue = el['value'];
+          el.setAttribute('selectedLabel', 'true');
+        }
+      }
+    }
   }
 
   @Listen('click', { target: 'document' })

--- a/components/src/components/dropdown/dropdown.tsx
+++ b/components/src/components/dropdown/dropdown.tsx
@@ -77,16 +77,7 @@ export class Dropdown {
   componentWillLoad() {
     // If default option is set, update the default selectedLabel value
     // this.host.children is a HTMLCollection type, cannot use forEach
-    if (this.defaultOption) {
-      for (let i = 0; i < this.host.children.length; i++) {
-        const el = this.host.children[i];
-        if (el['value'] === this.defaultOption) {
-          this.selectedLabel = el.textContent;
-          this.selectedValue = el['value'];
-          el.setAttribute('selectedLabel', 'true');
-        }
-      }
-    }
+    this.setOptionFromOutside(this.defaultOption);
   }
 
   componentDidLoad() {
@@ -94,18 +85,26 @@ export class Dropdown {
     this.uuid = new Date().getTime() + Math.random();
   }
 
-  @Watch('selectedOption')
-  changeSelectedOption() {
-    if (this.selectedOption) {
+  setOptionFromOutside(optionValue) {
+    if (optionValue) {
       for (let i = 0; i < this.host.children.length; i++) {
         const el = this.host.children[i];
-        if (el['value'] === this.selectedOption) {
+        if (el['value'] === optionValue) {
           this.selectedLabel = el.textContent;
           this.selectedValue = el['value'];
           el.setAttribute('selectedLabel', 'true');
+          el.setAttribute('selected', 'true');
+        } else {
+          el.setAttribute('selectedLabel', 'false');
+          el.setAttribute('selected', 'false');
         }
       }
     }
+  }
+
+  @Watch('selectedOption')
+  changeSelectedOption() {
+    this.setOptionFromOutside(this.selectedOption);
   }
 
   @Listen('click', { target: 'document' })


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Changing selected option dynamically

**Solving issue**  
Fixes: [AB#1864](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/1864)

**How to test**  
1. Go to Storybook
2. Open the Dropdown component
3. Try to pass another option value in the selected option control
4. It should change the selected state in regular dropdown via: 
 `document.getElementById('sdds-dropdown-reg').setAttribute('selected-option','option-3');`
5. It should change the selected state in filter dropdown via: 
`document.getElementById('sdds-dropdown-filter').setAttribute('selected-option','option-2');`


