### PR TITLE
feat(storybook): adding Google Analytics without addon

### DIFF
--- a/tegel/.storybook/main.js
+++ b/tegel/.storybook/main.js
@@ -6,7 +6,6 @@ module.exports = {
     '@storybook/addon-interactions',
     '@storybook/addon-notes/register',
     'storybook-dark-mode',
-    '@storybook/addon-google-analytics',
   ],
   framework: '@storybook/html',
 };

--- a/tegel/.storybook/manager-head.html
+++ b/tegel/.storybook/manager-head.html
@@ -1,3 +1,13 @@
 <!-- .storybook/manager-head.html -->
 
+<!-- Google tag (gtag.js) -->
+<script async src=`https://www.googletagmanager.com/gtag/js?id=${process.env.STORYBOOK_GA_ID}`></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', process.env.STORYBOOK_GA_ID);
+</script>
+
 <meta name="description" content="Tegel Storybook page - Scania's Digital Design System" key="desc" />

--- a/tegel/.storybook/manager.js
+++ b/tegel/.storybook/manager.js
@@ -1,8 +1,5 @@
 // .storybook/manager.js
 
-window.STORYBOOK_GA_ID = process.env.STORYBOOK_GA_ID;
-window.STORYBOOK_REACT_GA_OPTIONS = {};
-
 import { addons } from '@storybook/addons';
 import theme from './ScaniaThemeLight';
 


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Google Analytics without Storybook addon



**Additional context**  
Using code from the "Install manually" option of Google Analytics 
