### PR TITLE
fix(table): reset search results if search query is empty

### DIFF
--- a/components/src/components/table/table.tsx
+++ b/components/src/components/table/table.tsx
@@ -373,6 +373,7 @@ export class Table {
       if (this.pagination) {
         this.tempPaginationDisable = false;
       }
+
       sddsTableSearchBar.classList.remove('sdds-table__searchbar--active');
 
       dataRowsFiltering.forEach((item) => {
@@ -438,7 +439,6 @@ export class Table {
       const index = i + 1;
 
       if (this.tempPaginationDisable) {
-        item.classList.remove('sdds-table__row--hidden');
         this.paginationValue = 1;
       } else {
         const lastResult = this.rowsPerPage * this.paginationValue;

--- a/components/src/components/table/table.tsx
+++ b/components/src/components/table/table.tsx
@@ -334,14 +334,14 @@ export class Table {
         }
     */
 
+    // grab all rows in body
+    const dataRowsFiltering =
+      this.tableBodySelector.querySelectorAll('.sdds-table__row');
+
     if (searchTerm.length > 0) {
       if (this.pagination) {
         this.tempPaginationDisable = true;
       }
-
-      // grab all rows in body
-      const dataRowsFiltering =
-        this.tableBodySelector.querySelectorAll('.sdds-table__row');
 
       dataRowsFiltering.forEach((item) => {
         const cells = item.querySelectorAll('sdds-body-cell');
@@ -374,6 +374,11 @@ export class Table {
         this.tempPaginationDisable = false;
       }
       sddsTableSearchBar.classList.remove('sdds-table__searchbar--active');
+
+      dataRowsFiltering.forEach((item) => {
+        item.classList.remove('sdds-table__row--hidden');
+      });
+
       this.disableAllSorting = false;
       this.sortingEnabler.emit(this.disableAllSorting);
     }


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Table was not resetting search results after removing search criteria 

**Solving issue**  
Fixes: #395 

**How to test**  
1. Open Storybook on the link generated below
2. Go to the data table component and try to search
3. After you remove the search criteria, the table needs to show the original results 
4. Compare it with behavior on [prod Storybook ](https://production.d1g8v8mrkx992n.amplifyapp.com/?path=/story/foundation-colour--brand)where the bug still exists.


