### PR TITLE
fix(tabs): remove underline on hover state when showing tabs

### DIFF
--- a/components/src/components/tabs/inline-tabs/inline-tabs.scss
+++ b/components/src/components/tabs/inline-tabs/inline-tabs.scss
@@ -125,6 +125,7 @@
     &:hover {
       background-color: var(--sdds-grey-200);
       color: var(--sdds-blue-958);
+      text-decoration: none;
     }
 
     &:focus {

--- a/components/src/components/tabs/navigation-tabs/navigation-tabs.scss
+++ b/components/src/components/tabs/navigation-tabs/navigation-tabs.scss
@@ -50,6 +50,7 @@
 
     &:hover {
       background-color: var(--sdds-grey-300);
+      text-decoration: none;
     }
 
     &:active {


### PR DESCRIPTION
**Describe pull-request**  
fix: (tabs) fixed underline on hover state when showing tabs

**Solving issue**  
_In case of GitHub issue add # plus the number of the issue (for example #123) OR if it is Azure then AB# and number of ticket_
Fixes: [AB#1957](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/1957)

**How to test**  
go to the storybook and see if the hover state on inline tabs and navigation tabs have "text-decoration: none;"
