### PR TITLE
fix/textfield state count issues - tegel

### DIFF
--- a/tegel/src/components/textarea/textarea.tsx
+++ b/tegel/src/components/textarea/textarea.tsx
@@ -102,7 +102,7 @@ export class Textarea {
               this.focusInput = false;
             }}
             class={'sdds-textarea-input'}
-            ref={inputEl => (this.textEl = inputEl as HTMLTextAreaElement)}
+            ref={(inputEl) => (this.textEl = inputEl as HTMLTextAreaElement)}
             disabled={this.disabled}
             readonly={this.readonly}
             placeholder={this.placeholder}
@@ -112,11 +112,17 @@ export class Textarea {
             maxlength={this.maxlength}
             cols={this.cols}
             rows={this.rows}
-            onInput={e => this.handleInput(e)}
-            onChange={e => this.handleChange(e)}
+            onInput={(e) => this.handleInput(e)}
+            onChange={(e) => this.handleChange(e)}
           ></textarea>
           <span class="sdds-textarea-resizer-icon">
-            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 12 12"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
               <path
                 fill-rule="evenodd"
                 clip-rule="evenodd"
@@ -126,7 +132,14 @@ export class Textarea {
             </svg>
           </span>
 
-          <svg class="sdds-textarea-icon__readonly" width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <svg
+            class="sdds-textarea-icon__readonly"
+            width="20"
+            height="20"
+            viewBox="0 0 20 20"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
             <path
               fill-rule="evenodd"
               clip-rule="evenodd"
@@ -150,7 +163,8 @@ export class Textarea {
         {this.helper.length > 0 && <span class={'sdds-textarea-helper'}>{this.helper}</span>}
         {this.maxlength > 0 && (
           <div class={'sdds-textarea-textcounter'}>
-            {this.value?.length} <span class="sdds-textfield-textcounter-divider"> / </span> {this.maxlength}
+            {this.value === null ? 0 : this.value?.length}
+            <span class="sdds-textfield-textcounter-divider"> / </span> {this.maxlength}
           </div>
         )}
       </div>

--- a/tegel/src/components/textfield/textfield.scss
+++ b/tegel/src/components/textfield/textfield.scss
@@ -268,6 +268,11 @@
   letter-spacing: var(--sdds-detail-05-ls);
   display: flex;
   justify-content: space-between;
+
+  & .sdds-textfield-textcounter {
+    margin-left: auto;
+  }
+
   flex-basis: 100%;
   padding-top: var(--sdds-spacing-element-4);
   color: var(--sdds-textfield-helper);

--- a/tegel/src/components/textfield/textfield.tsx
+++ b/tegel/src/components/textfield/textfield.tsx
@@ -87,15 +87,27 @@ export class Textfield {
       <div
         class={`
         ${this.nominwidth ? 'sdds-form-textfield-nomin' : ''}
-        ${this.focusInput && !this.disabled ? 'sdds-form-textfield sdds-textfield-focus' : ' sdds-form-textfield'}
+        ${
+          this.focusInput && !this.disabled
+            ? 'sdds-form-textfield sdds-textfield-focus'
+            : ' sdds-form-textfield'
+        }
         ${this.value ? 'sdds-textfield-data' : ''}
-        ${this.labelInside.length > 0 && this.size !== 'sm' ? 'sdds-textfield-container-label-inside' : ''}
+        ${
+          this.labelInside.length > 0 && this.size !== 'sm'
+            ? 'sdds-textfield-container-label-inside'
+            : ''
+        }
         ${this.disabled ? 'sdds-form-textfield-disabled' : ''}
         ${this.readonly ? 'sdds-form-textfield-readonly' : ''}
         ${this.variant === 'default' ? '' : 'sdds-on-white-bg'}
         ${this.size === 'md' ? 'sdds-form-textfield-md' : ''}
         ${this.size === 'sm' ? 'sdds-form-textfield-sm' : ''}
-        ${this.state === 'error' || this.state === 'success' ? `sdds-form-textfield-${this.state}` : ''}
+        ${
+          this.state === 'error' || this.state === 'success'
+            ? `sdds-form-textfield-${this.state}`
+            : ''
+        }
         `}
       >
         <div class="sdds-textfield-slot-wrap-label">
@@ -109,7 +121,7 @@ export class Textfield {
 
           <div class="sdds-textfield-input-container">
             <input
-              onFocus={e => {
+              onFocus={(e) => {
                 if (this.readonly) {
                   e.preventDefault();
                   this.textInput.blur();
@@ -120,7 +132,7 @@ export class Textfield {
               onBlur={() => {
                 this.focusInput = false;
               }}
-              ref={inputEl => (this.textInput = inputEl as HTMLInputElement)}
+              ref={(inputEl) => (this.textInput = inputEl as HTMLInputElement)}
               class={className}
               type={this.type}
               disabled={this.disabled}
@@ -129,11 +141,13 @@ export class Textfield {
               autofocus={this.autofocus}
               maxlength={this.maxlength}
               name={this.name}
-              onInput={e => this.handleInput(e)}
-              onChange={e => this.handleChange(e)}
+              onInput={(e) => this.handleInput(e)}
+              onChange={(e) => this.handleChange(e)}
             />
 
-            {this.labelInside.length > 0 && this.size !== 'sm' && <label class="sdds-textfield-label-inside">{this.labelInside}</label>}
+            {this.labelInside.length > 0 && this.size !== 'sm' && (
+              <label class="sdds-textfield-label-inside">{this.labelInside}</label>
+            )}
           </div>
           <div class="sdds-textfield-bar"></div>
 
@@ -141,7 +155,14 @@ export class Textfield {
             <slot name="sdds-suffix" />
           </div>
 
-          <svg class="sdds-textfield-icon__readonly" width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <svg
+            class="sdds-textfield-icon__readonly"
+            width="20"
+            height="20"
+            viewBox="0 0 20 20"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
             <path
               fill-rule="evenodd"
               clip-rule="evenodd"
@@ -166,14 +187,23 @@ export class Textfield {
         <div class="sdds-textfield-helper">
           {this.state === 'error' && (
             <div class="sdds-textfield-helper-error-state">
-              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 16 16"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
                 <path
                   fill-rule="evenodd"
                   clip-rule="evenodd"
                   d="M8 2.00015C4.6853 2.00015 1.9982 4.68725 1.9982 8.00195C1.9982 11.3167 4.6853 14.0038 8 14.0038C11.3147 14.0038 14.0018 11.3167 14.0018 8.00195C14.0018 4.68725 11.3147 2.00015 8 2.00015ZM1 8.00195C1 4.13596 4.13401 1.00195 8 1.00195C11.866 1.00195 15 4.13596 15 8.00195C15 11.8679 11.866 15.002 8 15.002C4.13401 15.002 1 11.8679 1 8.00195Z"
                   fill="#FF2340"
                 />
-                <path d="M7.4014 7.2352V5H8.5894V7.2352L8.4134 9.3824H7.5774L7.4014 7.2352ZM7.375 10.0512H8.6246V11.248H7.375V10.0512Z" fill="#FF2340" />
+                <path
+                  d="M7.4014 7.2352V5H8.5894V7.2352L8.4134 9.3824H7.5774L7.4014 7.2352ZM7.375 10.0512H8.6246V11.248H7.375V10.0512Z"
+                  fill="#FF2340"
+                />
               </svg>
               <slot name="sdds-helper" />
             </div>
@@ -182,7 +212,7 @@ export class Textfield {
 
           {this.maxlength > 0 && (
             <div class="sdds-textfield-textcounter">
-              {this.value?.length}
+              {this.value === null ? 0 : this.value?.length}
               <span class="sdds-textfield-textcounter-divider"> / </span>
               {this.maxlength}
             </div>


### PR DESCRIPTION
**Describe pull-request**  
Added check for null values for char count correct css for textfield count.

**Solving issue**  
Fixes: [AB#2574](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2574)

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Textfield/Textarea
3. Add a char counter with and without a state and see that it renders correctly.

**Screenshots**  
-

**Additional context**  
-
