### PR TITLE
fix(dropdown): multiselect dropdown doesnt show option labels

### DIFF
--- a/tegel/src/components/dropdown/dropdown.tsx
+++ b/tegel/src/components/dropdown/dropdown.tsx
@@ -77,7 +77,7 @@ export class Dropdown {
     this.listItemArray = Array.from(this.host.children);
     this.listItemArray.map(listItem => {
       this.optionValues.push(listItem.value);
-      this.optionLabels.push(listItem.innerText);
+      this.optionLabels.push(listItem.innerText.trim());
     });
     this.setOptionFromOutside(this.defaultOption);
 
@@ -327,14 +327,14 @@ export class Dropdown {
 
                     {this.type === 'multiselect' && (
                       <span class="sdds-dropdown-multiselect-result">
-                        {this.labelPosition !== 'inside' && this.selectedLabelsArray.toString().length < 1 && this.placeholder}
+                        {this.labelPosition !== 'inside' && this.selectedLabelsArray.length < 1 && this.placeholder}
                         {this.selectedLabelsArray.toString().length > 0 && this.selectedLabelsArray.toString().split(',').join(', ')}
                       </span>
                     )}
 
                     {!this.selectedLabel && this.type !== 'multiselect' && this.labelPosition !== 'inside' && this.placeholder}
 
-                    {!this.selectedLabel && this.labelPosition === 'inside' && this.placeholder}
+                    {!this.selectedLabel && this.labelPosition === 'inside' && this.selectedLabelsArray.length < 1 && this.placeholder}
                   </span>
                 </span>
               )}


### PR DESCRIPTION
**Describe pull-request**  
 * Added a trim to the optionLabels to remove linebreaks.
 * Fixed placeholder to support inside labels on multiselect.

**Solving issue**  
Fixes: [AB#2495](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2495)

**How to test**  
1. Go to storybook link below
2. Check in Components -> Dropdown Webcomponent Multiselect
3. Check that the labels show the selected options and if nothing is selected it shows placeholder.

**Screenshots**  
-

**Additional context**  
-
