### PR TITLE
fix(textarea/textfield): handle-null-values-textfield/textarea

### DIFF
--- a/components/src/components/textarea/readme.md
+++ b/components/src/components/textarea/readme.md
@@ -19,7 +19,7 @@
 | `readonly`      | `readonly`       | Set input in readonly state                               | `boolean` | `false`      |
 | `rows`          | `rows`           | Textarea rows attribute                                   | `number`  | `undefined`  |
 | `state`         | `state`          | Error state of input                                      | `string`  | `undefined`  |
-| `value`         | `value`          | Value of the input text                                   | `string`  | `''`         |
+| `value`         | `value`          | Value of the input text                                   | `string`  | `null`       |
 
 
 ## Events

--- a/components/src/components/textarea/textarea.tsx
+++ b/components/src/components/textarea/textarea.tsx
@@ -31,7 +31,7 @@ export class Textarea {
   @Prop() placeholder: string = '';
 
   /** Value of the input text */
-  @Prop() value = '';
+  @Prop() value: string = null;
 
   /** Set input in disabled state */
   @Prop() disabled: boolean = false;
@@ -83,7 +83,7 @@ export class Textarea {
         ${this.focusInput ? 'sdds-textarea-focus' : ''}
         ${this.disabled ? 'sdds-textarea-disabled' : ''}
         ${this.readonly ? 'sdds-textarea-readonly' : ''}
-        ${this.value.length > 0 ? 'sdds-textarea-data' : ''}
+        ${this.value ? 'sdds-textarea-data' : ''}
         ${
           this.state == 'error' || this.state == 'success'
             ? `sdds-textarea-${this.state}`
@@ -169,7 +169,7 @@ export class Textarea {
         )}
         {this.maxlength > 0 && (
           <div class={'sdds-textarea-textcounter'}>
-            {this.value.length}{' '}
+            {this.value}{' '}
             <span class="sdds-textfield-textcounter-divider"> / </span>{' '}
             {this.maxlength}
           </div>

--- a/components/src/components/textarea/textarea.tsx
+++ b/components/src/components/textarea/textarea.tsx
@@ -169,7 +169,7 @@ export class Textarea {
         )}
         {this.maxlength > 0 && (
           <div class={'sdds-textarea-textcounter'}>
-            {this.value}{' '}
+            {this.value?.length}{' '}
             <span class="sdds-textfield-textcounter-divider"> / </span>{' '}
             {this.maxlength}
           </div>

--- a/components/src/components/textfield/readme.md
+++ b/components/src/components/textfield/readme.md
@@ -5,20 +5,20 @@
 
 ## Properties
 
-| Property      | Attribute      | Description                                 | Type                 | Default     |
-| ------------- | -------------- | ------------------------------------------- | -------------------- | ----------- |
-| `autofocus`   | `autofocus`    | Autofocus for input                         | `boolean`            | `false`     |
-| `disabled`    | `disabled`     | Set input in disabled state                 | `boolean`            | `false`     |
-| `labelInside` | `label-inside` | Label that will be put inside the input     | `string`             | `''`        |
-| `maxlength`   | `maxlength`    | Max length of input                         | `number`             | `undefined` |
-| `name`        | `name`         | Name property                               | `string`             | `''`        |
-| `nominwidth`  | `nominwidth`   | With setting                                | `boolean`            | `false`     |
-| `placeholder` | `placeholder`  | Placeholder text                            | `string`             | `''`        |
-| `readonly`    | `readonly`     | Set input in readonly state                 | `boolean`            | `false`     |
-| `size`        | `size`         | Size of the input                           | `"" \| "md" \| "sm"` | `''`        |
-| `state`       | `state`        | Error state of input                        | `string`             | `undefined` |
-| `type`        | `type`         | Which input type, text, password or similar | `string`             | `'text'`    |
-| `value`       | `value`        | Value of the input text                     | `string`             | `''`        |
+| Property      | Attribute      | Description                                 | Type                   | Default     |
+| ------------- | -------------- | ------------------------------------------- | ---------------------- | ----------- |
+| `autofocus`   | `autofocus`    | Autofocus for input                         | `boolean`              | `false`     |
+| `disabled`    | `disabled`     | Set input in disabled state                 | `boolean`              | `false`     |
+| `labelInside` | `label-inside` | Label that will be put inside the input     | `string`               | `''`        |
+| `maxlength`   | `maxlength`    | Max length of input                         | `number`               | `undefined` |
+| `name`        | `name`         | Name property                               | `string`               | `''`        |
+| `nominwidth`  | `nominwidth`   | With setting                                | `boolean`              | `false`     |
+| `placeholder` | `placeholder`  | Placeholder text                            | `string`               | `''`        |
+| `readonly`    | `readonly`     | Set input in readonly state                 | `boolean`              | `false`     |
+| `size`        | `size`         | Size of the input                           | `"" \| "md" \| "sm"`   | `''`        |
+| `state`       | `state`        | Error state of input                        | `string`               | `undefined` |
+| `type`        | `type`         | Which input type, text, password or similar | `"password" \| "text"` | `'text'`    |
+| `value`       | `value`        | Value of the input text                     | `string`               | `null`      |
 
 
 ## Events

--- a/components/src/components/textfield/textfield.tsx
+++ b/components/src/components/textfield/textfield.tsx
@@ -215,7 +215,7 @@ export class Textfield {
 
           {this.maxlength > 0 && (
             <div class="sdds-textfield-textcounter">
-              {this.value}
+              {this.value?.length}
               <span class="sdds-textfield-textcounter-divider"> / </span>
               {this.maxlength}
             </div>

--- a/components/src/components/textfield/textfield.tsx
+++ b/components/src/components/textfield/textfield.tsx
@@ -10,7 +10,7 @@ export class Textfield {
   textInput?: HTMLInputElement;
 
   /** Which input type, text, password or similar */
-  @Prop({ reflect: true }) type: string = 'text';
+  @Prop({ reflect: true }) type: 'text' | 'password' = 'text';
 
   /** Label that will be put inside the input */
   @Prop() labelInside: string = '';
@@ -19,7 +19,7 @@ export class Textfield {
   @Prop() placeholder: string = '';
 
   /** Value of the input text */
-  @Prop({ reflect: true }) value = '';
+  @Prop({ reflect: true }) value: string = null;
 
   /** Set input in disabled state */
   @Prop() disabled: boolean = false;
@@ -89,7 +89,7 @@ export class Textfield {
             ? 'sdds-form-textfield sdds-textfield-focus'
             : ' sdds-form-textfield'
         }
-        ${this.value.length > 0 ? 'sdds-textfield-data' : ''}
+        ${this.value ? 'sdds-textfield-data' : ''}
         ${
           this.labelInside.length > 0 && this.size !== 'sm'
             ? 'sdds-textfield-container-label-inside'
@@ -215,7 +215,7 @@ export class Textfield {
 
           {this.maxlength > 0 && (
             <div class="sdds-textfield-textcounter">
-              {this.value.length}
+              {this.value}
               <span class="sdds-textfield-textcounter-divider"> / </span>
               {this.maxlength}
             </div>


### PR DESCRIPTION
**Describe pull-request**  
A bug was found where to textarea/textfield components would not render in case they had null as their value. This is solved by instead adding a type to this value prop of string. This PR also updated the type-prop of the textfield component to expect 'text' or 'password'.

**Solving issue**  
Fixes: #526

**How to test**  
_Add description how to test if possible_
1. Go to storybook link below
2. Check in componets -> textarea/textfield
3. Check that the component renders even though value is initially set to null. 

**Screenshots**  
-

**Additional context**  
-
