### PR TITLE
fix(modal): move theming rules to component folder

### DIFF
--- a/components/src/components/modal/_modal-core.scss
+++ b/components/src/components/modal/_modal-core.scss
@@ -1,6 +1,6 @@
-@import '../../helpers/style-helpers.scss';
-@import '@scania/typography/dist/scss/mixins';
-@import '@scania/typography/dist/scss/tokens';
+@import "@scania/typography/dist/scss/mixins";
+@import "@scania/typography/dist/scss/tokens";
+
 // @import '@scania/grid/dist/scss/grid';
 
 //TODO: Find a way to create a mixin in spacings that can be used for screen size in rem
@@ -69,7 +69,8 @@ $modals: (
 }
 
 @mixin modal-body {
-  @include type-style('body-01');
+  @include type-style("body-01");
+
   padding-bottom: 40px;
   margin: 0;
 
@@ -87,7 +88,7 @@ $modals: (
   margin-right: var(--sdds-spacing-element-16);
 }
 
-.#{$prefix}-modal {
+.sdds-modal {
   background-color: var(--sdds-modal-bg);
   z-index: 4;
   margin: auto;
@@ -100,7 +101,7 @@ $modals: (
 @each $screen, $modals in $modals {
   @media (min-width: $screen) {
     @each $modal, $value in $modals {
-      .#{$prefix}-modal-#{$modal} {
+      .sdds-modal-#{$modal} {
         width: $value;
       }
     }
@@ -108,23 +109,23 @@ $modals: (
 }
 
 @media (max-width: $screen-s) {
-  .#{$prefix}-modal-md,
-  .#{$prefix}-modal-lg,
-  .#{$prefix}-modal-sm {
+  .sdds-modal-md,
+  .sdds-modal-lg,
+  .sdds-modal-sm {
     height: 100%;
 
-    slot[name='#{$prefix}-modal-actions']::slotted(*) {
+    slot[name="sdds-modal-actions"]::slotted(*) {
       display: flex;
     }
   }
 }
 
-.#{$prefix}-modal-header {
+.sdds-modal-header {
   display: flex;
   padding-bottom: var(--sdds-spacing-element-16);
 }
 
-.#{$prefix}-modal-btn {
+.sdds-modal-btn {
   display: inline-block;
   width: 16px;
   height: auto;
@@ -135,6 +136,7 @@ $modals: (
   @media (min-width: $screen-s) {
     margin-left: var(--sdds-spacing-element-16);
   }
+
   @media (min-width: $screen-l) {
     margin-left: var(--sdds-spacing-element-48);
   }

--- a/components/src/components/modal/modal-native.scss
+++ b/components/src/components/modal/modal-native.scss
@@ -1,12 +1,12 @@
-@import './modal-core';
+@import "./modal-core";
 
-.#{$prefix}-modal-body {
+.sdds-modal-body {
   & > * {
     @include modal-body;
   }
 }
 
-.#{$prefix}-modal-headline {
+.sdds-modal-headline {
   display: contents;
 
   & > * {
@@ -14,12 +14,12 @@
   }
 }
 
-.#{$prefix}-modal-actions {
+.sdds-modal-actions {
   & > * {
     @include modal-actions;
   }
 }
 
-.#{$prefix}-modal-backdrop {
+.sdds-modal-backdrop {
   @include modal-host;
 }

--- a/components/src/components/modal/modal.scss
+++ b/components/src/components/modal/modal.scss
@@ -1,6 +1,12 @@
 @import "./modal-core";
 @import "../../helpers/components-shared";
 
+:root,
+html {
+  --sdds-modal-backdrop: rgba(0 0 0 / 40%);
+  --sdds-modal-bg: var(--sdds-white);
+}
+
 :host {
   @include modal-host;
 
@@ -22,14 +28,14 @@
   display: none;
 }
 
-slot[name='#{$prefix}-modal-headline']::slotted(*) {
+slot[name="sdds-modal-headline"]::slotted(*) {
   @include modal-headline;
 }
 
-slot[name='#{$prefix}-modal-body']::slotted(*) {
+slot[name="sdds-modal-body"]::slotted(*) {
   @include modal-body;
 }
 
-slot[name='#{$prefix}-modal-actions']::slotted(*) {
+slot[name="sdds-modal-actions"]::slotted(*) {
   @include modal-actions;
 }

--- a/theme/light/src/components/_modal.scss
+++ b/theme/light/src/components/_modal.scss
@@ -1,5 +1,0 @@
-:root,
-html {
-  --#{$prefix}-modal-backdrop: rgba(0 0 0 / 0.4);
-  --#{$prefix}-modal-bg: #{get-colour(white)};
-}

--- a/theme/light/src/theme/sdds-theme.scss
+++ b/theme/light/src/theme/sdds-theme.scss
@@ -12,8 +12,6 @@ it contains all imports
 @import url("#{$cdn}/fonts/scania-sans/1.0.0/scania-sans.css");
 
 // Components
-
-@import "../components/modal";
 @import "../components/link";
 @import "../components/textfields";
 @import "../components/toast";


### PR DESCRIPTION
**Describe pull-request** 
Moving theming rules to component folder 

**Solving issue** 
Fixes: [AB#2219](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2219) 

**How to test** 
1. Open modal in Storybook of this branch 
2. Open modal in Storybook of production 
3. Compare styling- there should not be any difference between those two