### PR TITLE
fix(_core.scss): duplicate color variables generated

### DIFF
--- a/theme/light/src/_core.scss
+++ b/theme/light/src/_core.scss
@@ -1,15 +1,14 @@
 /*
 Import foundation into theme components
 */
-@import '../../core/logotype/vars.scss';
-@import '../../core/typography/typography-vars.scss';
-@import '../../core/colour/tokens';
-@import '../../core/spacing/spacing';
-@import '../../core/typography/vars';
-@import '../../core/typography/selectors';
-@import '../../core/colour/vars';
-@import '../../core/spacing/spacing-vars.scss';
-@import '../../core/colour/colour';
+@import "../../core/logotype/vars.scss";
+@import "../../core/typography/typography-vars.scss";
+@import "../../core/colour/tokens";
+@import "../../core/spacing/spacing";
+@import "../../core/typography/vars";
+@import "../../core/typography/selectors";
+@import "../../core/spacing/spacing-vars.scss";
+@import "../../core/colour/colour";
 
 //TODO: remove. Old colors are not used, only imported because of old setup
-@import 'old/core/old-colors.scss';
+@import "old/core/old-colors.scss";


### PR DESCRIPTION
**Describe pull-request**  
Removed import of color.vars since it's being imported in the color.sccs. 

**Solving issue**  
Fixes: #370 [AB#1927](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/1927)

**How to test**  
_Add description how to test if possible_
1. Checkout branch and do npm linking to sdds-website
2. Run website
3. Check the css of the doc and check that the colours are only defined once.

**Screenshots**  
-

**Additional context**  
-
