### PR TITLE
fix(header): fix position of active item indicator when its on an inline menu

### DIFF
--- a/components/src/components/header/header.scss
+++ b/components/src/components/header/header.scss
@@ -169,6 +169,7 @@ html,
   }
 
   .sdds-nav__item {
+    position: relative;
     border-right: 1px solid var(--sdds-blue-700);
     border-top: none;
     border-bottom: none;
@@ -989,13 +990,13 @@ html,
         content: "";
         border-bottom: none;
         border-right: 4px solid var(--sdds-blue-400);
-        width: 100%;
+        width: 0;
         height: 100%;
         display: block;
         margin-left: 0;
-        bottom: 100%;
-        left: -100%;
-        position: relative;
+        top: 0;
+        left: 0;
+        position: absolute;
       }
 
       .sdds-nav__item-core,


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
On the mobile menu, the active item indicator was displaying in the wrong position if the active item was a inline menu. This fixes that

**Solving issue**  
Fixes: #362 [AB#1895](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/1895)

**How to test**  
1. Run SDDS
2. Edit Header story -> inline menu, so the item with the inline menu is the active one
3. Look at the story in Storybook

**Screenshots**  
Before:
<img width="301" alt="Screenshot 2022-10-04 at 16 56 39" src="https://user-images.githubusercontent.com/8556022/193861794-13c2e08e-8e76-45fd-a56c-1f3b00fb3dce.png">

After:
<img width="319" alt="Screenshot 2022-10-04 at 17 31 04" src="https://user-images.githubusercontent.com/8556022/193861949-595ac6e1-af1a-4015-a37d-93257e12fac9.png">

