### PR TITLE
feat: use two letter t-shirt sizes in class names

### DIFF
--- a/tegel/package-lock.json
+++ b/tegel/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.6",
+        "@scania/typography": "^1.2.1",
         "@stencil/core": "^2.13.0",
         "concurrently": "^7.4.0",
         "html-format": "^1.0.2"
@@ -39,7 +40,8 @@
         "storybook-dark-mode": "^1.1.2"
       },
       "engines": {
-        "node": ">=16.10"
+        "node": ">=16.10.0 <17.0.0",
+        "npm": ">=8.0.0 <9.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4128,6 +4130,11 @@
         "react": "15.x || 16.x || 16.4.0-alpha.0911da3",
         "react-dom": "15.x || 16.x || 16.4.0-alpha.0911da3"
       }
+    },
+    "node_modules/@scania/typography": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@scania/typography/-/typography-1.2.1.tgz",
+      "integrity": "sha512-iAg2rL+1b7rHkX9U9LpV+wXiTTmZBjMJoDD4luRj/2Hl7S8e5lv5teiD8aWTXBXIP7zUEAw96WtgYLDaN9Ck/Q=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -29178,6 +29185,11 @@
         "prop-types": "^15.6.1",
         "react-lifecycles-compat": "^3.0.4"
       }
+    },
+    "@scania/typography": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@scania/typography/-/typography-1.2.1.tgz",
+      "integrity": "sha512-iAg2rL+1b7rHkX9U9LpV+wXiTTmZBjMJoDD4luRj/2Hl7S8e5lv5teiD8aWTXBXIP7zUEAw96WtgYLDaN9Ck/Q=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",

--- a/tegel/src/components/chips/chips.scss
+++ b/tegel/src/components/chips/chips.scss
@@ -45,7 +45,7 @@
     }
   }
 
-  &__small {
+  &-sm {
     padding: 4px 16px;
   }
 

--- a/tegel/src/components/chips/chips.scss
+++ b/tegel/src/components/chips/chips.scss
@@ -45,7 +45,8 @@
     }
   }
 
-  &-sm {
+  &-sm,
+  &__small {
     padding: 4px 16px;
   }
 

--- a/tegel/src/components/chips/chips.stories.ts
+++ b/tegel/src/components/chips/chips.stories.ts
@@ -59,7 +59,7 @@ const Template = ({ icon, state, placeholderText, size }) => {
 
   switch (size) {
     case 'Small':
-      sizeClass = 'sdds-chip__small';
+      sizeClass = 'sdds-chip-sm';
       break;
     default:
       break;

--- a/tegel/src/components/stepper/stepper.scss
+++ b/tegel/src/components/stepper/stepper.scss
@@ -70,6 +70,7 @@
       }
     }
 
+    &.sdds-stepper-sm,
     &.sdds-stepper--small {
       .sdds-stepper__step {
         margin-bottom: 34px;
@@ -212,6 +213,7 @@
     }
   }
 
+  &-sm,
   &--small {
     .sdds-stepper__step {
       &-icon {

--- a/tegel/src/components/stepper/stepper.stories.js
+++ b/tegel/src/components/stepper/stepper.stories.js
@@ -44,7 +44,7 @@ const Template = ({ size, style, label }) => {
 
   switch (size) {
     case 'Small':
-      sizeClass = 'sdds-stepper--small';
+      sizeClass = 'sdds-stepper-sm';
       break;
     default:
       break;

--- a/tegel/src/stories/Migration/Migration.stories.mdx
+++ b/tegel/src/stories/Migration/Migration.stories.mdx
@@ -132,7 +132,7 @@ Rename all instances of `sdds-dropdown-small` and `sdds-dropdown-medium`.
 
 #### Renamed class to `sdds-stepper-sm`
 
-The class `sdds-stepper--small` was changed to `sdds-stepper-sm` to comform with other class names.
+The class `sdds-stepper--small` was changed to `sdds-stepper-sm` to conform with other class names.
 
 ##### What action is required?
 

--- a/tegel/src/stories/Migration/Migration.stories.mdx
+++ b/tegel/src/stories/Migration/Migration.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs';
 import './migration.css';
 
-<Meta title="Intro/Migration" />
+<Meta title="Intro/Migrating from components&nbsp;v4" />
 
 # Migration Docs
 
@@ -55,23 +55,47 @@ If the button is one with only an icon it needs the class 'sdds-btn-only-icon'.
 <button
     class="sdds-btn sdds-btn-primary sdds-btn-lg sdds-btn-icon"
   >
-    <sdds-icon
-      class="sdds-btn-icon"
-      size="20px"
-      name="arrow_diagonal"
-    ></sdds-icon>
-  </button>
+  <sdds-icon
+    class="sdds-btn-icon"
+    size="20px"
+    name="arrow_diagonal"
+  ></sdds-icon>
+</button>
 
 // New ✅
 <button
     class="sdds-btn sdds-btn-primary sdds-btn-lg sdds-btn-icon sdds-btn-only-icon"
   >
-    <sdds-icon
-      class="sdds-btn-icon"
-      size="20px"
-      name="arrow_diagonal"
-    ></sdds-icon>
-  </button>
+  <sdds-icon
+    class="sdds-btn-icon"
+    size="20px"
+    name="arrow_diagonal"
+  ></sdds-icon>
+</button>
+```
+
+## Chips
+
+[Native](/docs/components-chips--default)
+
+#### Renamed class to `sdds-chips-sm`
+
+The class `sdds-chips__small` was changed to `sdds-chips-sm` to comform with other class names.
+
+##### What action is required?
+
+Rename all instances of `sdds-chips__small` to `sdds-chips-sm`.
+
+```jsx
+// Old ❌
+<div class="sdds-chip sdds-chip__small">
+  <span class="sdds-chip-text">Chip text</span>
+</div>
+
+// New ✅
+<div class="sdds-chip sdds-chip-sm">
+  <span class="sdds-chip-text">Chip text</span>
+</div>
 ```
 
 ## Dropdown
@@ -99,5 +123,29 @@ Rename all instances of `sdds-dropdown-small` and `sdds-dropdown-medium`.
   <select name="nativeDropdown">
     // ...
   </select>
+</div>
+```
+
+## Stepper
+
+[Native](/docs/components-stepper--default)
+
+#### Renamed class to `sdds-stepper-sm`
+
+The class `sdds-stepper--small` was changed to `sdds-stepper-sm` to comform with other class names.
+
+##### What action is required?
+
+Rename all instances of `sdds-stepper--small` to `sdds-stepper-sm`.
+
+```jsx
+// Old ❌
+<div class="sdds-stepper sdds-stepper--small">
+  // ...
+</div>
+
+// New ✅
+<div class="sdds-stepper sdds-stepper-sm">
+  // ...
 </div>
 ```

--- a/tegel/src/stories/Migration/Migration.stories.mdx
+++ b/tegel/src/stories/Migration/Migration.stories.mdx
@@ -74,17 +74,17 @@ If the button is one with only an icon it needs the class 'sdds-btn-only-icon'.
 </button>
 ```
 
-## Chips
+## Chip
 
 [Native](/docs/components-chips--default)
 
-#### Renamed class to `sdds-chips-sm`
+#### Renamed class to `sdds-chip-sm`
 
-The class `sdds-chips__small` was changed to `sdds-chips-sm` to comform with other class names.
+The class `sdds-chip__small` was changed to `sdds-chip-sm` to comform with other class names.
 
 ##### What action is required?
 
-Rename all instances of `sdds-chips__small` to `sdds-chips-sm`.
+Rename all instances of `sdds-chip__small` to `sdds-chip-sm`.
 
 ```jsx
 // Old ❌

--- a/tegel/src/stories/Migration/Migration.stories.mdx
+++ b/tegel/src/stories/Migration/Migration.stories.mdx
@@ -100,7 +100,7 @@ Rename all instances of `sdds-chip__small` to `sdds-chip-sm`.
 
 ## Dropdown
 
-[Native](/docs/components-stepper--default)
+[Native](/docs/components-dropdown--native)
 
 #### Renamed size classes to `sdds-dropdown-sm`, and `sdds-dropdown-md`
 

--- a/tegel/src/stories/Migration/Migration.stories.mdx
+++ b/tegel/src/stories/Migration/Migration.stories.mdx
@@ -80,7 +80,7 @@ If the button is one with only an icon it needs the class 'sdds-btn-only-icon'.
 
 #### Renamed class to `sdds-chip-sm`
 
-The class `sdds-chip__small` was changed to `sdds-chip-sm` to comform with other class names.
+The class `sdds-chip__small` was changed to `sdds-chip-sm` to conform with other class names.
 
 ##### What action is required?
 


### PR DESCRIPTION
👕 
**Describe pull-request**  
Renames some classes to use two letter size keywords, like `sm` instead of `small`

**Solving issue**  
Fixes: [AB#2303](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2303)

**How to test**  
Checkout the Migration page is Storybook

