### PR TITLE
fix(dropdown): fix misplaced native dropdown label

### DIFF
--- a/components/src/components/dropdown/dropdown-select.scss
+++ b/components/src/components/dropdown/dropdown-select.scss
@@ -1,6 +1,8 @@
 @import "./dropdown-core";
 
 .sdds-dropdown {
+  position: relative;
+
   select {
     @include dropdown-wrapper;
 


### PR DESCRIPTION



<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Labels of native dropdowns were being placed with position absolute relative to the nearest positioned ancestor of the dropdown, instead of the dropdown itself, since the dropdown class had position set to static. 
This commit sets position relative on the dropdown, so the label is positioned relative to it.

**Solving issue**  
Fixes: [AB#1826](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/1826)

**How to test**  
1. Check native dropdown in storybook

**Screenshots**  
Before:
<img width="379" alt="Screenshot 2022-10-04 at 17 56 53" src="https://user-images.githubusercontent.com/8556022/193867759-90839114-d249-4f28-9ecb-e1e2ec306624.png">

After:
<img width="350" alt="Screenshot 2022-10-04 at 17 57 06" src="https://user-images.githubusercontent.com/8556022/193867784-529e8322-a4f2-447c-b258-576bb7e28158.png">
