### PR TITLE
fix(textfield): display flex on sdds-helper to avoid clash between slot and char counter

### DIFF
--- a/tegel/src/components/textfield/textfield.scss
+++ b/tegel/src/components/textfield/textfield.scss
@@ -266,7 +266,8 @@
 .sdds-textfield-helper {
   font: var(--sdds-detail-05);
   letter-spacing: var(--sdds-detail-05-ls);
-  display: block;
+  display: flex;
+  justify-content: space-between;
   flex-basis: 100%;
   padding-top: var(--sdds-spacing-element-4);
   color: var(--sdds-textfield-helper);


### PR DESCRIPTION
This PR updates tegel with updates Tegel to solve a bug that was found in 4_10.0.
PR that has been merged in 4_10.0: https://github.com/scania-digital-design-system/sdds/pull/543

**Describe pull-request**  
Changed the sdds-textfield-helper to display flex and justify-content:between to allow for both the slot, error state and char counter to fit on the same row.

**Solving issue**  
Fixes: -

**How to test**  
_Add description how to test if possible_
 1. Go to storybook link below
 2. Add a helper text on textfield, state to error and set a number on the char count.
 3. Check that all of these elements can be on the same row.

**Screenshots**  
Before: 
<img width="897" alt="1" src="https://user-images.githubusercontent.com/62651103/199510859-952deb85-9dbd-4af3-b6a5-c4afe020363f.png">


After:
<img width="914" alt="2" src="https://user-images.githubusercontent.com/62651103/199510712-94164555-d3a2-4963-88cd-17c719f193de.png">

**Additional context**  
-