### PR TITLE
fix: adding not-allowed cursor to disabled state

### DIFF
--- a/tegel/src/components/checkbox/checkbox.scss
+++ b/tegel/src/components/checkbox/checkbox.scss
@@ -68,7 +68,7 @@
 
     &:disabled,
     &.disabled {
-      cursor: default;
+      cursor: not-allowed;
 
       &::after {
         border-color: var(--sdds-checkbox-border-color-disabled-after);
@@ -76,7 +76,7 @@
 
       + label {
         color: var(--sdds-grey-600);
-        cursor: default;
+        cursor: not-allowed;
       }
 
       &:hover {

--- a/tegel/src/components/datetime/datetime.scss
+++ b/tegel/src/components/datetime/datetime.scss
@@ -21,6 +21,7 @@
   &:disabled {
     background-color: var(--sdds-datetime-disabled-bg);
     color: var(--sdds-datetime-disabled-color);
+    cursor: not-allowed;
 
     &::placeholder {
       color: var(--sdds-datetime-disabled-placeholder);
@@ -164,8 +165,6 @@ slot[name='sdds-label']::slotted(*) {
 
 @mixin label-inside-transition {
   transition: 0.1s ease all;
-  transition: 0.1s ease all;
-  transition: 0.1s ease all;
 }
 
 //Form control
@@ -306,6 +305,7 @@ slot[name='sdds-label']::slotted(*) {
 
   slot[name='sdds-label']::slotted(*) {
     color: var(--sdds-datetime-disabled-label);
+    cursor: not-allowed;
   }
 }
 

--- a/tegel/src/components/dropdown/dropdown-select.scss
+++ b/tegel/src/components/dropdown/dropdown-select.scss
@@ -16,6 +16,10 @@
     &:focus {
       border-bottom: 2px solid var(--sdds-blue-400);
     }
+
+    &:disabled {
+      cursor: not-allowed;
+    }
   }
 
   // Size medium

--- a/tegel/src/components/radio-button/radio-button.scss
+++ b/tegel/src/components/radio-button/radio-button.scss
@@ -71,7 +71,7 @@
 
     &:disabled,
     &.disabled {
-      cursor: default;
+      cursor: not-allowed;
 
       &::after {
         border-color: var(--sdds-radio-button-border-color-disabled-after);
@@ -80,7 +80,7 @@
 
       + label {
         color: var(--sdds-grey-600);
-        cursor: default;
+        cursor: not-allowed;
       }
 
       &:hover {

--- a/tegel/src/components/textarea/textarea.scss
+++ b/tegel/src/components/textarea/textarea.scss
@@ -27,6 +27,7 @@
   &:disabled {
     background-color: var(--sdds-textarea-disabled-bg);
     color: var(--sdds-textarea-disabled-color);
+    cursor: not-allowed;
 
     &::placeholder {
       color: var(--sdds-textarea-disabled-placeholder);

--- a/tegel/src/components/textfield/textfield.scss
+++ b/tegel/src/components/textfield/textfield.scss
@@ -25,6 +25,7 @@
   }
 
   &:disabled {
+    cursor: not-allowed;
     background-color: var(--sdds-textfield-disabled-bg);
     color: var(--sdds-textfield-disabled-color);
 


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Adding not-allowed cursor to component that missed it

**Solving issue**  
Fixes: [AB#2476](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2476)

**How to test**  
1. Open Netlify build link
2. Check the disabled state of "affected" components
3. Make sure they have not-allowed cursor once in a disabled state

**Components affected**  

1. Checkbox
2. Datetime
3. Dropdown (native)
4. Radio button
5. Textarea
6. Textfield

**Additional context**  
Link and Inline Tabs have `pointer-events: none` which blocks not-allowed cursor. They would need to be changed to do this change so I am leaving them as is. It seems better that they remain with that rule as it prevents clicking better then disabled state. 