### PR TITLE
fix(textfield): display flex on sdds-helper to avoid clash between slot and char counter

### DIFF
--- a/components/src/components/textfield/textfield.scss
+++ b/components/src/components/textfield/textfield.scss
@@ -1,5 +1,5 @@
-@import '@scania/typography/dist/scss/mixins';
-@import '@scania/typography/dist/scss/tokens';
+@import "@scania/typography/dist/scss/mixins";
+@import "@scania/typography/dist/scss/tokens";
 
 :root,
 html {
@@ -94,21 +94,21 @@ html {
 //Sizes
 .sdds-textfield-input {
   @include textfield-base;
-  @include type-style('detail-02');
+  @include type-style("detail-02");
 
   padding: var(--sdds-spacing-element-20) var(--sdds-spacing-element-16);
 }
 
 .sdds-textfield-input-md {
   @include textfield-base;
-  @include type-style('detail-02');
+  @include type-style("detail-02");
 
   padding: var(--sdds-spacing-element-16);
 }
 
 .sdds-textfield-input-sm {
   @include textfield-base;
-  @include type-style('detail-02');
+  @include type-style("detail-02");
 
   padding: var(--sdds-spacing-element-16);
 }
@@ -154,7 +154,7 @@ html {
 
 //Textfield label
 .sdds-textfield-slot-wrap-label > * {
-  @include type-style('detail-05');
+  @include type-style("detail-05");
 
   display: block;
   margin-bottom: var(--sdds-spacing-element-8);
@@ -162,7 +162,7 @@ html {
 }
 
 .sdds-textfield-label-inside {
-  @include type-style('detail-02');
+  @include type-style("detail-02");
 
   position: absolute;
   pointer-events: none;
@@ -247,21 +247,21 @@ html {
   &.sdds-textfield-focus,
   &.sdds-textfield-data {
     .sdds-textfield-input-sm ~ .sdds-textfield-label-inside {
-      @include type-style('detail-07');
+      @include type-style("detail-07");
       @include label-inside-transition;
 
       top: 8px;
     }
 
     .sdds-textfield-input-md ~ .sdds-textfield-label-inside {
-      @include type-style('detail-07');
+      @include type-style("detail-07");
       @include label-inside-transition;
 
       top: 8px;
     }
 
     .sdds-textfield-input ~ .sdds-textfield-label-inside {
-      @include type-style('detail-07');
+      @include type-style("detail-07");
       @include label-inside-transition;
 
       top: 12px;
@@ -276,7 +276,7 @@ html {
 
   &::before,
   &::after {
-    content: '';
+    content: "";
     height: 2px;
     top: 54px;
     width: 0;
@@ -309,10 +309,10 @@ html {
 
 //Helper text
 .sdds-textfield-helper {
-  @include type-style('detail-05');
+  @include type-style("detail-05");
 
-  display: block;
-  flex-basis: 100%;
+  display: flex;
+  justify-content: space-between;
   padding-top: var(--sdds-spacing-element-4);
   color: var(--sdds-textfield-helper);
 }
@@ -361,7 +361,7 @@ html {
     right: 18px;
     bottom: -24px;
 
-    @include type-style('detail-05');
+    @include type-style("detail-05");
 
     padding: 8px;
     color: var(--sdds-white);
@@ -418,8 +418,8 @@ html {
     }
   }
 
-  slot[name='sdds-prefix']::slotted(sdds-icon),
-  slot[name='sdds-suffix']::slotted(sdds-icon) {
+  slot[name="sdds-prefix"]::slotted(sdds-icon),
+  slot[name="sdds-suffix"]::slotted(sdds-icon) {
     color: var(--sdds-textfield-icon-error);
   }
 }
@@ -435,7 +435,7 @@ html {
 }
 
 .sdds-textfield-textcounter {
-  @include type-style('detail-05');
+  @include type-style("detail-05");
 
   color: var(--sdds-textfield-textcounter);
   float: right;
@@ -458,7 +458,7 @@ slot[name="sdds-suffix"]::slotted(*) {
   align-self: center;
 
   > * {
-    @include type-style('detail-02');
+    @include type-style("detail-02");
 
     margin-left: 16px;
     color: var(--sdds-textfield-ps-color);
@@ -469,7 +469,7 @@ slot[name="sdds-suffix"]::slotted(*) {
   align-self: center;
 
   > * {
-    @include type-style('detail-02');
+    @include type-style("detail-02");
 
     margin-right: 16px;
     color: var(--sdds-textfield-ps-color);
@@ -477,14 +477,14 @@ slot[name="sdds-suffix"]::slotted(*) {
 }
 
 //TODO: When new icons are avaliable have a look at this one
-slot[name='sdds-prefix']::slotted(sdds-icon),
-slot[name='sdds-suffix']::slotted(sdds-icon) {
+slot[name="sdds-prefix"]::slotted(sdds-icon),
+slot[name="sdds-suffix"]::slotted(sdds-icon) {
   font-size: 6rem; //FIXME: When new icons is avaliable it should be 16x16
   line-height: 0;
 }
 
 //Text gerenerated infront of the input field
-slot[name='sdds-prefix']::slotted(*) {
+slot[name="sdds-prefix"]::slotted(*) {
   padding-left: var(--sdds-spacing-element-20);
 
   & ~ .sdds-textfield-input  {
@@ -493,6 +493,6 @@ slot[name='sdds-prefix']::slotted(*) {
 }
 
 //Text generated after the input field
-slot[name='sdds-suffix']::slotted(*) {
+slot[name="sdds-suffix"]::slotted(*) {
   padding-right: var(--sdds-spacing-element-20);
 }


### PR DESCRIPTION
**Describe pull-request**  
Changed the sdds-textfield-helper to display flex and justify-content:between to allow for both the slot, error state and char counter to fit on the same row. 

**Solving issue**  
Fixes: #524 [AB#2443](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2443)

**How to test**  
1. Go to storybook link below
2. Add a helper text on textfield, state to error and set a number on the char count. 
3. Check that all of these elements can be on the same row. 

**Screenshots**  
Before:
<img width="897" alt="Screenshot 2022-10-25 at 16 48 43" src="https://user-images.githubusercontent.com/62651103/197806570-625bd99d-d87a-4c66-85ba-eace2c96fa1a.png">


After:
<img width="914" alt="Screenshot 2022-10-25 at 16 49 07" src="https://user-images.githubusercontent.com/62651103/197806638-862fa272-2438-4315-8fac-aa8720121d65.png">


**Additional context**  
-