### PR TITLE
fix(modal): there is a issue setting overflow:hidden on body 

### DIFF
--- a/components/src/components/modal/modal.tsx
+++ b/components/src/components/modal/modal.tsx
@@ -83,7 +83,6 @@ export class Modal {
   render() {
     return (
       <Host class={`sdds-modal-backdrop ${this.show ? 'show' : 'hide'}`}>
-        fdsafdsafdsafdsafdsa
         <div
           class={`sdds-modal ${this.size ? `sdds-modal-${this.size}` : ''} `}
         >

--- a/components/src/components/modal/modal.tsx
+++ b/components/src/components/modal/modal.tsx
@@ -58,10 +58,11 @@ export class Modal {
 
   @Watch('show')
   showToggled() {
+    let root = document.querySelector('html');
     if (this.show === true) {
-      document.body.classList.add('sdds-modal-overflow');
+      root.classList.add('sdds-modal-overflow');
     } else {
-      document.body.classList.remove('sdds-modal-overflow');
+      root.classList.remove('sdds-modal-overflow');
     }
   }
 
@@ -82,6 +83,7 @@ export class Modal {
   render() {
     return (
       <Host class={`sdds-modal-backdrop ${this.show ? 'show' : 'hide'}`}>
+        fdsafdsafdsafdsafdsa
         <div
           class={`sdds-modal ${this.size ? `sdds-modal-${this.size}` : ''} `}
         >


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
_Describe what the pull-request is about_

Opening the modal in a page with a height over the screen size makes for example the header height
smaller. What I have done is switch the overflow:hidden so it is on the html instead of body element.

This problem exist even without modal, if you set the body with overflow hidden


**How to test**  
_Add description how to test if possible_
1. Open a page with a modal, the header component and a page that have the height bigger then screen (scrollbar)
2. Add the modal
3. Open them modal and see the header(video below)

**Screenshots**  
_If applicable, add screenshots to help explain_

Problem

https://user-images.githubusercontent.com/35451568/163327938-cbb26468-cb39-47b0-9ea8-c5b53d98a792.mov



Working example after

https://user-images.githubusercontent.com/35451568/163328061-1cabba54-cf0e-4aab-9bda-86744eb77bee.mov



