### PR TITLE
fix(textarea/textfield): migrate textarea textfield component improvements

### DIFF
--- a/tegel/src/components/textarea/readme.md
+++ b/tegel/src/components/textarea/readme.md
@@ -5,22 +5,22 @@
 
 ## Properties
 
-| Property        | Attribute        | Description                                               | Type                     | Default      |
-| --------------- | ---------------- | --------------------------------------------------------- | ------------------------ | ------------ |
-| `autofocus`     | `autofocus`      | Control of autofocus                                      | `boolean`                | `false`      |
-| `cols`          | `cols`           | Textarea cols attribute                                   | `number`                 | `undefined`  |
-| `disabled`      | `disabled`       | Set input in disabled state                               | `boolean`                | `false`      |
-| `helper`        | `helper`         | Helper text                                               | `string`                 | `''`         |
-| `label`         | `label`          | Label text                                                | `string`                 | `''`         |
-| `labelPosition` | `label-position` | Label position: `no-label` (default), `inside`, `outside` | `string`                 | `'no-label'` |
-| `maxlength`     | `maxlength`      | Max length of input                                       | `number`                 | `undefined`  |
-| `name`          | `name`           | Name attribute                                            | `string`                 | `''`         |
-| `placeholder`   | `placeholder`    | Placeholder text                                          | `string`                 | `''`         |
-| `readonly`      | `readonly`       | Set input in readonly state                               | `boolean`                | `false`      |
-| `rows`          | `rows`           | Textarea rows attribute                                   | `number`                 | `undefined`  |
-| `state`         | `state`          | Error state of input                                      | `string`                 | `undefined`  |
-| `value`         | `value`          | Value of the input text                                   | `string`                 | `''`         |
-| `variant`       | `variant`        | Variant of the textarea                                   | `"default" \| "variant"` | `'default'`  |
+| Property        | Attribute        | Description                                               | Type                      | Default      |
+| --------------- | ---------------- | --------------------------------------------------------- | ------------------------- | ------------ |
+| `autofocus`     | `autofocus`      | Control of autofocus                                      | `boolean`                 | `false`      |
+| `cols`          | `cols`           | Textarea cols attribute                                   | `number`                  | `undefined`  |
+| `disabled`      | `disabled`       | Set input in disabled state                               | `boolean`                 | `false`      |
+| `helper`        | `helper`         | Helper text                                               | `string`                  | `''`         |
+| `label`         | `label`          | Label text                                                | `string`                  | `''`         |
+| `labelPosition` | `label-position` | Label position: `no-label` (default), `inside`, `outside` | `string`                  | `'no-label'` |
+| `maxlength`     | `maxlength`      | Max length of input                                       | `number`                  | `undefined`  |
+| `name`          | `name`           | Name attribute                                            | `string`                  | `''`         |
+| `placeholder`   | `placeholder`    | Placeholder text                                          | `string`                  | `''`         |
+| `readonly`      | `readonly`       | Set input in readonly state                               | `boolean`                 | `false`      |
+| `rows`          | `rows`           | Textarea rows attribute                                   | `number`                  | `undefined`  |
+| `state`         | `state`          | Error state of input                                      | `string`                  | `undefined`  |
+| `value`         | `value`          | Value of the input text                                   | `string`                  | `''`         |
+| `variant`       | `variant`        | Variant of the textarea                                   | `"on-dark" \| "on-light"` | `'on-light'` |
 
 
 ## Events

--- a/tegel/src/components/textarea/textarea.stories.js
+++ b/tegel/src/components/textarea/textarea.stories.js
@@ -22,6 +22,9 @@ export default {
       control: {
         type: 'boolean',
       },
+      table: {
+        defaultValue: { summary: false },
+      },
       defaultValue: false,
     },
     readonly: {
@@ -29,6 +32,9 @@ export default {
       name: 'Read only',
       control: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
       },
       defaultValue: false,
     },
@@ -90,6 +96,9 @@ export default {
         options: { 'On light': 'on-light', 'On dark': 'on-dark' },
       },
       defaultValue: 'on-light',
+      table: {
+        defaultValue: { summary: 'on-light' },
+      },
     },
   },
 };

--- a/tegel/src/components/textarea/textarea.stories.js
+++ b/tegel/src/components/textarea/textarea.stories.js
@@ -45,9 +45,9 @@ export default {
       name: 'Label position',
       control: {
         type: 'radio',
-        options: ['No label', 'Inside', 'Outside'],
+        options: { 'No label': 'no-label', 'Inside': 'inside', 'Outside': 'outside' },
       },
-      defaultValue: 'No label',
+      defaultValue: 'no-label',
     },
     helper: {
       name: 'Helper text',
@@ -78,40 +78,25 @@ export default {
       description: 'Switch between success or error state',
       control: {
         type: 'radio',
-        options: ['None', 'Success', 'Error'],
+        options: { None: 'none', Success: 'success', Error: 'error' },
       },
-      defaultValue: 'None',
+      defaultValue: 'none',
     },
     variant: {
       name: 'Variant',
       description: 'The variant of the textarea',
       control: {
         type: 'radio',
-        options: ['Default', 'Variant'],
+        options: { 'On light': 'on-light', 'On dark': 'on-dark' },
       },
-      defaultValue: 'Default',
+      defaultValue: 'on-light',
     },
   },
 };
 
 const Template = ({ placeholder, disabled, readonly, label, labelPosition, state, helper, textcounter, rows, variant }) => {
   const maxlength = textcounter > 0 ? `maxlength="${textcounter}"` : '';
-  const variantValue = variant === 'Variant' ? 'variant' : 'default';
-  const stateValue = state.toLowerCase();
-  let labelPositionValue;
-  switch (labelPosition) {
-    case 'No label':
-      labelPositionValue = 'no-label';
-      break;
-    case 'Inside':
-      labelPositionValue = 'inside';
-      break;
-    case 'Outside':
-      labelPositionValue = 'outside';
-      break;
-    default:
-      labelPositionValue = 'no-label';
-  }
+
   return formatHtmlPreview(`
   <style>
     .demo-wrapper {
@@ -121,11 +106,11 @@ const Template = ({ placeholder, disabled, readonly, label, labelPosition, state
   <div class="demo-wrapper">
         <sdds-textarea
           rows="${rows}"
-          state="${stateValue}"
+          state="${state}"
           label="${label}"
-          variant="${variantValue}"
+          variant="${variant}"
           helper="${helper}"
-          label-position="${labelPositionValue}"
+          label-position="${labelPosition}"
           ${disabled ? 'disabled' : ''}
           ${readonly ? 'readonly' : ''}
           placeholder="${placeholder}"

--- a/tegel/src/components/textarea/textarea.tsx
+++ b/tegel/src/components/textarea/textarea.tsx
@@ -46,7 +46,7 @@ export class Textarea {
   @Prop() maxlength: number;
 
   /** Variant of the textarea */
-  @Prop() variant: 'default' | 'variant' = 'default';
+  @Prop() variant: 'on-light' | 'on-dark' = 'on-light';
 
   /** Control of autofocus */
   @Prop() autofocus: boolean = false;
@@ -86,7 +86,7 @@ export class Textarea {
         ${this.focusInput ? 'sdds-textarea-focus' : ''}
         ${this.disabled ? 'sdds-textarea-disabled' : ''}
         ${this.readonly ? 'sdds-textarea-readonly' : ''}
-        ${this.variant === 'default' ? '' : 'sdds-on-white-bg'}
+        ${this.variant === 'on-light' ? '' : 'sdds-on-white-bg'}
         ${this.value.length > 0 ? 'sdds-textarea-data' : ''}
         ${this.state == 'error' || this.state == 'success' ? `sdds-textarea-${this.state}` : ''}
         `}

--- a/tegel/src/components/textfield/readme.md
+++ b/tegel/src/components/textfield/readme.md
@@ -5,21 +5,21 @@
 
 ## Properties
 
-| Property      | Attribute      | Description                                 | Type                     | Default     |
-| ------------- | -------------- | ------------------------------------------- | ------------------------ | ----------- |
-| `autofocus`   | `autofocus`    | Autofocus for input                         | `boolean`                | `false`     |
-| `disabled`    | `disabled`     | Set input in disabled state                 | `boolean`                | `false`     |
-| `labelInside` | `label-inside` | Label that will be put inside the input     | `string`                 | `''`        |
-| `maxlength`   | `maxlength`    | Max length of input                         | `number`                 | `undefined` |
-| `name`        | `name`         | Name property                               | `string`                 | `''`        |
-| `nominwidth`  | `nominwidth`   | With setting                                | `boolean`                | `false`     |
-| `placeholder` | `placeholder`  | Placeholder text                            | `string`                 | `''`        |
-| `readonly`    | `readonly`     | Set input in readonly state                 | `boolean`                | `false`     |
-| `size`        | `size`         | Size of the input                           | `"lg" \| "md" \| "sm"`   | `'lg'`      |
-| `state`       | `state`        | Error state of input                        | `string`                 | `undefined` |
-| `type`        | `type`         | Which input type, text, password or similar | `string`                 | `'text'`    |
-| `value`       | `value`        | Value of the input text                     | `string`                 | `''`        |
-| `variant`     | `variant`      | Variant of the textfield                    | `"default" \| "variant"` | `'default'` |
+| Property      | Attribute      | Description                                 | Type                      | Default      |
+| ------------- | -------------- | ------------------------------------------- | ------------------------- | ------------ |
+| `autofocus`   | `autofocus`    | Autofocus for input                         | `boolean`                 | `false`      |
+| `disabled`    | `disabled`     | Set input in disabled state                 | `boolean`                 | `false`      |
+| `labelInside` | `label-inside` | Label that will be put inside the input     | `string`                  | `''`         |
+| `maxlength`   | `maxlength`    | Max length of input                         | `number`                  | `undefined`  |
+| `name`        | `name`         | Name property                               | `string`                  | `''`         |
+| `nominwidth`  | `nominwidth`   | With setting                                | `boolean`                 | `false`      |
+| `placeholder` | `placeholder`  | Placeholder text                            | `string`                  | `''`         |
+| `readonly`    | `readonly`     | Set input in readonly state                 | `boolean`                 | `false`      |
+| `size`        | `size`         | Size of the input                           | `"lg" \| "md" \| "sm"`    | `'lg'`       |
+| `state`       | `state`        | Error state of input                        | `string`                  | `undefined`  |
+| `type`        | `type`         | Which input type, text, password or similar | `string`                  | `'text'`     |
+| `value`       | `value`        | Value of the input text                     | `string`                  | `''`         |
+| `variant`     | `variant`      | Variant of the textfield                    | `"on-dark" \| "on-light"` | `'on-light'` |
 
 
 ## Events

--- a/tegel/src/components/textfield/textfield.stories.js
+++ b/tegel/src/components/textfield/textfield.stories.js
@@ -21,7 +21,7 @@ export default {
       description: 'Which type of textfield',
       control: {
         type: 'radio',
-        options: ['password', 'text'],
+        options: { Password: 'password', Text: 'text' },
       },
       defaultValue: 'text',
     },
@@ -32,7 +32,7 @@ export default {
         type: 'radio',
         options: { Large: 'lg', Medium: 'md', Small: 'sm' },
       },
-      defaultValue: 'Large',
+      defaultValue: 'lg',
     },
     minWidth: {
       name: 'Min width',

--- a/tegel/src/components/textfield/textfield.stories.js
+++ b/tegel/src/components/textfield/textfield.stories.js
@@ -30,7 +30,7 @@ export default {
       description: 'Switch between different sizes',
       control: {
         type: 'radio',
-        options: ['Large', 'Medium', 'Small'],
+        options: { Large: 'lg', Medium: 'md', Small: 'sm' },
       },
       defaultValue: 'Large',
     },
@@ -39,9 +39,9 @@ export default {
       description: 'Toggle min width',
       control: {
         type: 'radio',
-        options: ['Default', 'No min width'],
+        options: { 'Default': 'default', 'No min width': 'nomin' },
       },
-      defaultValue: 'Default',
+      defaultValue: 'default',
     },
     disabled: {
       description: 'Set textfield to disabled state',
@@ -96,7 +96,7 @@ export default {
       description: 'Switch between success or error state',
       control: {
         type: 'radio',
-        options: ['None', 'Success', 'Error'],
+        options: { None: 'none', Success: 'success', Error: 'error' },
       },
       defaultValue: 'none',
     },
@@ -105,55 +105,35 @@ export default {
       description: 'The variant of the textarea',
       control: {
         type: 'radio',
-        options: ['Default', 'Variant'],
+        options: { 'On light': 'on-light', 'On dark': 'on-dark' },
       },
-      defaultValue: 'Default',
+      defaultValue: 'on-light',
     },
   },
 };
 
 const Template = ({ type, placeholderText, size, minWidth, disabled, readonly, label, labelplacement, state, variant, helper, prefix, suffix, icon, textcounter }) => {
   const maxlength = textcounter > 0 ? `maxlength="${textcounter}"` : '';
-  const variantValue = variant === 'Variant' ? 'variant' : 'default';
-  const stateValue = state.toLowerCase();
-
-  let sizeValue;
-  switch (size) {
-    case 'Small':
-      sizeValue = 'sm';
-      break;
-    case 'Medium':
-      sizeValue = 'md';
-      break;
-    case 'Large':
-      sizeValue = 'lg';
-      break;
-    default:
-      sizeValue = 'lg';
-      break;
-  }
-  let minWidthValue = false;
-  switch (minWidth) {
-    case 'No min width':
-      minWidthValue = true;
-      break;
-    default:
-      break;
-  }
 
   return formatHtmlPreview(
     `
-  <div style="width: 208px">
+    <style>
+      .demo-wrapper {
+        width: 200px;
+      }
+
+    </style>
+  <div class="demo-wrapper">
     <sdds-textfield
       type="${type}"
-      size="${sizeValue}"
-      state="${stateValue}"
-      variant="${variantValue}"
+      size="${size}"
+      state="${state}"
+      variant="${variant}"
       ${maxlength}
       ${label && labelplacement ? `label-inside="${label}"` : ''}
       ${disabled ? 'disabled' : ''}
       ${readonly ? 'readonly' : ''}
-      ${minWidthValue ? 'noMinWidth' : ''}
+      ${minWidth === 'nomin' ? 'nominwidth="true"' : ''}
       placeholder="${placeholderText}" >
         ${prefix ? `${prefix}` : ''}
         ${label && !labelplacement ? `<label slot='sdds-label'>${label}</label>` : ''}

--- a/tegel/src/components/textfield/textfield.stories.js
+++ b/tegel/src/components/textfield/textfield.stories.js
@@ -24,6 +24,9 @@ export default {
         options: { Password: 'password', Text: 'text' },
       },
       defaultValue: 'text',
+      table: {
+        defaultValue: { summary: 'text' },
+      },
     },
     size: {
       name: 'Size',
@@ -33,6 +36,9 @@ export default {
         options: { Large: 'lg', Medium: 'md', Small: 'sm' },
       },
       defaultValue: 'lg',
+      table: {
+        defaultValue: { summary: 'lg' },
+      },
     },
     minWidth: {
       name: 'Min width',
@@ -50,6 +56,9 @@ export default {
         type: 'boolean',
       },
       defaultValue: false,
+      table: {
+        defaultValue: { summary: false },
+      },
     },
     readonly: {
       description: 'Set textfield to read only',
@@ -58,6 +67,9 @@ export default {
         type: 'boolean',
       },
       defaultValue: false,
+      table: {
+        defaultValue: { summary: false },
+      },
     },
     label: {
       description: 'Label text for specific textfield',
@@ -74,6 +86,9 @@ export default {
         type: 'boolean',
       },
       defaultValue: false,
+      table: {
+        defaultValue: { summary: false },
+      },
     },
     helper: {
       name: 'Helper text',

--- a/tegel/src/components/textfield/textfield.tsx
+++ b/tegel/src/components/textfield/textfield.tsx
@@ -31,7 +31,7 @@ export class Textfield {
   @Prop() size: 'sm' | 'md' | 'lg' = 'lg';
 
   /** Variant of the textfield */
-  @Prop() variant: 'default' | 'variant' = 'default';
+  @Prop() variant: 'on-light' | 'on-dark' = 'on-light';
 
   /** With setting */
   @Prop() nominwidth: boolean = false;
@@ -92,7 +92,7 @@ export class Textfield {
         ${this.labelInside.length > 0 && this.size !== 'sm' ? 'sdds-textfield-container-label-inside' : ''}
         ${this.disabled ? 'sdds-form-textfield-disabled' : ''}
         ${this.readonly ? 'sdds-form-textfield-readonly' : ''}
-        ${this.variant === 'default' ? '' : 'sdds-on-white-bg'}
+        ${this.variant === 'on-light' ? 'sdds-on-white-bg' : ''}
         ${this.size === 'md' ? 'sdds-form-textfield-md' : ''}
         ${this.size === 'sm' ? 'sdds-form-textfield-sm' : ''}
         ${this.state === 'error' || this.state === 'success' ? `sdds-form-textfield-${this.state}` : ''}


### PR DESCRIPTION
## `🚧 SHOULD NOT BE MERGED UNTIL VARIANT/ON-LIGHT/ON-DARK HAS BEEN DECIDED 🚧`

**Describe pull-request**  
This PR further improves the migration of the textarea/textfield components. The stories controls are improved and also the variant prop is aligned with other component. This does result in a breaking change, since the props have been changed to on-light/on-dark. 

**Solving issue**  
Fixes: -

**How to test**  
_Add description how to test if possible_
1. Go to storybook link below.
2. Check in components -> textarea/textfield
3. Test the controls and check that the design is aligned with the one in Figma. 

**Screenshots**  
-

**Additional context**  
-
