### PR TITLE
fix(breadcrums): moving theme rules to component folder

### DIFF
--- a/components/src/components/breadcrumb/breadcrumb.scss
+++ b/components/src/components/breadcrumb/breadcrumb.scss
@@ -1,21 +1,28 @@
-@import "../../helpers/style-helpers.scss";
 @import "@scania/typography/dist/scss/mixins";
 @import "@scania/typography/dist/scss/tokens";
 @import "../../helpers/components-shared.scss";
 
-.#{$prefix}-breadcrumb {
+:root,
+html {
+  --sdds-breadcrumb-color: var(--sdds-grey-900);
+  --sdds-breadcrumb-color-hover: var(--sdds-grey-700);
+  --sdds-breadcrumb-color-focus: var(--sdds-grey-700);
+  --sdds-breadcrumb-color-disabled: var(--sdds-grey-500);
+  --sdds-breadcrumb-separator-color: var(--sdds-grey-500);
+}
+
+.sdds-breadcrumb {
   @include type-style("detail-02");
 
   display: flex;
   flex-wrap: wrap;
 
-  .#{$prefix}-breadcrumb-item {
+  .sdds-breadcrumb-item {
     color: var(--sdds-breadcrumb-color);
 
     &::after {
       content: "";
       background-color: var(--sdds-breadcrumb-separator-color);
-      mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='4' height='8' viewBox='0 0 4 8' fill='currentColor'><path d='M2.548 4.178L0.602 0.985999H1.82L3.78 4.178L1.82 7.37H0.602L2.548 4.178Z' fill='currentColor'/></svg>");
       mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='4' height='8' viewBox='0 0 4 8' fill='currentColor'><path d='M2.548 4.178L0.602 0.985999H1.82L3.78 4.178L1.82 7.37H0.602L2.548 4.178Z' fill='currentColor'/></svg>");
       margin-right: 1rem;
       margin-left: 1rem;
@@ -42,10 +49,11 @@
 
       @include sdds-focus-state;
     }
+
     &:disabled,
     &.disabled,
-    &.#{$prefix}-breadcrumb-item-current,
-    [aria-current='page'] {
+    &.sdds-breadcrumb-item-current,
+    [aria-current="page"] {
       color: var(--sdds-breadcrumb-color-disabled);
 
       a {

--- a/theme/light/src/components/_breadcrumb.scss
+++ b/theme/light/src/components/_breadcrumb.scss
@@ -1,8 +1,0 @@
-:root,
-html {
-  --#{$prefix}-breadcrumb-color: #{get-colour(grey-900)};
-  --#{$prefix}-breadcrumb-color-hover: #{get-colour(grey-700)};
-  --#{$prefix}-breadcrumb-color-focus: #{get-colour(grey-700)};
-  --#{$prefix}-breadcrumb-color-disabled: #{get-colour(grey-500)};
-  --#{$prefix}-breadcrumb-separator-color: #{get-colour(grey-500)};
-}

--- a/theme/light/src/theme/sdds-theme.scss
+++ b/theme/light/src/theme/sdds-theme.scss
@@ -13,7 +13,6 @@ it contains all imports
 
 // Components
 @import "../components/banner";
-@import "../components/breadcrumb";
 @import "../components/cards";
 @import "../components/divider";
 @import "../components/modal";


### PR DESCRIPTION
**Describe pull-request** 
Moving theming rules to component folder

**Solving issue** 
Fixes: [AB#2214](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2214)

**How to test** 
1. Open breadcrums Storybook of this branch 
2. Open breadcrums Storybook of production 
3. Compare styling- there should not be any difference between those two