### PR TITLE
fix(dropdown): place outside label 8px above dropdown like design spec

### DIFF
--- a/components/src/components/dropdown/_dropdown-core.scss
+++ b/components/src/components/dropdown/_dropdown-core.scss
@@ -78,7 +78,7 @@ html {
 .sdds-dropdown-label-outside {
   @include type-style("detail-05");
 
+  display: block;
   color: var(--sdds-grey-958);
-  position: absolute;
-  top: -16px;
+  margin-bottom: var(--sdds-spacing-element-8);
 }

--- a/components/src/components/dropdown/dropdown.scss
+++ b/components/src/components/dropdown/dropdown.scss
@@ -121,6 +121,12 @@
     }
   }
 
+  &:has(span.sdds-dropdown-label-outside) {
+    .sdds-dropdown-menu {
+      margin-bottom: -24px;
+    }
+  }
+
   .sdds-dropdown-menu {
     z-index: 10000;
 

--- a/components/src/components/dropdown/dropdown.scss
+++ b/components/src/components/dropdown/dropdown.scss
@@ -121,12 +121,6 @@
     }
   }
 
-  &:has(span.sdds-dropdown-label-outside) {
-    .sdds-dropdown-menu {
-      margin-bottom: -24px;
-    }
-  }
-
   .sdds-dropdown-menu {
     z-index: 10000;
 
@@ -181,6 +175,12 @@
       box-shadow: 0 -1px 3px 0 rgb(0 0 0 / 10%);
       transform-origin: bottom;
     }
+  }
+}
+
+:host(.sdds-dropdown--open-upwards[label-position="outside"]) {
+  span.sdds-dropdown-menu {
+    bottom: calc(100% - 24px);
   }
 }
 


### PR DESCRIPTION




<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Places outside label variant of dropdown 8px above the dropdown, to align with appearance in figma, and also with appearance of text field. 
Also makes the label take up space on the page, which it did not previously do (it was placed with position absolute).

**Solving issue**  
[AB#718](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/718)

**How to test**  
Go here https://production.d1g8v8mrkx992n.amplifyapp.com/?path=/story/component-dropdown--label-outside,
or equivalent path on your localhost when running sdds.

**Screenshots**  
### Before
![Screenshot 2022-10-05 at 16 19 48](https://user-images.githubusercontent.com/8556022/194083964-77a69302-9e11-43b7-93fa-84028bf30e10.png)

### After
![Screenshot 2022-10-05 at 16 19 56](https://user-images.githubusercontent.com/8556022/194084010-9ed07bb9-7ab2-4685-bd47-0f5a348e632f.png)


