### PR TITLE
fix(textarea/textfield):textarea/field to handle null values for tegel

### DIFF
--- a/tegel/src/components/textarea/readme.md
+++ b/tegel/src/components/textarea/readme.md
@@ -19,7 +19,7 @@
 | `readonly`      | `readonly`       | Set input in readonly state                               | `boolean`                | `false`      |
 | `rows`          | `rows`           | Textarea rows attribute                                   | `number`                 | `undefined`  |
 | `state`         | `state`          | Error state of input                                      | `string`                 | `undefined`  |
-| `value`         | `value`          | Value of the input text                                   | `string`                 | `''`         |
+| `value`         | `value`          | Value of the input text                                   | `string`                 | `null`       |
 | `variant`       | `variant`        | Variant of the textarea                                   | `"default" \| "variant"` | `'default'`  |
 
 

--- a/tegel/src/components/textarea/textarea.tsx
+++ b/tegel/src/components/textarea/textarea.tsx
@@ -31,7 +31,7 @@ export class Textarea {
   @Prop() placeholder: string = '';
 
   /** Value of the input text */
-  @Prop() value = '';
+  @Prop() value: string = null;
 
   /** Set input in disabled state */
   @Prop() disabled: boolean = false;
@@ -87,7 +87,7 @@ export class Textarea {
         ${this.disabled ? 'sdds-textarea-disabled' : ''}
         ${this.readonly ? 'sdds-textarea-readonly' : ''}
         ${this.variant === 'default' ? '' : 'sdds-on-white-bg'}
-        ${this.value.length > 0 ? 'sdds-textarea-data' : ''}
+        ${this.value ? 'sdds-textarea-data' : ''}
         ${this.state == 'error' || this.state == 'success' ? `sdds-textarea-${this.state}` : ''}
         `}
         onClick={() => this.handleFocusClick()}
@@ -150,7 +150,7 @@ export class Textarea {
         {this.helper.length > 0 && <span class={'sdds-textarea-helper'}>{this.helper}</span>}
         {this.maxlength > 0 && (
           <div class={'sdds-textarea-textcounter'}>
-            {this.value.length} <span class="sdds-textfield-textcounter-divider"> / </span> {this.maxlength}
+            {this.value?.length} <span class="sdds-textfield-textcounter-divider"> / </span> {this.maxlength}
           </div>
         )}
       </div>

--- a/tegel/src/components/textfield/readme.md
+++ b/tegel/src/components/textfield/readme.md
@@ -17,8 +17,8 @@
 | `readonly`    | `readonly`     | Set input in readonly state                 | `boolean`                | `false`     |
 | `size`        | `size`         | Size of the input                           | `"lg" \| "md" \| "sm"`   | `'lg'`      |
 | `state`       | `state`        | Error state of input                        | `string`                 | `undefined` |
-| `type`        | `type`         | Which input type, text, password or similar | `string`                 | `'text'`    |
-| `value`       | `value`        | Value of the input text                     | `string`                 | `''`        |
+| `type`        | `type`         | Which input type, text, password or similar | `"password" \| "text"`   | `'text'`    |
+| `value`       | `value`        | Value of the input text                     | `string`                 | `null`      |
 | `variant`     | `variant`      | Variant of the textfield                    | `"default" \| "variant"` | `'default'` |
 
 

--- a/tegel/src/components/textfield/textfield.tsx
+++ b/tegel/src/components/textfield/textfield.tsx
@@ -10,7 +10,7 @@ export class Textfield {
   textInput?: HTMLInputElement;
 
   /** Which input type, text, password or similar */
-  @Prop({ reflect: true }) type: string = 'text';
+  @Prop({ reflect: true }) type: 'text' | 'password' = 'text';
 
   /** Label that will be put inside the input */
   @Prop() labelInside: string = '';
@@ -19,7 +19,7 @@ export class Textfield {
   @Prop() placeholder: string = '';
 
   /** Value of the input text */
-  @Prop({ reflect: true }) value = '';
+  @Prop({ reflect: true }) value: string = null;
 
   /** Set input in disabled state */
   @Prop() disabled: boolean = false;
@@ -88,7 +88,7 @@ export class Textfield {
         class={`
         ${this.nominwidth ? 'sdds-form-textfield-nomin' : ''}
         ${this.focusInput && !this.disabled ? 'sdds-form-textfield sdds-textfield-focus' : ' sdds-form-textfield'}
-        ${this.value.length > 0 ? 'sdds-textfield-data' : ''}
+        ${this.value ? 'sdds-textfield-data' : ''}
         ${this.labelInside.length > 0 && this.size !== 'sm' ? 'sdds-textfield-container-label-inside' : ''}
         ${this.disabled ? 'sdds-form-textfield-disabled' : ''}
         ${this.readonly ? 'sdds-form-textfield-readonly' : ''}
@@ -182,7 +182,7 @@ export class Textfield {
 
           {this.maxlength > 0 && (
             <div class="sdds-textfield-textcounter">
-              {this.value.length}
+              {this.value?.length}
               <span class="sdds-textfield-textcounter-divider"> / </span>
               {this.maxlength}
             </div>


### PR DESCRIPTION
This PR updates tegel with updates Tegel to solve a bug that was found in 4_10.0.

PR that has been merged in 4_10.0: https://github.com/scania-digital-design-system/sdds/pull/557

**Describe pull-request**  
Enables textarea/textfield to handle null as a value. This also updates the type for the type-prop for the textfield. 

**Solving issue**  
Fixes: -

**How to test**  
1. Go to storybook link below
2. Check in components -> textfield/textarea
3. Check that the components renders with null as a value. 

**Screenshots**  
-

**Additional context**  
-
