### PR TITLE
chore: reduce noise when running npm start

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -21,7 +21,7 @@
     "watch-stencil": "npm run build -- --watch",
     "stencil": "stencil build --docs-json dist/data/docs.json",
     "babel": "mkdirp .build && babel src/helpers/index.js --out-file .build/index.js",
-    "watch-sb": "start-storybook -p 1339 --no-dll --no-manager-cache",
+    "watch-sb": "start-storybook -p 1339 --no-dll --no-manager-cache --quiet",
     "build-sb": "build-storybook",
     "publish-sb": "npm run build && npm run build-sb",
     "readme": "stencil build --docs-readme",


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Adds --quiet flag to `storybook-start` command to reduce the amount of unnecessary noise that appears in the console when running `npm start`

**How to test**  
`npm start`

**Additional context**  
There was previously too much output in the console, to the point where it was a real chore to look through it.
