### PR TITLE
fix(button): remove display as flex

### DIFF
--- a/components/src/components/button/button.scss
+++ b/components/src/components/button/button.scss
@@ -27,8 +27,6 @@ $props: (background, border-color, color);
   height: $btn-default-height;
   padding: var(--sdds-spacing-element-20);
   border: 1px solid;
-  display: flex;
-  align-items: center;
 
   &:disabled,
   &.disabled {


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Issue reported in our development channel with the button being display: flex

**How to test**  
1. Go to Storybook example of button component
2. Inspect and see if display flex is gone
3. Compare the modal component between the link here and [prod Storybook](https://production.d1g8v8mrkx992n.amplifyapp.com/?path=/story/component-modal--modal)
4. In prod one, buttons are one below another, in fix one buttons are again next to each other with a gap between.


**Additional context**  
I introduced this issue with the last release
