### PR TITLE
fix(header): added box-shadow and border-radius (bottom left and righ…

### DIFF
--- a/components/src/components/header/header.scss
+++ b/components/src/components/header/header.scss
@@ -290,6 +290,8 @@
     transform: scaleY(0);
     transform-origin: top;
     transition: transform 150ms ease;
+    box-shadow: var(--sdds-card-box);
+    border-radius: 0 0 4px 4px;
   }
 
   .sdds-nav__dropdown-item {


### PR DESCRIPTION
fix(header): added box-shadow and border-radius (bottom left and right) to the dropdown-menu

Added box-shadow and border-radius (bottom left and right) to the dropdown-menu of the header component. The box-shadow was the original issue but I also noticed that the dropdown was missing a border-radius so added that fix to this commit.


**Describe pull-request**  
This PR adds the correct styling to the dropdown-menu in the header component. 

**Solving issue**  
Fixes: AB#2270

**How to test**  
_Add description how to test if possible_
1. Go to the storybook page below. 
2. Check in Header -> Inline Menu, Toolbar Menu, Searchbar Menu, All Menus and compare the styling of the dropdown to that in Figma.

**Screenshots**  
<img width="1009" alt="Screenshot 2022-10-04 at 11 05 04" src="https://user-images.githubusercontent.com/62651103/193780235-f63395cb-e40a-4b5f-966e-4f22b0689190.png">

