### PR TITLE
docs: show code example by default in storybook

### DIFF
--- a/components/.storybook/preview.js
+++ b/components/.storybook/preview.js
@@ -47,6 +47,11 @@ export const parameters = {
     lightClass: 'sdds-theme-light',
     stylePreview: true,
   },
+  docs: {
+    source: {
+      state: 'open',
+    },
+  },
 };
 
 defineCustomElements();


### PR DESCRIPTION
Shows code example by default in storybook.
Thought it felt better..
What do you think?

**Screenshots**  
<img width="1060" alt="Screenshot 2022-10-12 at 12 18 14" src="https://user-images.githubusercontent.com/8556022/195317370-abd308b9-0f6e-41dc-9d07-2f7ba3780ffc.png">

