### PR TITLE
fix(header): stop dropdowns showing briefly on page load

### DIFF
--- a/components/src/components/header/header.scss
+++ b/components/src/components/header/header.scss
@@ -290,12 +290,14 @@ html,
 
     .sdds-nav__dropdown-menu {
       transform: scaleY(1);
+      opacity: 1;
     }
   }
 
   .sdds-nav__dropdown-menu {
     position: absolute;
     list-style-type: none;
+    opacity: 0;
     transform: scaleY(0);
     transform-origin: top;
     transition: transform 150ms ease;
@@ -637,6 +639,7 @@ html,
     transition: transform 150ms ease;
     transform-origin: top;
     transform: scaleY(0);
+    opacity: 0;
   }
 
   .sdds-nav__avatar-item {
@@ -715,6 +718,7 @@ html,
 
     .sdds-nav__avatar-menu {
       transform: scaleY(1);
+      opacity: 1;
     }
   }
 
@@ -729,6 +733,7 @@ html,
     height: calc(100vh - 64px);
     padding-bottom: 32px;
     transform: scaleY(0);
+    opacity: 0;
     transform-origin: top;
     transition: transform 150ms ease;
   }
@@ -741,6 +746,7 @@ html,
 
     .sdds-nav__app-launcher-menu {
       transform: scaleY(1);
+      opacity: 1;
     }
   }
 


### PR DESCRIPTION


<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Will hide the header menus with `opacity: 0` when they are not open, so they wont show briefly when the page loads. 
See: #347

This is a partial quick fix to a larger issue. 
The issue seems to happen on anything with a transition property defined on it. If i add a background color transition on sdds-btn, for example, it will fade in from the browser defaults on page load. 
I think its because the css is loaded in sdds-theme, so it might come in a bit late.

re #347, [AB#1931](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/1931)

**How to test**  
Go to this page, and refresh the page: https://production.d1g8v8mrkx992n.amplifyapp.com/iframe.html?args=&id=component-header--all-menus&viewMode=story
