### PR TITLE
fix(storybook): reverting hard coded values for GA due to Netlify error

### DIFF
--- a/tegel/.storybook/manager-head.html
+++ b/tegel/.storybook/manager-head.html
@@ -1,13 +1,13 @@
 <!-- .storybook/manager-head.html -->
 
 <!-- Google tag (gtag.js) -->
-<script async src=`https://www.googletagmanager.com/gtag/js?id=${process.env.STORYBOOK_GA_ID}`></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T4S5M709VL"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', process.env.STORYBOOK_GA_ID);
+  gtag('config', 'G-T4S5M709VL');
 </script>
 
 <meta name="description" content="Tegel Storybook page - Scania's Digital Design System" key="desc" />


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Reverting hard coded values as Netlify is failing to build.
Let's test if leaving code as is will work.

**How to test**  
We need to merge this one as only when it is merged and built, we can check if we get any data in the google analytics board.


