### PR TITLE
feat: popover-menu component 

### DIFF
--- a/components/src/components/popover-menu/documentation.txt
+++ b/components/src/components/popover-menu/documentation.txt
@@ -1,0 +1,108 @@
+The popover menu is a component made for context menus.
+It requires a valid selector as an attribute and then it will be automatically opened when the user clicks on the element with this selector.
+
+There are two versions, one with and one without icons. Both variants supports a placement-attribute to control where the menu should popup when the element is clicked.
+
+Valid values are:
+
+'auto', 'auto-left', 'auto-right', 'bottom', 'bottom-start', 'bottom-end', 'top', 'top-start', 'top-end', 'left', 'left-start', 'left-end', 'right', 'right-start, 'right-end'
+
+#Popover menu
+
+<sdds-popover-menu
+    placement="auto"
+    selector="#trigger"> 
+    <ul class="sdds-popover-menu-wrapper">
+        <li>
+            <a target="_blank" href="https://digitaldesign.scania.com">Menu item 1</a>
+        </li>
+        <li>            
+            <a target="_blank" href="https://digitaldesign.scania.com">Menu item 2</a>        
+        </li>
+        <li>
+            <a target="_blank" href="https://digitaldesign.scania.com">Menu item 3</a>
+        </li>
+        <li class="divider"></li>
+        <li>        
+            <a target="_blank" href="https://digitaldesign.scania.com">Menu item 4</a>
+        </li>
+        <li>
+            <a target="_blank" href="https://digitaldesign.scania.com">Menu item 5</a>
+        </li>
+    </ul>        
+</sdds-popover-menu>
+
+<button id="trigger">Click to open popup menu</div>
+
+
+
+#Popover menu with icons
+
+<sdds-popover-menu
+    placement="auto"
+    selector="#trigger2"> 
+    <ul class="sdds-popover-menu-wrapper">
+        <li>
+            <a target="_blank" href="https://digitaldesign.scania.com">            
+                <i>
+                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <g clip-path="url(#clip0_1815_6834)">
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M2 3C2 2.44771 2.44771 2 3 2H10.7929C11.0581 2 11.3125 2.10536 11.5 2.2929L13.7071 4.5C13.8946 4.68754 14 4.94189 14 5.2071V13C14 13.5523 13.5523 14 13 14H3C2.44771 14 2 13.5523 2 13V3ZM10.7929 3H3V13H13V5.2071L10.7929 3Z" fill="#0D0F13"/>
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M5 4.75V2.5H6V4.5H10V2.5H11V4.75C11 5.1642 10.6642 5.5 10.25 5.5H5.75C5.3358 5.5 5 5.1642 5 4.75Z" fill="#0D0F13"/>
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M11 9.75V13.5H10V10H6V13.5H5V9.75C5 9.3358 5.3358 9 5.75 9H10.25C10.6642 9 11 9.3358 11 9.75Z" fill="#0D0F13"/>
+                    </g>
+                    <defs>
+                    <clipPath id="clip0_1815_6834">
+                    <rect width="16" height="16" fill="white"/>
+                    </clipPath>
+                    </defs>
+                    </svg>
+                </i>
+
+                Menu item 1
+            </a>
+        </li>
+        <li>            
+            <a target="_blank" href="https://digitaldesign.scania.com">
+                <i>
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <g clip-path="url(#clip0_1815_6834)">
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M2 3C2 2.44771 2.44771 2 3 2H10.7929C11.0581 2 11.3125 2.10536 11.5 2.2929L13.7071 4.5C13.8946 4.68754 14 4.94189 14 5.2071V13C14 13.5523 13.5523 14 13 14H3C2.44771 14 2 13.5523 2 13V3ZM10.7929 3H3V13H13V5.2071L10.7929 3Z" fill="#0D0F13"/>
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M5 4.75V2.5H6V4.5H10V2.5H11V4.75C11 5.1642 10.6642 5.5 10.25 5.5H5.75C5.3358 5.5 5 5.1642 5 4.75Z" fill="#0D0F13"/>
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M11 9.75V13.5H10V10H6V13.5H5V9.75C5 9.3358 5.3358 9 5.75 9H10.25C10.6642 9 11 9.3358 11 9.75Z" fill="#0D0F13"/>
+                    </g>
+                    <defs>
+                    <clipPath id="clip0_1815_6834">
+                    <rect width="16" height="16" fill="white"/>
+                    </clipPath>
+                    </defs>
+                </svg>
+                </i>
+
+                Menu item 2
+            </a>
+        </li>
+        <li class="divider"></li>
+        <li>            
+            <a target="_blank" href="https://digitaldesign.scania.com">
+                <i>
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <g clip-path="url(#clip0_1815_6834)">
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M2 3C2 2.44771 2.44771 2 3 2H10.7929C11.0581 2 11.3125 2.10536 11.5 2.2929L13.7071 4.5C13.8946 4.68754 14 4.94189 14 5.2071V13C14 13.5523 13.5523 14 13 14H3C2.44771 14 2 13.5523 2 13V3ZM10.7929 3H3V13H13V5.2071L10.7929 3Z" fill="#0D0F13"/>
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M5 4.75V2.5H6V4.5H10V2.5H11V4.75C11 5.1642 10.6642 5.5 10.25 5.5H5.75C5.3358 5.5 5 5.1642 5 4.75Z" fill="#0D0F13"/>
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M11 9.75V13.5H10V10H6V13.5H5V9.75C5 9.3358 5.3358 9 5.75 9H10.25C10.6642 9 11 9.3358 11 9.75Z" fill="#0D0F13"/>
+                    </g>
+                    <defs>
+                    <clipPath id="clip0_1815_6834">
+                    <rect width="16" height="16" fill="white"/>
+                    </clipPath>
+                    </defs>
+                </svg>
+                </i>
+
+                Menu item 3
+            </a>
+        </li>          
+    </ul>        
+</sdds-popover-menu>
+

--- a/components/src/components/popover-menu/popover-menu.scss
+++ b/components/src/components/popover-menu/popover-menu.scss
@@ -1,0 +1,95 @@
+@import "../../helpers/style-helpers.scss";
+@import "@scania/typography/dist/scss/mixins";
+@import "@scania/typography/dist/scss/tokens";
+
+.sdds-popover-menu {
+  overflow: hidden;
+  width: 160px;
+  background-color: #fff;
+  padding: 16px;
+  box-shadow: 0 3px 3px rgb(0 0 0 / 15%), 0 -1px 1px rgb(0 0 0 / 10%);
+  border-radius: 4px;
+  display: none;
+  z-index: 20000; /* same as tooltip */
+}
+
+ul.sdds-popover-menu-wrapper {
+  list-style-type: none;
+  margin: 0;
+  margin-block: 0;
+  padding: 0;
+
+  li {
+    @include type-style("detail-02");
+
+    color: var(--sdds-grey-958);
+    margin-bottom: 16px;
+    position: relative;
+    width: 100%;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    a {
+      text-decoration: none;
+      position: relative;
+      width: 100%;
+
+      // display: block;
+      color: var(--sdds-grey-958);
+      display: flex;
+      flex-wrap: nowrap;
+
+      i {
+        position: relative;
+        top: -1px;
+        display: block;
+        margin-right: 10px;
+        width: 12px;
+        height: 12px;
+        object-fit: contain;
+
+        svg {
+          width: auto;
+          height: auto;
+        }
+      }
+
+      &:hover {
+        &::before {
+          z-index: -1;
+          content: " ";
+          display: block;
+          position: absolute;
+          width: calc(100% + 32px);
+          height: calc(100% + 16px);
+          top: -8px;
+          left: -16px;
+          background-color: var(--sdds-grey-100);
+        }
+      }
+    }
+
+    &.divider {
+      display: block;
+      height: 1px;
+      width: 100%;
+
+      &::before {
+        position: relative;
+        content: " ";
+        display: block;
+        background-color: var(--sdds-grey-300);
+        height: 1px;
+        left: -16px;
+        width: calc(100% + 32px);
+      }
+    }
+  }
+}
+
+.sdds-popover-menu-show {
+  opacity: 1;
+  display: block;
+}

--- a/components/src/components/popover-menu/popover-menu.stories.js
+++ b/components/src/components/popover-menu/popover-menu.stories.js
@@ -1,0 +1,215 @@
+export default {
+  title: 'Component/Popover-Menu',
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    menuPosition: {
+      control: {
+        type: 'radio',
+        options: [
+          'bottom',
+          'bottom-start',
+          'bottom-end',
+          'top',
+          'top-start',
+          'top-end',
+          'left',
+          'left-start',
+          'left-end',
+          'right',
+          'right-start',
+          'right-end',
+        ],
+      },
+      defaultValue: 'right-start',
+      description: 'Position of the PopoverMenu',
+    },
+    withIcons: {
+      name: 'withIcons',
+      control: {
+        type: 'boolean',
+      },
+      defaultValue: false,
+      if: {},
+    },
+  },
+};
+
+const ComponentPopoverMenu = ({ ...Basic }) => {
+  const withoutIcons = `
+    <sdds-popover-menu
+        placement="${Basic.menuPosition}"
+        selector="#trigger"> 
+        <ul class="sdds-popover-menu-wrapper">
+          <li>
+            <a target="_blank" href="https://digitaldesign.scania.com">Menu item 1</a>
+          </li>
+          <li>            
+            <a target="_blank" href="https://digitaldesign.scania.com">
+              Menu item 2
+            </a>
+          </li>
+          <li>
+            <a target="_blank" href="https://digitaldesign.scania.com">Menu item 3</a>
+          </li>
+          <li class="divider"></li>
+          <li>
+            <a target="_blank" href="https://digitaldesign.scania.com">Menu item 4</a>
+          </li>
+          <li>
+            <a target="_blank" href="https://digitaldesign.scania.com">Menu item 5</a>
+          </li>
+        </ul>        
+      </sdds-popover-menu>
+
+      <div style="display: flex; flex-wrap: nowrap; align-items: center;">
+        <span style="user-select: none;margin-right: 16px;">Click icon for popover menu</span>
+        <div style="cursor: pointer; display: flex; align-items: center;" id="trigger">
+          <svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M7.03296 3.98828C7.03296 4.54057 7.48278 4.98828 8.03767 4.98828C8.59255 4.98828 9.04238 4.54057 9.04238 3.98828C9.04238 3.436 8.59255 2.98828 8.03767 2.98828C7.48278 2.98828 7.03296 3.436 7.03296 3.98828Z" fill="#0D0F13"/>
+            <path d="M7.03296 8C7.03296 8.55228 7.48278 9 8.03767 9C8.59255 9 9.04238 8.55228 9.04238 8C9.04238 7.44772 8.59255 7 8.03767 7C7.48278 7 7.03296 7.44772 7.03296 8Z" fill="#0D0F13"/>
+            <path d="M7.03296 12.0146C7.03296 12.5669 7.48278 13.0146 8.03767 13.0146C8.59255 13.0146 9.04238 12.5669 9.04238 12.0146C9.04238 11.4624 8.59255 11.0146 8.03767 11.0146C7.48278 11.0146 7.03296 11.4624 7.03296 12.0146Z" fill="#0D0F13"/>
+          </svg>        
+        </div>
+      </div>
+  `;
+
+  const withIcons = `
+  <sdds-popover-menu
+    placement="${Basic.menuPosition}"
+    selector="#trigger"> 
+    <ul class="sdds-popover-menu-wrapper">
+      <li>
+        <a target="_blank" href="https://digitaldesign.scania.com">
+        
+            <i>
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <g clip-path="url(#clip0_1815_6834)">
+                <path fill-rule="evenodd" clip-rule="evenodd" d="M2 3C2 2.44771 2.44771 2 3 2H10.7929C11.0581 2 11.3125 2.10536 11.5 2.2929L13.7071 4.5C13.8946 4.68754 14 4.94189 14 5.2071V13C14 13.5523 13.5523 14 13 14H3C2.44771 14 2 13.5523 2 13V3ZM10.7929 3H3V13H13V5.2071L10.7929 3Z" fill="#0D0F13"/>
+                <path fill-rule="evenodd" clip-rule="evenodd" d="M5 4.75V2.5H6V4.5H10V2.5H11V4.75C11 5.1642 10.6642 5.5 10.25 5.5H5.75C5.3358 5.5 5 5.1642 5 4.75Z" fill="#0D0F13"/>
+                <path fill-rule="evenodd" clip-rule="evenodd" d="M11 9.75V13.5H10V10H6V13.5H5V9.75C5 9.3358 5.3358 9 5.75 9H10.25C10.6642 9 11 9.3358 11 9.75Z" fill="#0D0F13"/>
+                </g>
+                <defs>
+                <clipPath id="clip0_1815_6834">
+                <rect width="16" height="16" fill="white"/>
+                </clipPath>
+                </defs>
+              </svg>
+            </i>
+
+            Menu item 1            
+        </a>
+      </li>
+      <li>            
+        <a target="_blank" href="https://digitaldesign.scania.com">
+
+          <i>
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <g clip-path="url(#clip0_1815_6834)">
+              <path fill-rule="evenodd" clip-rule="evenodd" d="M2 3C2 2.44771 2.44771 2 3 2H10.7929C11.0581 2 11.3125 2.10536 11.5 2.2929L13.7071 4.5C13.8946 4.68754 14 4.94189 14 5.2071V13C14 13.5523 13.5523 14 13 14H3C2.44771 14 2 13.5523 2 13V3ZM10.7929 3H3V13H13V5.2071L10.7929 3Z" fill="#0D0F13"/>
+              <path fill-rule="evenodd" clip-rule="evenodd" d="M5 4.75V2.5H6V4.5H10V2.5H11V4.75C11 5.1642 10.6642 5.5 10.25 5.5H5.75C5.3358 5.5 5 5.1642 5 4.75Z" fill="#0D0F13"/>
+              <path fill-rule="evenodd" clip-rule="evenodd" d="M11 9.75V13.5H10V10H6V13.5H5V9.75C5 9.3358 5.3358 9 5.75 9H10.25C10.6642 9 11 9.3358 11 9.75Z" fill="#0D0F13"/>
+              </g>
+              <defs>
+              <clipPath id="clip0_1815_6834">
+              <rect width="16" height="16" fill="white"/>
+              </clipPath>
+              </defs>
+            </svg>
+          </i>
+
+          Menu item 2
+        </a>
+      </li>
+      <li>            
+        <a target="_blank" href="https://digitaldesign.scania.com">
+
+          <i>
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <g clip-path="url(#clip0_1815_6834)">
+              <path fill-rule="evenodd" clip-rule="evenodd" d="M2 3C2 2.44771 2.44771 2 3 2H10.7929C11.0581 2 11.3125 2.10536 11.5 2.2929L13.7071 4.5C13.8946 4.68754 14 4.94189 14 5.2071V13C14 13.5523 13.5523 14 13 14H3C2.44771 14 2 13.5523 2 13V3ZM10.7929 3H3V13H13V5.2071L10.7929 3Z" fill="#0D0F13"/>
+              <path fill-rule="evenodd" clip-rule="evenodd" d="M5 4.75V2.5H6V4.5H10V2.5H11V4.75C11 5.1642 10.6642 5.5 10.25 5.5H5.75C5.3358 5.5 5 5.1642 5 4.75Z" fill="#0D0F13"/>
+              <path fill-rule="evenodd" clip-rule="evenodd" d="M11 9.75V13.5H10V10H6V13.5H5V9.75C5 9.3358 5.3358 9 5.75 9H10.25C10.6642 9 11 9.3358 11 9.75Z" fill="#0D0F13"/>
+              </g>
+              <defs>
+              <clipPath id="clip0_1815_6834">
+              <rect width="16" height="16" fill="white"/>
+              </clipPath>
+              </defs>
+            </svg>
+          </i>
+
+          Menu item 3
+        </a>
+      </li>
+      <li class="divider"></li>
+      <li>            
+        <a target="_blank" href="https://digitaldesign.scania.com">
+
+          <i>
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <g clip-path="url(#clip0_1815_6834)">
+              <path fill-rule="evenodd" clip-rule="evenodd" d="M2 3C2 2.44771 2.44771 2 3 2H10.7929C11.0581 2 11.3125 2.10536 11.5 2.2929L13.7071 4.5C13.8946 4.68754 14 4.94189 14 5.2071V13C14 13.5523 13.5523 14 13 14H3C2.44771 14 2 13.5523 2 13V3ZM10.7929 3H3V13H13V5.2071L10.7929 3Z" fill="#0D0F13"/>
+              <path fill-rule="evenodd" clip-rule="evenodd" d="M5 4.75V2.5H6V4.5H10V2.5H11V4.75C11 5.1642 10.6642 5.5 10.25 5.5H5.75C5.3358 5.5 5 5.1642 5 4.75Z" fill="#0D0F13"/>
+              <path fill-rule="evenodd" clip-rule="evenodd" d="M11 9.75V13.5H10V10H6V13.5H5V9.75C5 9.3358 5.3358 9 5.75 9H10.25C10.6642 9 11 9.3358 11 9.75Z" fill="#0D0F13"/>
+              </g>
+              <defs>
+              <clipPath id="clip0_1815_6834">
+              <rect width="16" height="16" fill="white"/>
+              </clipPath>
+              </defs>
+            </svg>
+          </i>
+
+          Menu item 4
+        </a>
+      </li>
+      <li>            
+        <a target="_blank" href="https://digitaldesign.scania.com">
+
+          <i>
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <g clip-path="url(#clip0_1815_6834)">
+              <path fill-rule="evenodd" clip-rule="evenodd" d="M2 3C2 2.44771 2.44771 2 3 2H10.7929C11.0581 2 11.3125 2.10536 11.5 2.2929L13.7071 4.5C13.8946 4.68754 14 4.94189 14 5.2071V13C14 13.5523 13.5523 14 13 14H3C2.44771 14 2 13.5523 2 13V3ZM10.7929 3H3V13H13V5.2071L10.7929 3Z" fill="#0D0F13"/>
+              <path fill-rule="evenodd" clip-rule="evenodd" d="M5 4.75V2.5H6V4.5H10V2.5H11V4.75C11 5.1642 10.6642 5.5 10.25 5.5H5.75C5.3358 5.5 5 5.1642 5 4.75Z" fill="#0D0F13"/>
+              <path fill-rule="evenodd" clip-rule="evenodd" d="M11 9.75V13.5H10V10H6V13.5H5V9.75C5 9.3358 5.3358 9 5.75 9H10.25C10.6642 9 11 9.3358 11 9.75Z" fill="#0D0F13"/>
+              </g>
+              <defs>
+              <clipPath id="clip0_1815_6834">
+              <rect width="16" height="16" fill="white"/>
+              </clipPath>
+              </defs>
+            </svg>
+          </i>
+
+          Menu item 5
+        </a>
+      </li>
+    </ul>        
+  </sdds-popover-menu>
+
+  <div style="display: flex; flex-wrap: nowrap; align-items: center;">
+    <span style="user-select: none;margin-right: 16px;">Click icon for popover menu</span>
+    <div style="cursor: pointer; display: flex; align-items: center;" id="trigger">
+      <svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M7.03296 3.98828C7.03296 4.54057 7.48278 4.98828 8.03767 4.98828C8.59255 4.98828 9.04238 4.54057 9.04238 3.98828C9.04238 3.436 8.59255 2.98828 8.03767 2.98828C7.48278 2.98828 7.03296 3.436 7.03296 3.98828Z" fill="#0D0F13"/>
+        <path d="M7.03296 8C7.03296 8.55228 7.48278 9 8.03767 9C8.59255 9 9.04238 8.55228 9.04238 8C9.04238 7.44772 8.59255 7 8.03767 7C7.48278 7 7.03296 7.44772 7.03296 8Z" fill="#0D0F13"/>
+        <path d="M7.03296 12.0146C7.03296 12.5669 7.48278 13.0146 8.03767 13.0146C8.59255 13.0146 9.04238 12.5669 9.04238 12.0146C9.04238 11.4624 8.59255 11.0146 8.03767 11.0146C7.48278 11.0146 7.03296 11.4624 7.03296 12.0146Z" fill="#0D0F13"/>
+      </svg>        
+    </div>
+  </div>
+  `;
+
+  if (Basic.withIcons) {
+    return withIcons;
+  }
+
+  return withoutIcons;
+};
+
+export const Basic = ComponentPopoverMenu.bind({});
+Basic.args = { withIcons: false };
+
+export const WithIcons = ComponentPopoverMenu.bind({});
+WithIcons.args = { withIcons: true };

--- a/components/src/components/popover-menu/popover-menu.tsx
+++ b/components/src/components/popover-menu/popover-menu.tsx
@@ -1,0 +1,102 @@
+import {
+  Component,
+  Element,
+  Host,
+  Listen,
+  h,
+  Prop,
+  State,
+} from '@stencil/core';
+import { createPopper } from '@popperjs/core';
+import type { Placement } from '@popperjs/core';
+
+@Component({
+  tag: 'sdds-popover-menu',
+  styleUrl: 'popover-menu.scss',
+  shadow: true,
+})
+export class PopoverMenu {
+  @Element() popoverMenuElement!: HTMLElement;
+
+  /** The CSS-selector that will trigger this Popover Menu */
+  @Prop() selector = '';
+
+  /** Decides if the Popover Menu should be visible from the start */
+  @Prop() show: boolean = false;
+
+  /** Decides the placement of the Popover Menu */
+  @Prop() placement: Placement = 'auto';
+
+  /** Sets the offset skidding */
+  @Prop() offsetSkidding: number = 0;
+
+  /** Sets the offset distance */
+  @Prop() offsetDistance: number = 8;
+
+  @State() target: any;
+
+  @Listen('mousedown', { target: 'window' })
+  handleOutsideClick() {
+    if (this.show) {
+      this.show = false;
+    }
+  }
+
+  componentDidLoad() {
+    this.target = document.querySelector(this.selector);
+    const _this = this;
+    createPopper(this.target, this.popoverMenuElement, {
+      placement: _this.placement,
+      modifiers: [
+        {
+          name: 'positionCalc',
+          enabled: true,
+          phase: 'main',
+          fn({}) {},
+        },
+        {
+          name: 'offset',
+          options: {
+            offset: [this.offsetSkidding, this.offsetDistance],
+          },
+        },
+      ],
+    });
+
+    const showMenu = () => {
+      this.show = true;
+    };
+
+    const hideMenu = () => {
+      this.show = false;
+    };
+
+    this.target.addEventListener('mousedown', (event) => {
+      event.stopPropagation();
+
+      if (this.show) {
+        hideMenu();
+      } else {
+        showMenu();
+      }
+    });
+
+    this.popoverMenuElement.addEventListener('mousemove', (event) => {
+      event.stopPropagation();
+    });
+
+    this.popoverMenuElement.addEventListener('mousedown', (event) => {
+      event.stopPropagation();
+    });
+  }
+
+  render() {
+    return (
+      <Host
+        class={`sdds-popover-menu ${this.show ? 'sdds-popover-menu-show' : ''}`}
+      >
+        <slot></slot>
+      </Host>
+    );
+  }
+}

--- a/components/src/components/popover-menu/readme.md
+++ b/components/src/components/popover-menu/readme.md
@@ -1,0 +1,21 @@
+# sdds-popover-canvas
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property         | Attribute         | Description                                                  | Type                                                                                                                                                                                                         | Default  |
+| ---------------- | ----------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
+| `offsetDistance` | `offset-distance` | Sets the offset distance                                     | `number`                                                                                                                                                                                                     | `8`      |
+| `offsetSkidding` | `offset-skidding` | Sets the offset skidding                                     | `number`                                                                                                                                                                                                     | `0`      |
+| `placement`      | `placement`       | Decides the placement of the Popover Menu                    | `"auto" \| "auto-end" \| "auto-start" \| "bottom" \| "bottom-end" \| "bottom-start" \| "left" \| "left-end" \| "left-start" \| "right" \| "right-end" \| "right-start" \| "top" \| "top-end" \| "top-start"` | `'auto'` |
+| `selector`       | `selector`        | The CSS-selector that will trigger this Popover Menu         | `string`                                                                                                                                                                                                     | `''`     |
+| `show`           | `show`            | Decides if the Popover Menu should be visible from the start | `boolean`                                                                                                                                                                                                    | `false`  |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/components/src/components/theme/theme.scss
+++ b/components/src/components/theme/theme.scss
@@ -15,6 +15,8 @@
 @import '../link/link.scss';
 @import '../message/message.scss';
 @import '../modal/modal-native.scss';
+@import '../popover-canvas/popover-canvas.scss';
+@import '../popover-menu/popover-menu.scss';
 @import '../tabs/inline-tabs/inline-tabs.scss';
 @import '../tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.scss';
 @import '../tabs/navigation-tabs/navigation-tabs.scss';
@@ -26,7 +28,6 @@
 @import '../textfield/textfield.scss';
 @import '../toast/toast.scss';
 @import '../toggle/toggle.scss';
-@import '../popover-canvas/popover-canvas.scss';
 
 // Utility classes
 @import '../../helpers/_utility-classes.scss';

--- a/sandbox/angular/src/app/components/home/home.component.html
+++ b/sandbox/angular/src/app/components/home/home.component.html
@@ -243,14 +243,66 @@
 </div>
 
 <div class="component-wrapper">
-  <sdds-textfield
+  <sdds-popover-menu
+        placement="auto"
+        selector="#trigger">
+        <ul class="sdds-popover-menu-wrapper">
+          <li>
+            <a target="_blank" href="https://digitaldesign.scania.com">Menu item 1</a>
+          </li>
+          <li>
+            <a target="_blank" href="https://digitaldesign.scania.com">
+
+              <i>
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <g clip-path="url(#clip0_1815_6834)">
+                  <path fill-rule="evenodd" clip-rule="evenodd" d="M2 3C2 2.44771 2.44771 2 3 2H10.7929C11.0581 2 11.3125 2.10536 11.5 2.2929L13.7071 4.5C13.8946 4.68754 14 4.94189 14 5.2071V13C14 13.5523 13.5523 14 13 14H3C2.44771 14 2 13.5523 2 13V3ZM10.7929 3H3V13H13V5.2071L10.7929 3Z" fill="#0D0F13"/>
+                  <path fill-rule="evenodd" clip-rule="evenodd" d="M5 4.75V2.5H6V4.5H10V2.5H11V4.75C11 5.1642 10.6642 5.5 10.25 5.5H5.75C5.3358 5.5 5 5.1642 5 4.75Z" fill="#0D0F13"/>
+                  <path fill-rule="evenodd" clip-rule="evenodd" d="M11 9.75V13.5H10V10H6V13.5H5V9.75C5 9.3358 5.3358 9 5.75 9H10.25C10.6642 9 11 9.3358 11 9.75Z" fill="#0D0F13"/>
+                  </g>
+                  <defs>
+                  <clipPath id="clip0_1815_6834">
+                  <rect width="16" height="16" fill="white"/>
+                  </clipPath>
+                  </defs>
+                </svg>
+              </i>
+
+              Menu item 2
+            </a>
+          </li>
+          <li>
+            <a target="_blank" href="https://digitaldesign.scania.com">Menu item 3</a>
+          </li>
+          <li class="divider"></li>
+          <li>
+            <a target="_blank" href="https://digitaldesign.scania.com">Menu item 4</a>
+          </li>
+          <li>
+            <a target="_blank" href="https://digitaldesign.scania.com">Menu item 5</a>
+          </li>
+        </ul>
+      </sdds-popover-menu>
+
+      <sdds-textfield
       type="text"
       placeholder="Placeholder textfield"
       labelinside="Label text"
       maxlength="20"
     ></sdds-textfield>
-  <sdds-slider tooltip label="hello there" min="0" max="100" value="50"></sdds-slider>
-  <sdds-textfield
+
+      <div style="display: flex; flex-wrap: nowrap; align-items: center;">
+        <span style="user-select: none;margin-right: 16px;">Click icon for popover menu</span>
+        <div style="cursor: pointer; display: flex; align-items: center;" id="trigger">
+          <svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M7.03296 3.98828C7.03296 4.54057 7.48278 4.98828 8.03767 4.98828C8.59255 4.98828 9.04238 4.54057 9.04238 3.98828C9.04238 3.436 8.59255 2.98828 8.03767 2.98828C7.48278 2.98828 7.03296 3.436 7.03296 3.98828Z" fill="#0D0F13"/>
+            <path d="M7.03296 8C7.03296 8.55228 7.48278 9 8.03767 9C8.59255 9 9.04238 8.55228 9.04238 8C9.04238 7.44772 8.59255 7 8.03767 7C7.48278 7 7.03296 7.44772 7.03296 8Z" fill="#0D0F13"/>
+            <path d="M7.03296 12.0146C7.03296 12.5669 7.48278 13.0146 8.03767 13.0146C8.59255 13.0146 9.04238 12.5669 9.04238 12.0146C9.04238 11.4624 8.59255 11.0146 8.03767 11.0146C7.48278 11.0146 7.03296 11.4624 7.03296 12.0146Z" fill="#0D0F13"/>
+          </svg>
+        </div>
+      </div>
+
+      <sdds-textfield
       type="text"
       placeholder="Placeholder textfield"
       labelinside="Label text"


### PR DESCRIPTION
**Describe pull-request**  
A new component in the form of a Popover Menu, based on core-code from the popover canvas component.

**Solving issue**  
Fixes: #2043

**How to test**  
Go to the netlify link or checkout the branch, and browse to the PopoverMenu component. Click the kebab-dots to see it in action, both with and without icon.

Now with updated z-index to be correctly placed.