### PR TITLE
fix(dropdown): dropdown label inside full height

### DIFF
--- a/components/src/components/dropdown/dropdown.tsx
+++ b/components/src/components/dropdown/dropdown.tsx
@@ -290,7 +290,7 @@ export class Dropdown {
           'sdds-dropdown--error': this.state === 'error',
           'sdds-dropdown--open-upwards': this.openUpwards,
           'sdds-dropdown--label-inside-position':
-            this.labelPosition === 'inside',
+            this.labelPosition === 'inside' && this.selectedLabelsArray.length > 0,
         }}
         selected-value={this.selectedValue}
         selected-text={this.selectedLabel}
@@ -339,10 +339,11 @@ export class Dropdown {
                   class={{
                     'sdds-dropdown-label-container': true,
                     'sdds-dropdown-label-container--label-inside':
-                      this.labelPosition === 'inside',
+                      this.labelPosition === 'inside' && this.selectedLabel.length > 0,
                   }}
                 >
                   {this.size !== 'sm' &&
+                  this.selectedLabel.length > 0 &&
                     this.labelPosition === 'inside' &&
                     this.label.length > 0 && (
                       <span class="sdds-dropdown-label-inside">
@@ -373,6 +374,9 @@ export class Dropdown {
                             .join(', ')}
                       </span>
                     )}
+                    {!this.selectedLabel &&
+                      this.labelPosition === 'inside' &&
+                      this.label}
 
                     {!this.selectedLabel &&
                       this.type !== 'multiselect' &&

--- a/tegel/src/components/dropdown/dropdown.tsx
+++ b/tegel/src/components/dropdown/dropdown.tsx
@@ -8,7 +8,7 @@ import { Component, h, Prop, State, Element, Listen, Host, Event, EventEmitter, 
 export class Dropdown {
   textInput?: HTMLInputElement;
 
-  /** Placeholder text for dropdown with no selectedLabel item 2 */
+  /** Placeholder text for dropdown with no selectedLabel item */
   @Prop() placeholder: string;
 
   /** Add the value of the option as string to set it as default */
@@ -20,7 +20,7 @@ export class Dropdown {
   /** Set to true for disabled states */
   @Prop() disabled: boolean;
 
-  /** Controls type of dropdown. 'Default', 'multiselect' and 'filter' are correct values */
+  /** `Controls type of dropdown. 'Default', 'multiselect' and 'filter' are correct values */
   @Prop() type: 'default' | 'multiselect' | 'filter' = 'default';
 
   /** Controls the size of dropdown. 'sm', 'md' and 'lg' correct values and 'small', 'medium' and 'large' are deprecated */
@@ -133,8 +133,8 @@ export class Dropdown {
       if (typeof this.textInput !== 'undefined' || this.textInput === null) {
         this.textInput.focus();
       }
-      //Remove if it works
-      //this.open ? !this.open : this.open;
+      // TODO: Maybe can be this.open = !this.open ?
+      this.open ? !this.open : this.open;
     } else {
       this.tabbingLabelReset();
       this.open = false;
@@ -251,7 +251,7 @@ export class Dropdown {
       optionItem.selected = false;
     });
   }
-  /**Use this method to reset the dropdown. Then it will go back to its initial state.*/
+
   @Method() async resetOption() {
     this.deselectAll();
     this.open = false;
@@ -271,7 +271,7 @@ export class Dropdown {
           'sdds-dropdown--selected': this.selectedLabel.length > 0 || this.selectedLabel === '',
           'sdds-dropdown--error': this.state === 'error',
           'sdds-dropdown--open-upwards': this.openUpwards,
-          'sdds-dropdown--label-inside-position': this.labelPosition === 'inside',
+          'sdds-dropdown--label-inside-position': this.labelPosition === 'inside' && this.selectedLabelsArray.length > 0,
         }}
         selected-value={this.selectedValue}
         selected-text={this.selectedLabel}
@@ -291,12 +291,7 @@ export class Dropdown {
             onClick={() => this.handleClick()}
             ref={node => (this.node = node)}
           >
-            <span
-              class={{
-                'sdds-dropdown-label': true,
-                'sdds-dropdown-label--label-inside': this.labelPosition === 'inside',
-              }}
-            >
+            <span class="sdds-dropdown-label">
               {this.type === 'filter' ? (
                 <input
                   part={this.disabled ? 'dropdown-filter-disabled' : ''}
@@ -314,10 +309,12 @@ export class Dropdown {
                 <span
                   class={{
                     'sdds-dropdown-label-container': true,
-                    'sdds-dropdown-label-container--label-inside': this.labelPosition === 'inside',
+                    'sdds-dropdown-label-container--label-inside': this.labelPosition === 'inside' && this.selectedLabel.length > 0,
                   }}
                 >
-                  {this.size !== 'sm' && this.labelPosition === 'inside' && this.label.length > 0 && <span class="sdds-dropdown-label-inside">{this.label}</span>}
+                  {this.size !== 'sm' && this.selectedLabel.length > 0 && this.labelPosition === 'inside' && this.label.length > 0 && (
+                    <span class="sdds-dropdown-label-inside">{this.label}</span>
+                  )}
                   <span
                     class={`sdds-dropdown-label-main ${
                       (this.selectedLabel.length === 0 || (this.labelPosition === 'inside' && this.label.length > 0)) && 'sdds-dropdown-placeholder'
@@ -331,10 +328,11 @@ export class Dropdown {
                         {this.selectedLabelsArray.toString().length > 0 && this.selectedLabelsArray.toString().split(',').join(', ')}
                       </span>
                     )}
+                    {!this.selectedLabel && this.labelPosition === 'inside' && this.label}
 
                     {!this.selectedLabel && this.type !== 'multiselect' && this.labelPosition !== 'inside' && this.placeholder}
 
-                    {!this.selectedLabel && this.labelPosition === 'inside' && this.placeholder}
+                    {!this.selectedLabel && this.size === 'sm' && this.labelPosition === 'inside' && this.placeholder}
                   </span>
                 </span>
               )}

--- a/tegel/src/components/dropdown/readme.md
+++ b/tegel/src/components/dropdown/readme.md
@@ -13,11 +13,11 @@
 | `inline`         | `inline`          | Set to true to make the width following the label text length                                                      | `boolean`                                                | `false`      |
 | `label`          | `label`           | Label text for label inside & outside                                                                              | `string`                                                 | `undefined`  |
 | `labelPosition`  | `label-position`  | Controls position of label                                                                                         | `"inside" \| "no-label" \| "outside"`                    | `'no-label'` |
-| `placeholder`    | `placeholder`     | Placeholder text for dropdown with no selectedLabel item 2                                                         | `string`                                                 | `undefined`  |
+| `placeholder`    | `placeholder`     | Placeholder text for dropdown with no selectedLabel item                                                           | `string`                                                 | `undefined`  |
 | `selectedOption` | `selected-option` | Add the value of the option as string to set it as new selected value                                              | `string`                                                 | `undefined`  |
 | `size`           | `size`            | Controls the size of dropdown. 'sm', 'md' and 'lg' correct values and 'small', 'medium' and 'large' are deprecated | `"large" \| "lg" \| "md" \| "medium" \| "sm" \| "small"` | `'lg'`       |
 | `state`          | `state`           | Support `error` state                                                                                              | `string`                                                 | `'default'`  |
-| `type`           | `type`            | Controls type of dropdown. 'Default', 'multiselect' and 'filter' are correct values                                | `"default" \| "filter" \| "multiselect"`                 | `'default'`  |
+| `type`           | `type`            | `Controls type of dropdown. 'Default', 'multiselect' and 'filter' are correct values                               | `"default" \| "filter" \| "multiselect"`                 | `'default'`  |
 
 
 ## Events
@@ -31,7 +31,7 @@
 
 ### `resetOption() => Promise<void>`
 
-Use this method to reset the dropdown. Then it will go back to its initial state.
+
 
 #### Returns
 


### PR DESCRIPTION
**Describe pull-request**
Dropdown with label inside is not rendering the label properly when no option is selected. Not changed for new Tegel components yet

**Solving issue**
Github issue https://github.com/scania-digital-design-system/sdds/issues/440 and Azure ticket [AB#2321](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2321)

**How to test**

- Go to storybook
- Check dropdown label inside and see if it looks correct