### PR TITLE
feat: scania colors for storybook ui

### DIFF
--- a/components/.storybook/ScaniaTheme.js
+++ b/components/.storybook/ScaniaTheme.js
@@ -8,4 +8,34 @@ export default create({
   //brandUrl: 'https://example.com',
   brandImage: ScaniaLogotype,
   brandTarget: '_self',
+
+  // colorPrimary: '#ff2340',
+  // Commented out as its usage is unclear
+
+  colorSecondary: '#2b70d3',
+
+  // UI
+  appBg: '#f9fafb',
+  appContentBg: '#ffffff',
+  appBorderColor: '#edeff3',
+  appBorderRadius: 4,
+
+  // Typography
+  fontBase: '"Helvetica Neue", "Arial", sans-serif',
+  fontCode: 'monospace',
+
+  // Text colors
+  textColor: '#0d0f13',
+  textInverseColor: 'rgba(255,255,255,0.9)',
+
+  // Toolbar default and active colors
+  barTextColor: '#5f6d80',
+  barSelectedColor: '#2b70d3',
+  barBg: '#ffffff',
+
+  // Form colors
+  inputBg: 'white',
+  inputBorder: 'silver',
+  inputTextColor: 'black',
+  inputBorderRadius: 4,
 });

--- a/components/.storybook/preview.js
+++ b/components/.storybook/preview.js
@@ -66,7 +66,7 @@ const customViewports = {
 const customBGvalues = [
   {
     name: 'grey',
-    value: '#F6F6F7',
+    value: '#F9FAFB',
   },
   {
     name: 'white',
@@ -82,7 +82,7 @@ export const parameters = {
     default: 'on-grey',
     list: [
       { name: 'on-white', class: 'sdds-on-white-bg', color: '#FFFFFF' },
-      { name: 'on-grey', class: 'sdds-on-grey-bg', color: '#F6F6F7' },
+      { name: 'on-grey', class: 'sdds-on-grey-bg', color: '#F9FAFB' },
     ],
   },
   backgrounds: {


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Updating Storybook with Scania colors

**How to test**  

1. Open the Storybook link that will build this PR
2. Compare it with [Production one](https://production.d1g8v8mrkx992n.amplifyapp.com/?path=/story/foundation-colour--brand)
3. Check to see if you see new colors in menu, tabs selector...



**Additional context**  
Alex can approve visual changes but the developer would need to confirm the code side.

More about Storybook theming [here](https://storybook.js.org/docs/react/configure/theming)
