### PR TITLE
fix: focus style bleeding

### DIFF
--- a/components/src/components/accordion/accordion.scss
+++ b/components/src/components/accordion/accordion.scss
@@ -1,7 +1,8 @@
-@import '../../helpers/style-helpers.scss';
-@import '@scania/typography/dist/scss/mixins';
-@import '@scania/typography/dist/scss/tokens';
-@import '../divider/divider.scss';
+@import "../../helpers/style-helpers.scss";
+@import "@scania/typography/dist/scss/mixins";
+@import "@scania/typography/dist/scss/tokens";
+@import "../divider/divider.scss";
+@import "../../helpers/components-shared.scss";
 
 @mixin disabledStyle {
   &,
@@ -36,7 +37,7 @@
     display: flex;
     align-items: center;
 
-    @include type-style('headline-07');
+    @include type-style("headline-07");
 
     padding: var(--sdds-spacing-element-16);
     background-color: var(--sdds-accordion-bg);
@@ -60,7 +61,7 @@
     padding-right: var(--sdds-spacing-layout-64);
     display: none;
 
-    @include type-style('detail-03');
+    @include type-style("detail-03");
 
     p {
       margin: 0;
@@ -95,7 +96,7 @@
   }
 
   &:focus {
-    outline: none;
+    @include sdds-focus-state;
     .#{$prefix}-accordion-header-prefix,
     .#{$prefix}-accordion-header-suffix {
       background-color: var(--sdds-accordion-bg-focus);
@@ -129,7 +130,7 @@
     &:focus,
     &:active,
     &.active {
-      @include disabledStyle();
+      @include disabledStyle;
     }
   }
 
@@ -163,7 +164,7 @@
     position: relative;
 
     &::after {
-      content: '';
+      content: "";
       position: absolute;
       width: 100%;
       height: 0;
@@ -186,7 +187,7 @@
   border-top: 1px solid var(--sdds-accordion-border-focus);
 }
 
-::slotted(sdds-accordion-item[disabled='true']:focus) {
+::slotted(sdds-accordion-item[disabled="true"]:focus) {
   border-color: var(--sdds-accordion-border);
 }
 
@@ -195,7 +196,7 @@
 }
 
 :host(:focus) {
-  outline: none;
+  @include sdds-focus-state;
 
   .#{$prefix}-accordion-item {
     .#{$prefix}-accordion-header-prefix,
@@ -210,7 +211,7 @@
   }
 
   .disabled {
-    @include disabledStyle();
+    @include disabledStyle;
   }
 }
 
@@ -222,6 +223,6 @@
   }
 
   .disabled {
-    @include disabledStyle();
+    @include disabledStyle;
   }
 }

--- a/components/src/components/breadcrumb/breadcrumb.scss
+++ b/components/src/components/breadcrumb/breadcrumb.scss
@@ -1,19 +1,21 @@
-@import '../../helpers/style-helpers.scss';
-@import '@scania/typography/dist/scss/mixins';
-@import '@scania/typography/dist/scss/tokens';
+@import "../../helpers/style-helpers.scss";
+@import "@scania/typography/dist/scss/mixins";
+@import "@scania/typography/dist/scss/tokens";
+@import "../../helpers/components-shared.scss";
 
 .#{$prefix}-breadcrumb {
-  @include type-style('detail-02');
+  @include type-style("detail-02");
+
   display: flex;
   flex-wrap: wrap;
 
   .#{$prefix}-breadcrumb-item {
     color: var(--sdds-breadcrumb-color);
 
-    &:after {
-      content: '';
+    &::after {
+      content: "";
       background-color: var(--sdds-breadcrumb-separator-color);
-      -webkit-mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='4' height='8' viewBox='0 0 4 8' fill='currentColor'><path d='M2.548 4.178L0.602 0.985999H1.82L3.78 4.178L1.82 7.37H0.602L2.548 4.178Z' fill='currentColor'/></svg>");
+      mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='4' height='8' viewBox='0 0 4 8' fill='currentColor'><path d='M2.548 4.178L0.602 0.985999H1.82L3.78 4.178L1.82 7.37H0.602L2.548 4.178Z' fill='currentColor'/></svg>");
       mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='4' height='8' viewBox='0 0 4 8' fill='currentColor'><path d='M2.548 4.178L0.602 0.985999H1.82L3.78 4.178L1.82 7.37H0.602L2.548 4.178Z' fill='currentColor'/></svg>");
       margin-right: 1rem;
       margin-left: 1rem;
@@ -29,13 +31,16 @@
 
     &:hover {
       color: var(--sdds-breadcrumb-color-hover);
+
       > a {
         text-decoration: underline;
       }
     }
+
     &:focus {
       color: var(--sdds-breadcrumb-color-focus);
-      border: 0.8px solid var(--sdds-breadcrumb-color-focus);
+
+      @include sdds-focus-state;
     }
     &:disabled,
     &.disabled,
@@ -56,7 +61,7 @@
     }
 
     &:last-child {
-      &:after {
+      &::after {
         display: none;
       }
     }

--- a/components/src/components/dropdown/dropdown.scss
+++ b/components/src/components/dropdown/dropdown.scss
@@ -217,8 +217,7 @@
   }
 
   ::slotted(sdds-dropdown-option:focus) {
-    outline: 2px solid var(--sdds-blue-400);
-    outline-offset: -2px;
+    @include sdds-focus-state;
   }
 
   ::slotted(sdds-dropdown-option.sdds-dropdown--selected),

--- a/components/src/components/footer/footer.scss
+++ b/components/src/components/footer/footer.scss
@@ -2,6 +2,7 @@
 @import "../../../node_modules/@scania/typography/dist/scss/mixins";
 @import "../../../node_modules/@scania/typography/dist/scss/tokens";
 @import "../../../node_modules/@scania/grid/dist/scss/grid";
+@import "../../helpers/components-shared.scss";
 
 @mixin footer-links {
   padding: 0;
@@ -18,6 +19,10 @@
     a {
       margin-right: var(--sdds-spacing-element-24);
       text-decoration: none;
+
+      &:focus {
+        @include sdds-focus-state;
+      }
     }
   }
 }

--- a/components/src/components/header/header.scss
+++ b/components/src/components/header/header.scss
@@ -11,6 +11,10 @@
   &:hover {
     background-color: var(--sdds-blue-700);
   }
+
+  &:focus {
+    @include sdds-focus-state;
+  }
 }
 
 // Style for Header itself

--- a/components/src/components/link/link.scss
+++ b/components/src/components/link/link.scss
@@ -1,4 +1,5 @@
-@import '../../helpers/style-helpers.scss';
+@import "../../helpers/style-helpers.scss";
+@import "../../helpers/components-shared";
 
 .#{$prefix}-link {
   cursor: pointer;
@@ -26,7 +27,8 @@
   &:focus {
     color: var(--sdds-link-focus);
     text-decoration: none;
-    outline: var(--sdds-link-focus-border);
+
+    @include sdds-focus-state;
   }
 
   &:disabled,

--- a/components/src/components/modal/modal.scss
+++ b/components/src/components/modal/modal.scss
@@ -1,7 +1,17 @@
-@import './modal-core';
+@import "./modal-core";
+@import "../../helpers/components-shared";
 
 :host {
   @include modal-host;
+
+  .sdds-modal-btn {
+    border: none;
+    background-color: transparent;
+
+    &:focus {
+      @include sdds-focus-state;
+    }
+  }
 }
 
 :host(.show) {

--- a/components/src/components/modal/modal.tsx
+++ b/components/src/components/modal/modal.tsx
@@ -58,7 +58,7 @@ export class Modal {
 
   @Watch('show')
   showToggled() {
-    let root = document.querySelector('html');
+    const root = document.querySelector('html');
     if (this.show === true) {
       root.classList.add('sdds-modal-overflow');
     } else {
@@ -88,7 +88,7 @@ export class Modal {
         >
           <div class="sdds-modal-header">
             <slot name="sdds-modal-headline"></slot>
-            <span class="sdds-modal-btn"></span>
+            <button class="sdds-modal-btn"></button>
           </div>
           <slot name="sdds-modal-body"></slot>
           <div class="sdds-modal-actions">

--- a/components/src/components/side-menu/side-menu.scss
+++ b/components/src/components/side-menu/side-menu.scss
@@ -1,6 +1,7 @@
 @import "../../../node_modules/@scania/typography/dist/scss/mixins";
 @import "../../../node_modules/@scania/typography/dist/scss/tokens";
 @import "../../../node_modules/@scania/grid/dist/scss/grid";
+@import "../../helpers/components-shared";
 
 /* HEADER ICON. KINDA WANT THIS IN THE HEADER COMPONENT INSTEAD? */
 
@@ -31,8 +32,9 @@
 
 @mixin item-states {
   &:focus {
-    outline: none;
     background-color: var(--sdds-grey-50);
+
+    @include sdds-focus-state;
 
     &::after {
       content: " ";
@@ -218,6 +220,10 @@
         box-sizing: content-box;
         transition: background-color 0.15s ease-in-out;
 
+        &:focus {
+          @include sdds-focus-state;
+        }
+
         .sdds-sidebar-nav__item-text {
           margin-top: 3px;
           opacity: 1;
@@ -277,6 +283,10 @@
             background-color 0.15s ease-in-out;
           font-weight: normal;
           min-height: auto;
+
+          &:focus {
+            @include sdds-focus-state;
+          }
 
           .sdds-sidebar-nav__item-text {
             @include type-style("detail-02");

--- a/components/src/components/table/table.scss
+++ b/components/src/components/table/table.scss
@@ -1,5 +1,6 @@
 @import "@scania/typography/dist/scss/mixins";
 @import "@scania/typography/dist/scss/tokens";
+@import "../../helpers/components-shared";
 
 .sdds-table {
   border-collapse: collapse;
@@ -248,6 +249,10 @@
           &:hover {
             background-color: var(--sdds-white);
           }
+
+          &:focus {
+            @include sdds-focus-state;
+          }
         }
 
         .sdds-table__page-selector-input--shake {
@@ -301,6 +306,10 @@
 
           &:hover {
             background-color: var(--sdds-grey-300);
+          }
+
+          &:focus {
+            @include sdds-focus-state;
           }
 
           &:disabled {
@@ -529,6 +538,10 @@
   border-radius: 4px;
   transition: background-color 250ms ease;
   margin-left: 0;
+
+  &:focus {
+    @include sdds-focus-state;
+  }
 
   &:hover {
     background-color: var(--sdds-grey-300);

--- a/components/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.scss
+++ b/components/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.scss
@@ -1,12 +1,13 @@
-@import '../../../../node_modules/@scania/typography/dist/scss/mixins';
-@import '../../../../node_modules/@scania/typography/dist/scss/tokens';
+@import "../../../../node_modules/@scania/typography/dist/scss/mixins";
+@import "../../../../node_modules/@scania/typography/dist/scss/tokens";
+@import "../../../helpers/components-shared";
 
 .sdds-inline-tabs-fullbleed {
   display: flex;
   position: relative;
 
   &::after {
-    content: ' ';
+    content: " ";
     display: block;
     border-bottom: 1px solid var(--sdds-grey-300);
     left: 0;
@@ -54,6 +55,10 @@
     &:active {
       background-color: var(--sdds-grey-400);
     }
+
+    &:focus {
+      @include sdds-focus-state;
+    }
   }
 
   &--back {
@@ -83,6 +88,10 @@
     &:active {
       background-color: var(--sdds-grey-400);
     }
+
+    &:focus {
+      @include sdds-focus-state;
+    }
   }
 
   &-centered {
@@ -90,7 +99,7 @@
   }
 
   &--tab {
-    @include type-style('headline-07');
+    @include type-style("headline-07");
 
     color: rgb(0 21 51 / 60%);
     padding: 16px 0;
@@ -111,7 +120,7 @@
     }
 
     &::after {
-      content: ' ';
+      content: " ";
       position: absolute;
       bottom: 0;
       right: 0;
@@ -136,18 +145,9 @@
     }
 
     &:focus {
-      outline: none;
-      color: var(--sdds-grey-958);
+      @include sdds-focus-state;
 
-      &::before {
-        content: ' ';
-        border: 1px solid var(--sdds-blue-400);
-        position: absolute;
-        top: 11px;
-        bottom: 13px;
-        left: -8px;
-        right: -8px;
-      }
+      color: var(--sdds-grey-958);
 
       &::after {
         width: 0;

--- a/components/src/components/tabs/inline-tabs/inline-tabs.scss
+++ b/components/src/components/tabs/inline-tabs/inline-tabs.scss
@@ -1,5 +1,6 @@
 @import "../../../../node_modules/@scania/typography/dist/scss/mixins";
 @import "../../../../node_modules/@scania/typography/dist/scss/tokens";
+@import "../../../helpers/components-shared";
 
 :host {
   outline: 0 !important;
@@ -55,6 +56,10 @@
     &:active {
       background-color: var(--sdds-grey-400);
     }
+
+    &:focus {
+      @include sdds-focus-state;
+    }
   }
 
   &--back {
@@ -83,6 +88,10 @@
 
     &:active {
       background-color: var(--sdds-grey-400);
+    }
+
+    &:focus {
+      @include sdds-focus-state;
     }
   }
 
@@ -129,16 +138,7 @@
     }
 
     &:focus {
-      &::before {
-        content: " ";
-        position: absolute;
-        left: 0;
-        right: 0;
-        top: 0;
-        bottom: 0;
-        display: block;
-        border: 1px solid var(--sdds-blue-400);
-      }
+      @include sdds-focus-state;
     }
 
     &__active {
@@ -166,15 +166,6 @@
         left: -1px;
         display: block;
         position: absolute;
-      }
-
-      &:focus {
-        &::before {
-          right: -1px;
-          left: -1px;
-          width: auto;
-          background-color: transparent;
-        }
       }
 
       &:first-child {

--- a/components/src/components/tabs/navigation-tabs/navigation-tabs.scss
+++ b/components/src/components/tabs/navigation-tabs/navigation-tabs.scss
@@ -1,5 +1,6 @@
 @import "../../../../node_modules/@scania/typography/dist/scss/mixins";
 @import "../../../../node_modules/@scania/typography/dist/scss/tokens";
+@import "../../../helpers/components-shared";
 
 .sdds-navigation-tabs {
   background-color: var(--sdds-white);
@@ -56,6 +57,10 @@
     &:active {
       background-color: var(--sdds-grey-400);
     }
+
+    &:focus {
+      @include sdds-focus-state;
+    }
   }
 
   &--back {
@@ -84,6 +89,10 @@
 
     &:active {
       background-color: var(--sdds-grey-400);
+    }
+
+    &:focus {
+      @include sdds-focus-state;
     }
   }
 
@@ -133,18 +142,9 @@
     }
 
     &:focus {
-      outline: none;
-      color: var(--sdds-grey-958);
+      @include sdds-focus-state;
 
-      &::before {
-        content: " ";
-        border: 1px solid var(--sdds-blue-400);
-        position: absolute;
-        top: 20px;
-        bottom: 22px;
-        left: -8px;
-        right: -8px;
-      }
+      color: var(--sdds-grey-958);
 
       &::after {
         width: 0;

--- a/components/src/components/theme/theme.scss
+++ b/components/src/components/theme/theme.scss
@@ -28,11 +28,6 @@
 // Utility classes
 @import "../../helpers/_utility-classes.scss";
 
-* :focus {
-  outline: 2px solid var(--sdds-blue-400);
-  outline-offset: -2px;
-}
-
 html.#{$prefix},
 body.#{$prefix},
 .#{$prefix}-body {

--- a/components/src/helpers/components-shared.scss
+++ b/components/src/helpers/components-shared.scss
@@ -19,3 +19,8 @@
     width: 0;
   }
 }
+
+@mixin sdds-focus-state {
+  outline: 2px solid var(--sdds-blue-400);
+  outline-offset: -2px;
+}


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Removing "star" focus rule as it might create unwanted focuses on subcomponents which results in a blue outline on a couple of places on the same component. Now, when we create a new component we have to make sure that the new component has a focus rule and uses the mixin defined in the component-shared file.

**How to test**  
1. Open prod and this PR Storybook versions to compare results.
2. Try to tab on components that are changed to see the blue outline.
3. Check below which components are affected


**Additional context**  
Components that are changed:

1. accordion
2. breadcrumb
3. dropdown
4. footer
5. header
6. link
7. modal
8. side-menu
9. table
10. tabs
