### PR TITLE
fix(inline-tabs): make inline tabs html compliant

### DIFF
--- a/components/src/components/tabs/inline-tabs/inline-tabs.stories.js
+++ b/components/src/components/tabs/inline-tabs/inline-tabs.stories.js
@@ -34,7 +34,7 @@ const Template = ({ autoHeight = false }) => `
       And here is a little bit more.
     </div>
 
-    <div default data-name="Tab 2">
+    <div data-default="true" data-name="Tab 2">
       Content for tab 2<br>
       This is just a little content, but the size of the container is based to the tab with the most content.
     </div>

--- a/components/src/components/tabs/inline-tabs/inline-tabs.stories.js
+++ b/components/src/components/tabs/inline-tabs/inline-tabs.stories.js
@@ -25,7 +25,7 @@ const Template = ({ autoHeight = false }) => `
   </style>
 
   <sdds-inline-tabs ${autoHeight ? 'auto-height' : ''}>
-    <div name="Tab very long name">
+    <div data-name="Tab very long name">
       Content for tab 1<br>
       This tabs has a lot of content so this is the one that decides the height of the container if height="auto" is specified on the component.
       <br><br>
@@ -34,27 +34,27 @@ const Template = ({ autoHeight = false }) => `
       And here is a little bit more.
     </div>
 
-    <div default name="Tab 2">
+    <div default data-name="Tab 2">
       Content for tab 2<br>
       This is just a little content, but the size of the container is based to the tab with the most content.
     </div>
 
-    <div disabled name="Tab 3">
+    <div aria-disabled="true" data-name="Tab 3">
       Content for tab 3<br>
       This tab is disabled, so you should not be able to see this content.
     </div>
 
-    <div name="Tab 4">
+    <div data-name="Tab 4">
       Content for tab 4<br>
       here is some content...
     </div>
 
-    <div name="Tab 5">
+    <div data-name="Tab 5">
       Content for tab 5<br>
       here is some content...
     </div>
 
-    <div name="Tab 6">
+    <div data-name="Tab 6">
       Content for tab 6<br>
       here is some content...
     </div>

--- a/components/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/components/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -78,7 +78,9 @@ export class InlineTabs {
         ? item.dataset.name
         : item.getAttribute('name') || `Tab ${index + 1}`;
 
-      let key = item.dataset.tabKey;
+      let key = item.dataset.tabKey
+        ? item.dataset.tabKey
+        : item.getAttribute('tab-key');
       if (!key) {
         key = this._generateKeyFromName(name);
       }

--- a/components/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/components/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -87,18 +87,18 @@ export class InlineTabs {
 
       //TODO - why doesn't dataset.default work here?
       if (
-        item.getAttribute('data-default')
+        (item.getAttribute('data-default')
           ? item.getAttribute('data-default')
-          : item.getAttribute('default') !== null
+          : item.getAttribute('default')) !== null
       ) {
         this.startingTab = key;
       }
 
       let disabled = false;
       if (
-        item.getAttribute('aria-disabled')
+        (item.getAttribute('aria-disabled')
           ? item.getAttribute('data-disabled')
-          : item.getAttribute('disabled') !== null
+          : item.getAttribute('disabled')) !== null
       ) {
         disabled = true;
       }

--- a/components/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/components/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -74,7 +74,9 @@ export class InlineTabs {
     }
 
     Array.from(this.host.children).map((item: HTMLElement, index) => {
-      const name = item.dataset.name || `Tab ${index + 1}`;
+      const name = item.dataset.name
+        ? item.dataset.name
+        : item.getAttribute('name') || `Tab ${index + 1}`;
 
       let key = item.dataset.tabKey;
       if (!key) {
@@ -82,12 +84,20 @@ export class InlineTabs {
       }
 
       //TODO - why doesn't dataset.default work here?
-      if (item.getAttribute('data-default') !== null) {
+      if (
+        item.getAttribute('data-default')
+          ? item.getAttribute('data-default')
+          : item.getAttribute('default') !== null
+      ) {
         this.startingTab = key;
       }
 
       let disabled = false;
-      if (item.getAttribute('aria-disabled') !== null) {
+      if (
+        item.getAttribute('aria-disabled')
+          ? item.getAttribute('data-disabled')
+          : item.getAttribute('disabled') !== null
+      ) {
         disabled = true;
       }
 

--- a/components/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/components/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -74,19 +74,19 @@ export class InlineTabs {
     }
 
     Array.from(this.host.children).map((item: HTMLElement, index) => {
-      const name = item.getAttribute('name') || `Tab ${index + 1}`;
+      const name = item.dataset.name || `Tab ${index + 1}`;
 
-      let key = item.getAttribute('tab-key');
+      let key = item.dataset.tabKey;
       if (!key) {
         key = this._generateKeyFromName(name);
       }
 
-      if (item.getAttribute('default') !== null) {
+      if (item.dataset.default !== null) {
         this.startingTab = key;
       }
 
       let disabled = false;
-      if (item.getAttribute('disabled') !== null) {
+      if (item.getAttribute('aria-disabled') !== null) {
         disabled = true;
       }
 

--- a/components/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/components/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -81,7 +81,8 @@ export class InlineTabs {
         key = this._generateKeyFromName(name);
       }
 
-      if (item.dataset.default !== null) {
+      //TODO - why doesn't dataset.default work here?
+      if (item.getAttribute('data-default') !== null) {
         this.startingTab = key;
       }
 


### PR DESCRIPTION
**Describe pull-request**  
Made the component HTML compliant by making sure the inline tabs use data-name instead of name and aria-disabled="true" instead of disabled. Since the previous attributes isn't part of the global attributes we can't expects it's children to have those elements. 

https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes

**Solving issue**  
Fixes: [AB#2489](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2489)

**How to test**  
1. Check the component in the sandbox and storybook
2. Make sure it's using data-* / aria-hidden attributes
3. Check that it renders and act in the expected way. 

**Screenshots**  
-

**Additional context**  
-
