### PR TITLE
feat(modal): add prop to to hide close button

### DIFF
--- a/components/src/components/modal/modal.stories.js
+++ b/components/src/components/modal/modal.stories.js
@@ -8,6 +8,13 @@ export default {
       },
       defaultValue: false,
     },
+    hideClose: {
+      name: 'Hide close button',
+      control: {
+        type: 'boolean',
+      },
+      defaultValue: false,
+    },
     size: {
       name: 'Size',
       control: {
@@ -32,7 +39,7 @@ const ModalTemplate = ({ ...Modal }) => `
   
   <sdds-modal id="modal-test" size="${Modal.size}" selector=".modal1" ${
   Modal.preventBackdrop === true ? 'prevent' : ''
-} >
+}  >
     <h5 slot="sdds-modal-headline">${Modal.headline}</h5>
       <div slot="sdds-modal-body">
         Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Maecenas tempus, tellus eget condimentum rhoncus.
@@ -60,7 +67,7 @@ const ModalTemplate = ({ ...Modal }) => `
   <sdds-modal id="modal-test-2" size="${Modal.size}" selector="#modal2" ${
   Modal.preventBackdrop === true ? 'prevent' : ''
 } >
-      <h5 slot="sdds-modal-headline">${Modal.headline}</h5>
+      <h5 slot="sdds-modal-headline">${Modal.headline} has no X-button</h5>
       <div slot="sdds-modal-body">
         Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Maecenas tempus, tellus eget condimentum rhoncus.
         Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Maecenas tempus, tellus eget condimentum rhoncus.
@@ -82,7 +89,36 @@ const ModalTemplate = ({ ...Modal }) => `
   </sdds-modal>
 
   <button onclick="console.log('Open modal 2')" id="modal2" class="sdds-btn sdds-btn-primary">Open modal 2</button>
-  `;
+  
+  
+  <sdds-modal id="modal-test-3" size="${Modal.size}" selector="#modal3" ${
+  Modal.preventBackdrop === true ? 'prevent' : ''
+} hide-close=${true} >
+        <h5 slot="sdds-modal-headline">${
+          Modal.headline
+        } - Modal without close button.</h5>
+        <div slot="sdds-modal-body">
+          Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Maecenas tempus, tellus eget condimentum rhoncus.
+          Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Maecenas tempus, tellus eget condimentum rhoncus.
+          Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Maecenas tempus, tellus eget condimentum rhoncus.
+          Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Maecenas tempus, tellus eget condimentum rhoncus.
+          <br><br>
+          Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Maecenas tempus, tellus eget condimentum rhoncus.
+          Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Maecenas tempus, tellus eget condimentum rhoncus.
+          Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Maecenas tempus, tellus eget condimentum rhoncus.
+          Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Maecenas tempus, tellus eget condimentum rhoncus.
+          <br><br>
+          Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Maecenas tempus, tellus eget condimentum rhoncus.
+          Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Maecenas tempus, tellus eget condimentum rhoncus.
+          Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Maecenas tempus, tellus eget condimentum rhoncus.
+          Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Maecenas tempus, tellus eget condimentum rhoncus. 
+        </div>
+      <button slot="sdds-modal-actions" onclick="console.log('save')" class="sdds-btn sdds-btn-primary sdds-btn-md">Save</button>
+      <button slot="sdds-modal-actions" data-dismiss-modal onclick="console.log('cancel')" class="sdds-btn sdds-btn-secondary sdds-btn-md">Cancel</button>
+    </sdds-modal>
+  
+    <button onclick="console.log('Open modal 3')" id="modal3" class="sdds-btn sdds-btn-primary">Open modal 3</button>
+    `;
 
 export const WebComponent = ModalTemplate.bind();
 

--- a/components/src/components/modal/modal.stories.js
+++ b/components/src/components/modal/modal.stories.js
@@ -117,6 +117,10 @@ const ModalTemplate = ({ ...Modal }) => `
       <button slot="sdds-modal-actions" data-dismiss-modal onclick="console.log('cancel')" class="sdds-btn sdds-btn-secondary sdds-btn-md">Cancel</button>
     </sdds-modal>
   
+    </br>
+    </br>
+    <span> Modal with no top-right close button. </span>
+    </br>
     <button onclick="console.log('Open modal 3')" id="modal3" class="sdds-btn sdds-btn-primary">Open modal 3</button>
     `;
 

--- a/components/src/components/modal/modal.tsx
+++ b/components/src/components/modal/modal.tsx
@@ -20,10 +20,13 @@ export class Modal {
   @Prop() selector: string = '';
 
   /** Disables closing modal on clicking on overlay area. */
-  @Prop() prevent: boolean = false;
+  @Prop() prevent: boolean;
 
   /** Size of modal. Accepted strings are: xs, sm, md, lg.  */
   @Prop() size: 'xs' | 'sm' | 'md' | 'lg' = 'md';
+
+  /** Hide the X-close button on modal */
+  @Prop() hideClose: boolean = false;
 
   @Element() el: HTMLElement;
 
@@ -94,7 +97,7 @@ export class Modal {
         >
           <div class="sdds-modal-header">
             <slot name="sdds-modal-headline"></slot>
-            <button class="sdds-modal-btn"></button>
+            {!this.hideClose && <button class="sdds-modal-btn"></button>}
           </div>
           <slot name="sdds-modal-body"></slot>
           <div class="sdds-modal-actions sdds-modal-actions__sticky">

--- a/components/src/components/modal/readme.md
+++ b/components/src/components/modal/readme.md
@@ -5,11 +5,12 @@
 
 ## Properties
 
-| Property   | Attribute  | Description                                                                                                 | Type                           | Default |
-| ---------- | ---------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------ | ------- |
-| `prevent`  | `prevent`  | Disables closing modal on clicking on overlay area.                                                         | `boolean`                      | `false` |
-| `selector` | `selector` | Target selector that triggers opening of modal, for example button with id="btn1", then selector is "#btn1" | `string`                       | `''`    |
-| `size`     | `size`     | Size of modal. Accepted strings are: xs, sm, md, lg.                                                        | `"lg" \| "md" \| "sm" \| "xs"` | `'md'`  |
+| Property    | Attribute    | Description                                                                                                 | Type                           | Default     |
+| ----------- | ------------ | ----------------------------------------------------------------------------------------------------------- | ------------------------------ | ----------- |
+| `hideClose` | `hide-close` | Hide the X-close button on modal                                                                            | `boolean`                      | `false`     |
+| `prevent`   | `prevent`    | Disables closing modal on clicking on overlay area.                                                         | `boolean`                      | `undefined` |
+| `selector`  | `selector`   | Target selector that triggers opening of modal, for example button with id="btn1", then selector is "#btn1" | `string`                       | `''`        |
+| `size`      | `size`       | Size of modal. Accepted strings are: xs, sm, md, lg.                                                        | `"lg" \| "md" \| "sm" \| "xs"` | `'md'`      |
 
 
 ## Methods


### PR DESCRIPTION
Added a prop to be able to chose if to modal has a close button or not.



**Describe pull-request**  
The PR adds a prop ("hideClose") to the modal which if true hides the close button in the top right corner. 

**Solving issue**  
Fixes: [AB#2298](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2298)

**How to test**  
1. Go to the storybook page below.
2. Check in Modal and open modal number 3. 
3. See that this modal does not have a close button due to it being passed the attribute "hide-close=true".

**Screenshots**  
<img width="927" alt="Screenshot 2022-10-04 at 16 16 14" src="https://user-images.githubusercontent.com/62651103/193843360-9250f7e6-c5d5-4c15-be30-08b14e270b65.png">
