### PR TITLE
docs: make docs tab default in storybook

### DIFF
--- a/components/.storybook/preview.js
+++ b/components/.storybook/preview.js
@@ -1,3 +1,4 @@
+import { themes } from '@storybook/theming';
 import { defineCustomElements } from '../loader';
 
 // https://github.com/storybookjs/storybook/issues/6364
@@ -13,6 +14,10 @@ export const parameters = {
       color: /(background|color)$/i,
       date: /Date$/,
     },
+  },
+  viewMode: 'docs',
+  previewTabs: {
+    'storybook/docs/panel': { index: -1 },
   },
 };
 

--- a/components/.storybook/preview.js
+++ b/components/.storybook/preview.js
@@ -1,4 +1,3 @@
-import { themes } from '@storybook/theming';
 import { defineCustomElements } from '../loader';
 
 // https://github.com/storybookjs/storybook/issues/6364


### PR DESCRIPTION
Not sure what was decided, but if we decided to change the default tab we can merge this PR.

<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Makes the docs tab the default tab in storybook, instead of canvas.

**Screenshots**  
<img width="331" alt="Screenshot 2022-10-12 at 12 07 45" src="https://user-images.githubusercontent.com/8556022/195315055-9276f11c-6991-4758-8fac-0b399caef2cc.png">
