### PR TITLE
build: fix build failing on netlify

### DIFF
--- a/tegel/package-lock.json
+++ b/tegel/package-lock.json
@@ -34,6 +34,7 @@
         "clsx": "^1.2.1",
         "jest": "^27.4.5",
         "jest-cli": "^27.4.5",
+        "prettier": "^2.7.1",
         "puppeteer": "^10.0.0",
         "storybook-dark-mode": "^1.1.2"
       },
@@ -5882,6 +5883,18 @@
         "ts-dedent": "^2.0.0"
       }
     },
+    "node_modules/@storybook/mdx1-csf/node_modules/prettier": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+      "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/@storybook/node-logger": {
       "version": "6.5.13",
       "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-6.5.13.tgz",
@@ -6127,6 +6140,18 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/source-loader/node_modules/prettier": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+      "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/@storybook/store": {
@@ -19802,15 +19827,18 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
-      "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
         "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-error": {
@@ -29831,6 +29859,14 @@
         "lodash": "^4.17.21",
         "prettier": ">=2.2.1 <=2.3.0",
         "ts-dedent": "^2.0.0"
+      },
+      "dependencies": {
+        "prettier": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+          "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+          "dev": true
+        }
       }
     },
     "@storybook/node-logger": {
@@ -30008,6 +30044,14 @@
         "lodash": "^4.17.21",
         "prettier": ">=2.2.1 <=2.3.0",
         "regenerator-runtime": "^0.13.7"
+      },
+      "dependencies": {
+        "prettier": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+          "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+          "dev": true
+        }
       }
     },
     "@storybook/store": {
@@ -40792,9 +40836,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
-      "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
     },
     "pretty-error": {

--- a/tegel/package-lock.json
+++ b/tegel/package-lock.json
@@ -13,7 +13,8 @@
         "@scania/typography": "^1.2.1",
         "@stencil/core": "^2.13.0",
         "concurrently": "^7.4.0",
-        "html-format": "^1.0.2"
+        "html-format": "^1.0.2",
+        "prettier": "^2.7.1"
       },
       "devDependencies": {
         "@babel/core": "^7.19.1",
@@ -34,7 +35,6 @@
         "clsx": "^1.2.1",
         "jest": "^27.4.5",
         "jest-cli": "^27.4.5",
-        "prettier": "^2.7.1",
         "puppeteer": "^10.0.0",
         "storybook-dark-mode": "^1.1.2"
       },
@@ -19830,7 +19830,6 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
       "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-      "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -40838,8 +40837,7 @@
     "prettier": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-      "dev": true
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
     },
     "pretty-error": {
       "version": "2.1.2",

--- a/tegel/package.json
+++ b/tegel/package.json
@@ -71,6 +71,7 @@
     "clsx": "^1.2.1",
     "jest": "^27.4.5",
     "jest-cli": "^27.4.5",
+    "prettier": "^2.7.1",
     "puppeteer": "^10.0.0",
     "storybook-dark-mode": "^1.1.2"
   },

--- a/tegel/package.json
+++ b/tegel/package.json
@@ -50,7 +50,8 @@
     "@scania/typography": "^1.2.1",
     "@stencil/core": "^2.13.0",
     "concurrently": "^7.4.0",
-    "html-format": "^1.0.2"
+    "html-format": "^1.0.2",
+    "prettier": "^2.7.1"
   },
   "devDependencies": {
     "@babel/core": "^7.19.1",
@@ -71,7 +72,6 @@
     "clsx": "^1.2.1",
     "jest": "^27.4.5",
     "jest-cli": "^27.4.5",
-    "prettier": "^2.7.1",
     "puppeteer": "^10.0.0",
     "storybook-dark-mode": "^1.1.2"
   },


### PR DESCRIPTION
I had removed prettier in the tegel package, thinking that we only used that for linting while developing, when we're in-fact using it to format code examples in storybook as well.
This PR re-adds prettier to the tegel packages dependencies.