### PR TITLE
fix(inline-tabs): make inline-tabs valid html in tegel

### DIFF
--- a/tegel/src/components/tabs/inline-tabs/inline-tabs.stories.ts
+++ b/tegel/src/components/tabs/inline-tabs/inline-tabs.stories.ts
@@ -35,14 +35,14 @@ export default {
 const Template = ({ autoHeight = false, altBgColor = false }) => {
   return formatHtmlPreview(`
     <sdds-inline-tabs ${autoHeight ? 'auto-height' : ''} ${altBgColor ? 'color-variant="on-grey"' : ''}>
-      <div name="Tab with tall content">
+      <div data-name="Tab with tall content">
         Tab panel 1
         <div style="width:200px; height:200px; background: linear-gradient(125deg,rgba(255, 0, 0, 1) 0%,rgba(255, 255, 0, 1) 33%,rgba(0, 192, 255, 1) 66%,rgba(192, 0, 255, 1) 100%);"></div>
       </div>
-      <div name="Default tab" default>
+      <div data-name="Default tab" data-default="true">
         Tab panel 2
       </div>
-      <div name="Disabled tab" disabled>
+      <div data-name="Disabled tab" aria-disabled="true">
         Tab panel 3
       </div>
     </sdds-inline-tabs>

--- a/tegel/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/tegel/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -81,7 +81,7 @@ export class InlineTabs {
       }
 
       let disabled = false;
-      if ((item.getAttribute('aria-disabled') ? item.getAttribute('data-disabled') : item.getAttribute('disabled')) !== null) {
+      if ((item.getAttribute('aria-disabled') ? item.getAttribute('aria-disabled') : item.getAttribute('disabled')) !== null) {
         disabled = true;
       }
 

--- a/tegel/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/tegel/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -69,19 +69,19 @@ export class InlineTabs {
     }
 
     Array.from(this.host.children).map((item: HTMLElement, index) => {
-      const name = item.getAttribute('name') || `Tab ${index + 1}`;
+      const name = item.dataset.name ? item.dataset.name : item.getAttribute('name') || `Tab ${index + 1}`;
 
-      let key = item.getAttribute('tab-key');
+      let key = item.dataset.tabKey ? item.dataset.tabKey : item.getAttribute('tab-key');
       if (!key) {
         key = this._generateKeyFromName(name);
       }
 
-      if (item.getAttribute('default') !== null) {
+      if ((item.getAttribute('data-default') ? item.getAttribute('data-default') : item.getAttribute('default')) !== null) {
         this.startingTab = key;
       }
 
       let disabled = false;
-      if (item.getAttribute('disabled') !== null) {
+      if ((item.getAttribute('aria-disabled') ? item.getAttribute('data-disabled') : item.getAttribute('disabled')) !== null) {
         disabled = true;
       }
 


### PR DESCRIPTION
**Describe pull-request**  
Makes inline-tabs html compliant, but keeps an option of using old way aswell.

**Solving issue**  
Fixes: [AB#2493](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2493)

**How to test**  
1. Go to storybook link below.
2. Check in Components -> inline-tabs
3. Check that the component uses valid HTML.

**Screenshots**  
-

**Additional context**  
-