### PR TITLE
fix(dropdown): changed the dropdown options to use the bg variables

### DIFF
--- a/components/src/components/dropdown/_dropdown-core.scss
+++ b/components/src/components/dropdown/_dropdown-core.scss
@@ -5,7 +5,7 @@ html {
 
   .sdds-on-white-bg {
     --sdds-dropdown-bg: var(--sdds-grey-50);
-    --sdds-dropdown-bg-hover: var(--sdds-grey-300);
+    --sdds-dropdown-bg-hover: var(--sdds-grey-100);
   }
 }
 

--- a/components/src/components/dropdown/dropdown.scss
+++ b/components/src/components/dropdown/dropdown.scss
@@ -232,7 +232,7 @@
   ::slotted(sdds-dropdown-option) {
     display: flex;
     padding: var(--sdds-spacing-element-16);
-    background-color: var(--sdds-white);
+    background-color: var(--sdds-dropdown-bg);
     border-top: 1px solid transparent;
     border-bottom: 1px solid var(--sdds-grey-100);
     opacity: 0;
@@ -249,11 +249,11 @@
 
   ::slotted(sdds-dropdown-option:hover),
   ::slotted(sdds-dropdown-option:focus) {
-    background-color: var(--sdds-grey-50);
+    background-color: var(--sdds-dropdown-bg-hover);
   }
 
   ::slotted(sdds-dropdown-option:hover:not(:focus):not(sdds-dropdown-option.selected)) {
-    background-color: var(--sdds-white);
+    background-color: var(--sdds-dropdown-bg-hover);
   }
 
   ::slotted(sdds-dropdown-option:hover:focus) {


### PR DESCRIPTION
The dropdown options were using a fixed background of white and hover of grey-50. This was only valid for the on-grey version.

**Describe pull-request**  
The dropdown options were using a fixed background of white and hover of grey-50. This was only valid for the on-grey version. This PR makes the dropdown option use the variables "--sdds-dropdown-bg" and "--sdds-dropdown-bg-hover" which reflect the design. 

**Solving issue**  

Fixes: [AB#1825](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/1825)

**How to test**  
1. In the storybook link below.
2. Check that the dropdown components in the on-white theme follows the design. 
3. Run -

**Screenshots**  
<img width="518" alt="Screenshot 2022-10-03 at 17 01 27" src="https://user-images.githubusercontent.com/62651103/193610293-f698ca04-3ec9-437a-8bda-1b17f31aaa8c.png">
