### PR TITLE
fix(toast): added color to the wrapper class of the icon

### DIFF
--- a/tegel/src/components/toast/toast.scss
+++ b/tegel/src/components/toast/toast.scss
@@ -17,32 +17,32 @@
   &-success {
     border-left-color: var(--sdds-positive);
 
-    .sdds-toast-icon svg {
-      background: var(--sdds-positive);
+    .sdds-toast-icon {
+      color: var(--sdds-positive);
     }
   }
 
   &-info {
     border-left-color: var(--sdds-information);
 
-    .sdds-toast-icon svg {
-      background: var(--sdds-information);
+    .sdds-toast-icon {
+      color: var(--sdds-information);
     }
   }
 
   &-warning {
     border-left-color: var(--sdds-warning);
 
-    .sdds-toast-icon svg {
-      background: var(--sdds-warning);
+    .sdds-toast-icon {
+      color: var(--sdds-warning);
     }
   }
 
   &-error {
     border-left-color: var(--sdds-negative);
 
-    .sdds-toast-icon svg {
-      background: var(--sdds-negative);
+    .sdds-toast-icon {
+      color: var(--sdds-negative);
     }
   }
 

--- a/tegel/src/components/toast/toast.stories.ts
+++ b/tegel/src/components/toast/toast.stories.ts
@@ -80,14 +80,18 @@ const Template = ({ toastType, subheader, link, iconType, icon }) => {
           : ''
       }
   <div class="sdds-toast sdds-toast-${typeLookup[toastType]}">
+    ${
+      icon !== 'none'
+        ? `
     <div class="sdds-toast-icon">
-      ${
-        iconType === 'Native'
-          ? `<i class="sdds-icon ${iconValue}"></i>`
-          : `<sdds-icon name="${iconValue}" size="20px" />
-      `
-      }
-    </div>
+    ${
+      iconType === 'Native'
+        ? `<i class="sdds-icon ${iconValue}"></i>`
+        : `<sdds-icon name="${iconValue}" size="20px" />
+        </div>`
+    }`
+        : ''
+    }
     <div class="sdds-toast-content">
       <div class="sdds-toast-header">
         <span class="sdds-toast-headline">This is ${

--- a/tegel/src/components/toast/toast.stories.ts
+++ b/tegel/src/components/toast/toast.stories.ts
@@ -1,4 +1,5 @@
 import { formatHtmlPreview } from '../../utils/utils';
+import { iconsNames } from '../icon/iconsArray';
 
 export default {
   title: 'Components/Toast',
@@ -30,35 +31,46 @@ export default {
       },
       options: ['Native', 'Webcomponent'],
     },
+    icon: {
+      name: 'Icon',
+      description:
+        'Icon to display on the button. Choose "none" to exclude the icon, or choose "recommended" to pick the icon that is recommended for the type of toast.',
+      control: {
+        type: 'select',
+      },
+      options: ['none', 'recommended', ...iconsNames],
+      if: { arg: 'size', neq: 'xs' },
+    },
   },
   args: {
     toastType: 'Success',
     subheader: false,
     link: false,
     iconType: 'Webcomponent',
+    icon: 'recommended',
   },
 };
+const typeLookup = {
+  Success: 'success',
+  Info: 'info',
+  Warning: 'warning',
+  Error: 'error',
+};
+const colorLooup = {
+  Success: 'positive',
+  Info: 'information',
+  Warning: 'warning',
+  Error: 'negative',
+};
+const iconLookup = {
+  Success: 'tick',
+  Info: 'info',
+  Warning: 'warning',
+  Error: 'info',
+};
 
-const Template = ({ toastType, subheader, link, iconType }) => {
-  const typeLookup = {
-    Success: 'success',
-    Info: 'info',
-    Warning: 'warning',
-    Error: 'error',
-  };
-  const iconLookup = {
-    Success: 'tick',
-    Info: 'info',
-    Warning: 'warning',
-    Error: 'info',
-  };
-  const colorLooup = {
-    Success: 'positive',
-    Info: 'information',
-    Warning: 'warning',
-    Error: 'negative',
-  };
-
+const Template = ({ toastType, subheader, link, iconType, icon }) => {
+  const iconValue = icon === 'recommended' ? iconLookup[toastType] : icon;
   return formatHtmlPreview(
     `
     <style>
@@ -81,8 +93,8 @@ const Template = ({ toastType, subheader, link, iconType }) => {
     <div class="sdds-toast-icon">
       ${
         iconType === 'Native'
-          ? `<i class="sdds-icon ${iconLookup[toastType]}"></i>`
-          : `<sdds-icon name="${iconLookup[toastType]}" size="20px" />
+          ? `<i class="sdds-icon ${iconValue}"></i>`
+          : `<sdds-icon name="${iconValue}" size="20px" />
       `
       }
     </div>
@@ -108,6 +120,4 @@ const Template = ({ toastType, subheader, link, iconType }) => {
 };
 
 export const Default = Template.bind({});
-Default.args = {
-  toastType: 'Success',
-};
+Default.args = {};

--- a/tegel/src/components/toast/toast.stories.ts
+++ b/tegel/src/components/toast/toast.stories.ts
@@ -56,12 +56,6 @@ const typeLookup = {
   Warning: 'warning',
   Error: 'error',
 };
-const colorLooup = {
-  Success: 'positive',
-  Info: 'information',
-  Warning: 'warning',
-  Error: 'negative',
-};
 const iconLookup = {
   Success: 'tick',
   Info: 'info',
@@ -73,22 +67,18 @@ const Template = ({ toastType, subheader, link, iconType, icon }) => {
   const iconValue = icon === 'recommended' ? iconLookup[toastType] : icon;
   return formatHtmlPreview(
     `
-    <style>
       ${
         iconType === 'Native'
-          ? `@import url('https://cdn.digitaldesign.scania.com/icons/webfont/css/sdds-icons.css');
-      i {
+          ? `
+    <style>
+    @import url('https://cdn.digitaldesign.scania.com/icons/webfont/css/sdds-icons.css');
+      i.sdds-icon {
         font-size: 20px;
-        color: var(--sdds-${colorLooup[toastType]});
-      }
-      `
-          : `
-      sdds-icon{
-        color: var(--sdds-${colorLooup[toastType]});
-      }
-      `
       }
     </style>
+      `
+          : ''
+      }
   <div class="sdds-toast sdds-toast-${typeLookup[toastType]}">
     <div class="sdds-toast-icon">
       ${

--- a/tegel/src/components/toast/toast.stories.ts
+++ b/tegel/src/components/toast/toast.stories.ts
@@ -80,18 +80,20 @@ const Template = ({ toastType, subheader, link, iconType, icon }) => {
           : ''
       }
   <div class="sdds-toast sdds-toast-${typeLookup[toastType]}">
-    ${
-      icon !== 'none'
-        ? `
+  ${
+    icon === 'none'
+      ? ''
+      : `
     <div class="sdds-toast-icon">
-    ${
-      iconType === 'Native'
-        ? `<i class="sdds-icon ${iconValue}"></i>`
-        : `<sdds-icon name="${iconValue}" size="20px" />
-        </div>`
-    }`
-        : ''
-    }
+      ${
+        iconType === 'Native'
+          ? `<i class="sdds-icon ${iconValue}"></i>`
+          : `<sdds-icon name="${iconValue}" size="20px" />
+      `
+      }
+    </div>
+  `
+  }
     <div class="sdds-toast-content">
       <div class="sdds-toast-header">
         <span class="sdds-toast-headline">This is ${


### PR DESCRIPTION
**Describe pull-request**  
Added color to the wrapper class of the icon and added the possibility to pick icons from toast

**Solving issue**  
Fixes: [AB#2583](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2583) [AB#2595](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2595)

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Toast
3. Check that the controls for the icons work as intended.

**Screenshots**  
-

**Additional context**  
-
