### PR TITLE
feat(datatable): use required prop for id instead of id attribute

### DIFF
--- a/tegel/src/components/data-table/table-body-cell/table-body-cell.tsx
+++ b/tegel/src/components/data-table/table-body-cell/table-body-cell.tsx
@@ -34,7 +34,7 @@ export class TableBodyCell {
 
   @State() whiteBackground: boolean = false;
 
-  @State() uniqueTableIdentifier: string = '';
+  @State() tableId: string = '';
 
   @Element() host: HTMLElement;
 
@@ -42,7 +42,7 @@ export class TableBodyCell {
 
   @Listen('tablePropsChangedEvent', { target: 'body' })
   tablePropsChangedEventListener(event: CustomEvent<TablePropsChangedEvent>) {
-    if (this.uniqueTableIdentifier === event.detail.tableId) {
+    if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))
         .forEach((changedProp) => {
@@ -59,7 +59,7 @@ export class TableBodyCell {
   headCellHoverEventListener(event: CustomEvent<any>) {
     const [receivedID, receivedKeyValue] = event.detail;
 
-    if (this.uniqueTableIdentifier === receivedID) {
+    if (this.tableId === receivedID) {
       this.activeSorting = this.cellKey === receivedKeyValue;
     }
   }
@@ -69,7 +69,7 @@ export class TableBodyCell {
   textAlignEventListener(event: CustomEvent<any>) {
     const [receivedID, receivedKey, receivedTextAlign] = event.detail;
 
-    if (this.uniqueTableIdentifier === receivedID) {
+    if (this.tableId === receivedID) {
       if (this.cellKey === receivedKey) {
         this.textAlignState = receivedTextAlign;
       }
@@ -78,11 +78,10 @@ export class TableBodyCell {
 
   connectedCallback() {
     this.tableEl = this.host.closest('sdds-table');
+    this.tableId = this.tableEl.tableId;
   }
 
   componentWillLoad() {
-    this.uniqueTableIdentifier = this.tableEl.getAttribute('id');
-
     relevantTableProps.forEach((tablePropName) => {
       this[tablePropName] = this.tableEl[tablePropName];
     });

--- a/tegel/src/components/data-table/table-body-row-expandable/table-body-row-expandable.tsx
+++ b/tegel/src/components/data-table/table-body-row-expandable/table-body-row-expandable.tsx
@@ -28,7 +28,7 @@ export class TableBodyRowExpandable {
 
   @State() isExpanded: boolean = false;
 
-  @State() uniqueTableIdentifier: string = '';
+  @State() tableId: string = '';
 
   @State() columnsNumber: number = null;
 
@@ -64,7 +64,7 @@ export class TableBodyRowExpandable {
 
   @Listen('tablePropsChangedEvent', { target: 'body' })
   tablePropsChangedEventListener(event: CustomEvent<TablePropsChangedEvent>) {
-    if (this.uniqueTableIdentifier === event.detail.tableId) {
+    if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))
         .forEach((changedProp) => {
@@ -78,18 +78,17 @@ export class TableBodyRowExpandable {
 
   connectedCallback() {
     this.tableEl = this.host.closest('sdds-table');
+    this.tableId = this.tableEl.tableId;
   }
 
   componentWillLoad() {
-    this.uniqueTableIdentifier = this.tableEl.getAttribute('id');
-
     relevantTableProps.forEach((tablePropName) => {
       this[tablePropName] = this.tableEl[tablePropName];
     });
   }
 
   componentDidLoad() {
-    this.runPaginationEvent.emit(this.uniqueTableIdentifier);
+    this.runPaginationEvent.emit(this.tableId);
   }
 
   componentWillRender() {
@@ -101,7 +100,7 @@ export class TableBodyRowExpandable {
   }
 
   sendValue() {
-    this.singleRowExpandedEvent.emit([this.uniqueTableIdentifier, this.isExpanded]);
+    this.singleRowExpandedEvent.emit([this.tableId, this.isExpanded]);
   }
 
   onChangeHandler(event) {

--- a/tegel/src/components/data-table/table-body-row/table-body-row.tsx
+++ b/tegel/src/components/data-table/table-body-row/table-body-row.tsx
@@ -28,7 +28,7 @@ export class TableBodyRow {
 
   @State() whiteBackground: boolean = false;
 
-  @State() uniqueTableIdentifier: string = '';
+  @State() tableId: string = '';
 
   @Element() host: HTMLElement;
 
@@ -59,7 +59,7 @@ export class TableBodyRow {
 
   @Listen('tablePropsChangedEvent', { target: 'body' })
   tablePropsChangedEventListener(event: CustomEvent<TablePropsChangedEvent>) {
-    if (this.uniqueTableIdentifier === event.detail.tableId) {
+    if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))
         .forEach((changedProp) => {
@@ -91,7 +91,7 @@ export class TableBodyRow {
 
   @Listen('mainCheckboxSelectedEvent', { target: 'body' })
   headCheckboxListener(event: CustomEvent<any>) {
-    if (this.uniqueTableIdentifier === event.detail[0]) {
+    if (this.tableId === event.detail[0]) {
       this.bodyCheckBoxStatusUpdater(event.detail[1]);
     }
   }
@@ -99,25 +99,24 @@ export class TableBodyRow {
   @Listen('updateBodyCheckboxesEvent', { target: 'body' })
   updateBodyCheckboxesEventListener(event: CustomEvent<any>) {
     const [receivedID, receivedBodyCheckboxStatus] = event.detail;
-    if (this.uniqueTableIdentifier === receivedID) {
+    if (this.tableId === receivedID) {
       this.bodyCheckBoxStatusUpdater(receivedBodyCheckboxStatus);
     }
   }
 
   connectedCallback() {
     this.tableEl = this.host.closest('sdds-table');
+    this.tableId = this.tableEl.tableId;
   }
 
   componentWillLoad() {
-    this.uniqueTableIdentifier = this.tableEl.getAttribute('id');
-
     relevantTableProps.forEach((tablePropName) => {
       this[tablePropName] = this.tableEl[tablePropName];
     });
   }
 
   componentDidLoad() {
-    this.runPaginationEvent.emit(this.uniqueTableIdentifier);
+    this.runPaginationEvent.emit(this.tableId);
   }
 
   render() {

--- a/tegel/src/components/data-table/table-body/table-body.tsx
+++ b/tegel/src/components/data-table/table-body/table-body.tsx
@@ -72,7 +72,7 @@ export class TableBody {
 
   @State() showNoResultsMessage: boolean = false;
 
-  @State() uniqueTableIdentifier: string = '';
+  @State() tableId: string = '';
 
   tableEl: HTMLSddsTableElement;
 
@@ -116,7 +116,7 @@ export class TableBody {
 
   @Listen('tablePropsChangedEvent', { target: 'body' })
   tablePropsChangedEventListener(event: CustomEvent<TablePropsChangedEvent>) {
-    if (this.uniqueTableIdentifier === event.detail.tableId) {
+    if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))
         .forEach((changedProp) => {
@@ -151,8 +151,8 @@ export class TableBody {
 
   uncheckAll = () => {
     this.mainCheckboxStatus = false;
-    this.updateMainCheckboxEvent.emit([this.uniqueTableIdentifier, this.mainCheckboxStatus]);
-    this.updateBodyCheckboxesEvent.emit([this.uniqueTableIdentifier, this.mainCheckboxStatus]);
+    this.updateMainCheckboxEvent.emit([this.tableId, this.mainCheckboxStatus]);
+    this.updateBodyCheckboxesEvent.emit([this.tableId, this.mainCheckboxStatus]);
   };
 
   sortData(keyValue, sortingDirection) {
@@ -172,7 +172,7 @@ export class TableBody {
   @Listen('sortColumnDataEvent', { target: 'body' })
   updateOptionsContent(event: CustomEvent<any>) {
     const [receivedID, receivedKeyValue, receivedSortingDirection] = event.detail;
-    if (this.uniqueTableIdentifier === receivedID) {
+    if (this.tableId === receivedID) {
       this.sortData(receivedKeyValue, receivedSortingDirection);
     }
   }
@@ -196,7 +196,7 @@ export class TableBody {
 
   @Listen('mainCheckboxSelectedEvent', { target: 'body' })
   headCheckboxListener(event: CustomEvent<any>) {
-    if (this.uniqueTableIdentifier === event.detail[0]) {
+    if (this.tableId === event.detail[0]) {
       [, this.mainCheckboxStatus] = event.detail;
       this.selectedDataExporter();
     }
@@ -211,7 +211,7 @@ export class TableBody {
 
     this.mainCheckboxStatus = numberOfRows === numberOfRowsSelected;
 
-    this.updateMainCheckboxEvent.emit([this.uniqueTableIdentifier, this.mainCheckboxStatus]);
+    this.updateMainCheckboxEvent.emit([this.tableId, this.mainCheckboxStatus]);
 
     this.selectedDataExporter();
   };
@@ -272,7 +272,7 @@ export class TableBody {
         });
 
         this.disableAllSorting = true;
-        this.sortingSwitcherEvent.emit([this.uniqueTableIdentifier, this.disableAllSorting]);
+        this.sortingSwitcherEvent.emit([this.tableId, this.disableAllSorting]);
 
         const dataRowsHidden = this.host.querySelectorAll('.sdds-table__row--hidden');
 
@@ -293,7 +293,7 @@ export class TableBody {
         }
 
         this.disableAllSorting = false;
-        this.sortingSwitcherEvent.emit([this.uniqueTableIdentifier, this.disableAllSorting]);
+        this.sortingSwitcherEvent.emit([this.tableId, this.disableAllSorting]);
       }
     }
   }
@@ -301,18 +301,17 @@ export class TableBody {
   // Listen to tableFilteringTerm from tableToolbar component
   @Listen('tableFilteringTerm', { target: 'body' })
   tableFilteringTermListener(event: CustomEvent<any>) {
-    if (this.uniqueTableIdentifier === event.detail[0]) {
+    if (this.tableId === event.detail[0]) {
       this.searchFunction(event.detail[1]);
     }
   }
 
   connectedCallback() {
     this.tableEl = this.host.closest('sdds-table');
+    this.tableId = this.tableEl.tableId;
   }
 
   componentWillLoad() {
-    this.uniqueTableIdentifier = this.tableEl.getAttribute('id');
-
     relevantTableProps.forEach((tablePropName) => {
       this[tablePropName] = this.tableEl[tablePropName];
     });

--- a/tegel/src/components/data-table/table-component-basic.stories.ts
+++ b/tegel/src/components/data-table/table-component-basic.stories.ts
@@ -87,7 +87,6 @@ export default {
 const BasicTemplate = (args) =>
   formatHtmlPreview(`
   <sdds-table
-      id="basic-table"
       vertical-dividers="${args.verticalDivider}"
       compact-design="${args.compactDesign}"
       white-background="${args.onWhiteBackground}"

--- a/tegel/src/components/data-table/table-component-batch-actions.stories.ts
+++ b/tegel/src/components/data-table/table-component-batch-actions.stories.ts
@@ -106,7 +106,6 @@ const BatchActionTemplate = ({
 }) =>
   formatHtmlPreview(`
    <sdds-table
-        id="actionbar-table"
         enable-multiselect
         vertical-dividers="${verticalDivider}"
         compact-design="${compactDesign}"

--- a/tegel/src/components/data-table/table-component-custom-width.stories.ts
+++ b/tegel/src/components/data-table/table-component-custom-width.stories.ts
@@ -153,7 +153,6 @@ export default {
 const BasicTemplate = (args) =>
   formatHtmlPreview(`
   <sdds-table
-      id="basic-table"
       vertical-dividers="${args.verticalDivider}"
       compact-design="${args.compactDesign}"
       white-background="${args.onWhiteBackground}"

--- a/tegel/src/components/data-table/table-component-event-listeners.stories.ts
+++ b/tegel/src/components/data-table/table-component-event-listeners.stories.ts
@@ -111,7 +111,6 @@ const EventListenersTemplate = ({
 
   <h3>Disabled filtering, pagination and sorting - left to the user to listen to events</h3>
    <sdds-table
-      id="disabled-functionality-table"
       vertical-dividers="${verticalDivider}"
       compact-design="${compactDesign}"
       white-background="${onWhiteBackground}"

--- a/tegel/src/components/data-table/table-component-expandable-rows.stories.ts
+++ b/tegel/src/components/data-table/table-component-expandable-rows.stories.ts
@@ -93,7 +93,6 @@ const ExpandableRowTemplate = ({
   formatHtmlPreview(`
   <h3>Expandable rows</h3>
   <sdds-table
-    id="expendable-rows-table"
     enable-expandable-rows
     vertical-dividers="${verticalDivider}"
     compact-design="${compactDesign}"

--- a/tegel/src/components/data-table/table-component-filtering.stories.ts
+++ b/tegel/src/components/data-table/table-component-filtering.stories.ts
@@ -93,7 +93,6 @@ const FilteringTemplate = ({
   formatHtmlPreview(`
   <h3>Filtering example</h3>
    <sdds-table
-      id="filtering-table"
       vertical-dividers="${verticalDivider}"
       compact-design="${compactDesign}"
       white-background="${onWhiteBackground}"

--- a/tegel/src/components/data-table/table-component-pagination.stories.ts
+++ b/tegel/src/components/data-table/table-component-pagination.stories.ts
@@ -107,7 +107,6 @@ const PaginationTemplate = ({
   formatHtmlPreview(`
   <h3>Pagination</h3>
    <sdds-table
-      id="pagination-table"
       vertical-dividers="${verticalDivider}"
       compact-design="${compactDesign}"
       white-background="${onWhiteBackground}"

--- a/tegel/src/components/data-table/table-component-sorting.stories.ts
+++ b/tegel/src/components/data-table/table-component-sorting.stories.ts
@@ -99,7 +99,6 @@ const SortingTemplate = ({
   formatHtmlPreview(`
   <h3>Sorting example</h3>
    <sdds-table
-      id="sorting-table"
       vertical-dividers="${verticalDivider}"
       compact-design="${compactDesign}"
       white-background="${onWhiteBackground}"

--- a/tegel/src/components/data-table/table-footer/table-footer.tsx
+++ b/tegel/src/components/data-table/table-footer/table-footer.tsx
@@ -69,7 +69,7 @@ export class TableFooter {
 
   @State() whiteBackground: boolean = false;
 
-  @State() uniqueTableIdentifier: string = '';
+  @State() tableId: string = '';
 
   @Element() host: HTMLElement;
 
@@ -86,7 +86,7 @@ export class TableFooter {
 
   @Listen('tablePropsChangedEvent', { target: 'body' })
   tablePropsChangedEventListener(event: CustomEvent<TablePropsChangedEvent>) {
-    if (this.uniqueTableIdentifier === event.detail.tableId) {
+    if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))
         .forEach((changedProp) => {
@@ -100,11 +100,10 @@ export class TableFooter {
 
   connectedCallback() {
     this.tableEl = this.host.closest('sdds-table');
+    this.tableId = this.tableEl.tableId;
   }
 
   componentWillLoad() {
-    this.uniqueTableIdentifier = this.tableEl.getAttribute('id');
-
     relevantTableProps.forEach((tablePropName) => {
       this[tablePropName] = this.tableEl[tablePropName];
     });
@@ -122,7 +121,7 @@ export class TableFooter {
       this.columnsNumber = numberOfColumns;
     }
 
-    this.enablePaginationEvent.emit(this.uniqueTableIdentifier);
+    this.enablePaginationEvent.emit(this.tableId);
   }
 
   paginationPrev = (event) => {
@@ -157,7 +156,7 @@ export class TableFooter {
 
   @Listen('runPaginationEvent', { target: 'body' })
   runPaginationEventListener(event: CustomEvent<any>) {
-    if (this.uniqueTableIdentifier === event.detail) {
+    if (this.tableId === event.detail) {
       this.runPagination();
     }
   }
@@ -201,7 +200,7 @@ export class TableFooter {
   currentPageValueEvent: EventEmitter<any>;
 
   sendPaginationValue(value) {
-    this.currentPageValueEvent.emit([this.uniqueTableIdentifier, value]);
+    this.currentPageValueEvent.emit([this.tableId, value]);
   }
 
   clientPaginationPrev = (event) => {

--- a/tegel/src/components/data-table/table-header-cell/table-header-cell.tsx
+++ b/tegel/src/components/data-table/table-header-cell/table-header-cell.tsx
@@ -61,7 +61,7 @@ export class TableHeaderCell {
 
   @State() enableToolbarDesign: boolean = false;
 
-  @State() uniqueTableIdentifier: string = '';
+  @State() tableId: string = '';
 
   @State() enableExpandableRows: boolean = false;
 
@@ -98,7 +98,7 @@ export class TableHeaderCell {
 
   @Listen('tablePropsChangedEvent', { target: 'body' })
   tablePropsChangedEventListener(event: CustomEvent<TablePropsChangedEvent>) {
-    if (this.uniqueTableIdentifier === event.detail.tableId) {
+    if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))
         .forEach((changedProp) => {
@@ -114,7 +114,7 @@ export class TableHeaderCell {
   @Listen('sortingSwitcherEvent', { target: 'body' })
   sortingSwitcherEventListener(event: CustomEvent<any>) {
     const [receivedID, receivedSortingStatus] = event.detail;
-    if (this.uniqueTableIdentifier === receivedID) {
+    if (this.tableId === receivedID) {
       this.disableSortingBtn = receivedSortingStatus;
     }
   }
@@ -122,7 +122,7 @@ export class TableHeaderCell {
   // target is set to body so other instances of same component "listen" and react to the change
   @Listen('sortColumnDataEvent', { target: 'body' })
   updateOptionsContent(event: CustomEvent<any>) {
-    if (this.uniqueTableIdentifier === event.detail[0]) {
+    if (this.tableId === event.detail[0]) {
       // grab only value at position 1 as it is the "key"
       if (this.columnKey !== event.detail[1]) {
         this.sortedByMyKey = false;
@@ -136,16 +136,15 @@ export class TableHeaderCell {
 
   @Listen('enableMultiselectEvent', { target: 'body' })
   enableMultiselectEventListener(event: CustomEvent<any>) {
-    if (this.uniqueTableIdentifier === event.detail[0]) [, this.enableMultiselect] = event.detail;
+    if (this.tableId === event.detail[0]) [, this.enableMultiselect] = event.detail;
   }
 
   connectedCallback() {
     this.tableEl = this.host.closest('sdds-table');
+    this.tableId = this.tableEl.tableId;
   }
 
   componentWillLoad() {
-    this.uniqueTableIdentifier = this.tableEl.getAttribute('id');
-
     relevantTableProps.forEach((tablePropName) => {
       this[tablePropName] = this.tableEl[tablePropName];
     });
@@ -159,7 +158,7 @@ export class TableHeaderCell {
       this.textAlignState = 'left';
     }
     // To enable body cells text align per rules set in head cell
-    this.textAlignEvent.emit([this.uniqueTableIdentifier, this.columnKey, this.textAlignState]);
+    this.textAlignEvent.emit([this.tableId, this.columnKey, this.textAlignState]);
 
     this.enableToolbarDesign =
       this.host.closest('sdds-table').getElementsByTagName('sdds-table-toolbar').length >= 1;
@@ -175,7 +174,7 @@ export class TableHeaderCell {
     // Setting to true we can set enable CSS class for "active" state of column
     this.sortedByMyKey = true;
     // Use array to send both key and sorting direction
-    this.sortColumnDataEvent.emit([this.uniqueTableIdentifier, key, this.sortingDirection]);
+    this.sortColumnDataEvent.emit([this.tableId, key, this.sortingDirection]);
   };
 
   headerCellContent = () => {
@@ -245,7 +244,7 @@ export class TableHeaderCell {
   };
 
   onHeadCellHover = (key) => {
-    this.headCellHoverEvent.emit([this.uniqueTableIdentifier, key]);
+    this.headCellHoverEvent.emit([this.tableId, key]);
   };
 
   render() {

--- a/tegel/src/components/data-table/table-header/table-header.tsx
+++ b/tegel/src/components/data-table/table-header/table-header.tsx
@@ -34,7 +34,7 @@ export class TableHeaderRow {
 
   @State() enableToolbarDesign: boolean = false;
 
-  @State() uniqueTableIdentifier: string = '';
+  @State() tableId: string = '';
 
   @Element() host: HTMLElement;
 
@@ -51,7 +51,7 @@ export class TableHeaderRow {
 
   @Listen('tablePropsChangedEvent', { target: 'body' })
   tablePropsChangedEventListener(event: CustomEvent<TablePropsChangedEvent>) {
-    if (this.uniqueTableIdentifier === event.detail.tableId) {
+    if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))
         .forEach((changedProp) => {
@@ -66,14 +66,14 @@ export class TableHeaderRow {
   @Listen('updateMainCheckboxEvent', { target: 'body' })
   updateMainCheckboxEventListener(event: CustomEvent<any>) {
     const [receivedID, receivedMainCheckboxStatus] = event.detail;
-    if (this.uniqueTableIdentifier === receivedID) {
+    if (this.tableId === receivedID) {
       this.mainCheckboxSelected = receivedMainCheckboxStatus;
     }
   }
 
   @Listen('singleRowExpandedEvent', { target: 'body' })
   singleRowExpandedEventListener(event: CustomEvent<any>) {
-    if (this.uniqueTableIdentifier === event.detail[0]) {
+    if (this.tableId === event.detail[0]) {
       // TODO: Improve this logic. Why we get late repose in DOM?
       setTimeout(() => {
         this.bodyExpandClicked();
@@ -98,11 +98,10 @@ export class TableHeaderRow {
 
   connectedCallback() {
     this.tableEl = this.host.closest('sdds-table');
+    this.tableId = this.tableEl.tableId;
   }
 
   componentWillLoad() {
-    this.uniqueTableIdentifier = this.tableEl.getAttribute('id');
-
     relevantTableProps.forEach((tablePropName) => {
       this[tablePropName] = this.tableEl[tablePropName];
     });
@@ -115,7 +114,7 @@ export class TableHeaderRow {
 
   headCheckBoxClicked(event) {
     this.mainCheckboxSelected = event.currentTarget.checked;
-    this.mainCheckboxSelectedEvent.emit([this.uniqueTableIdentifier, this.mainCheckboxSelected]);
+    this.mainCheckboxSelectedEvent.emit([this.tableId, this.mainCheckboxSelected]);
   }
 
   render() {

--- a/tegel/src/components/data-table/table-toolbar/table-toolbar.tsx
+++ b/tegel/src/components/data-table/table-toolbar/table-toolbar.tsx
@@ -38,7 +38,7 @@ export class TableToolbar {
 
   @State() whiteBackground: boolean = false;
 
-  @State() uniqueTableIdentifier: string = '';
+  @State() tableId: string = '';
 
   @Element() host: HTMLElement;
 
@@ -55,7 +55,7 @@ export class TableToolbar {
 
   @Listen('tablePropsChangedEvent', { target: 'body' })
   tablePropsChangedEventListener(event: CustomEvent<TablePropsChangedEvent>) {
-    if (this.uniqueTableIdentifier === event.detail.tableId) {
+    if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))
         .forEach((changedProp) => {
@@ -69,11 +69,10 @@ export class TableToolbar {
 
   connectedCallback() {
     this.tableEl = this.host.closest('sdds-table');
+    this.tableId = this.tableEl.tableId;
   }
 
   componentWillLoad() {
-    this.uniqueTableIdentifier = this.tableEl.getAttribute('id');
-
     relevantTableProps.forEach((tablePropName) => {
       this[tablePropName] = this.tableEl[tablePropName];
     });
@@ -83,7 +82,7 @@ export class TableToolbar {
     const searchTerm = event.currentTarget.value.toLowerCase();
     const sddsTableSearchBar = event.currentTarget.parentElement;
 
-    this.tableFilteringTerm.emit([this.uniqueTableIdentifier, searchTerm]);
+    this.tableFilteringTerm.emit([this.tableId, searchTerm]);
 
     if (searchTerm.length > 0) {
       sddsTableSearchBar.classList.add('sdds-table__searchbar--active');

--- a/tegel/src/components/data-table/table/readme.md
+++ b/tegel/src/components/data-table/table/readme.md
@@ -7,15 +7,16 @@
 
 ## Properties
 
-| Property               | Attribute                | Description                                                              | Type      | Default     |
-| ---------------------- | ------------------------ | ------------------------------------------------------------------------ | --------- | ----------- |
-| `compactDesign`        | `compact-design`         | Enables style where data-table toolbar, rows and footer are less high    | `boolean` | `false`     |
-| `enableExpandableRows` | `enable-expandable-rows` | Enables extended row feature of data-table                               | `boolean` | `false`     |
-| `enableMultiselect`    | `enable-multiselect`     | Enables multiselect feature of data-table                                | `boolean` | `false`     |
-| `enableResponsive`     | `enable-responsive`      | Enables table to take 100% available width with equal spacing of columns | `boolean` | `false`     |
-| `noMinWidth`           | `no-min-width`           | Enables to customise width on data-table columns                         | `boolean` | `undefined` |
-| `verticalDividers`     | `vertical-dividers`      | Enables style with vertical dividers between columns                     | `boolean` | `false`     |
-| `whiteBackground`      | `white-background`       | Changes a colors of data data-table when used on white background        | `boolean` | `false`     |
+| Property               | Attribute                | Description                                                              | Type      | Default               |
+| ---------------------- | ------------------------ | ------------------------------------------------------------------------ | --------- | --------------------- |
+| `compactDesign`        | `compact-design`         | Enables style where data-table toolbar, rows and footer are less high    | `boolean` | `false`               |
+| `enableExpandableRows` | `enable-expandable-rows` | Enables extended row feature of data-table                               | `boolean` | `false`               |
+| `enableMultiselect`    | `enable-multiselect`     | Enables multiselect feature of data-table                                | `boolean` | `false`               |
+| `enableResponsive`     | `enable-responsive`      | Enables table to take 100% available width with equal spacing of columns | `boolean` | `false`               |
+| `noMinWidth`           | `no-min-width`           | Enables to customise width on data-table columns                         | `boolean` | `undefined`           |
+| `tableId`              | `table-id`               |                                                                          | `string`  | `crypto.randomUUID()` |
+| `verticalDividers`     | `vertical-dividers`      | Enables style with vertical dividers between columns                     | `boolean` | `false`               |
+| `whiteBackground`      | `white-background`       | Changes a colors of data data-table when used on white background        | `boolean` | `false`               |
 
 
 ## Events

--- a/tegel/src/components/data-table/table/readme.md
+++ b/tegel/src/components/data-table/table/readme.md
@@ -14,7 +14,7 @@
 | `enableMultiselect`    | `enable-multiselect`     | Enables multiselect feature of data-table                                | `boolean` | `false`               |
 | `enableResponsive`     | `enable-responsive`      | Enables table to take 100% available width with equal spacing of columns | `boolean` | `false`               |
 | `noMinWidth`           | `no-min-width`           | Enables to customise width on data-table columns                         | `boolean` | `undefined`           |
-| `tableId`              | `table-id`               |                                                                          | `string`  | `crypto.randomUUID()` |
+| `tableId`              | `table-id`               | ID used for internal table functionality and events, must be unique.     | `string`  | `crypto.randomUUID()` |
 | `verticalDividers`     | `vertical-dividers`      | Enables style with vertical dividers between columns                     | `boolean` | `false`               |
 | `whiteBackground`      | `white-background`       | Changes a colors of data data-table when used on white background        | `boolean` | `false`               |
 

--- a/tegel/src/components/data-table/table/table.tsx
+++ b/tegel/src/components/data-table/table/table.tsx
@@ -1,17 +1,7 @@
 // https://stackoverflow.com/questions/63051941/how-to-pass-data-as-array-of-object-in-stencil-js
 // https://medium.com/@scottmgerstl/passing-an-object-or-array-to-stencil-dd62b7d92641
 
-import {
-  Component,
-  Prop,
-  h,
-  Host,
-  Event,
-  EventEmitter,
-  Element,
-  State,
-  Watch,
-} from '@stencil/core';
+import { Component, Prop, h, Host, Event, EventEmitter, Element, Watch } from '@stencil/core';
 
 type Props = {
   verticalDividers: boolean;
@@ -56,7 +46,7 @@ export class Table {
   /** Enables table to take 100% available width with equal spacing of columns */
   @Prop({ reflect: true }) enableResponsive: boolean = false;
 
-  @State() uniqueTableIdentifier: string = '';
+  @Prop() tableId: string = crypto.randomUUID();
 
   @Element() host: HTMLElement;
 
@@ -71,7 +61,7 @@ export class Table {
 
   emitTablePropsChangedEvent(changedValueName: keyof Props, changedValue: Props[keyof Props]) {
     this.tablePropsChangedEvent.emit({
-      tableId: this.uniqueTableIdentifier,
+      tableId: this.tableId,
       changed: [changedValueName],
       [changedValueName]: changedValue,
     });
@@ -105,10 +95,6 @@ export class Table {
   @Watch('whiteBackground')
   whiteBackgroundChanged(newValue: boolean) {
     this.emitTablePropsChangedEvent('whiteBackground', newValue);
-  }
-
-  componentWillLoad() {
-    this.uniqueTableIdentifier = this.host.getAttribute('id');
   }
 
   render() {

--- a/tegel/src/components/data-table/table/table.tsx
+++ b/tegel/src/components/data-table/table/table.tsx
@@ -46,6 +46,7 @@ export class Table {
   /** Enables table to take 100% available width with equal spacing of columns */
   @Prop({ reflect: true }) enableResponsive: boolean = false;
 
+  /** ID used for internal table functionality and events, must be unique. */
   @Prop() tableId: string = crypto.randomUUID();
 
   @Element() host: HTMLElement;


### PR DESCRIPTION
Since the id attribute was required for datatable to work, this PR replaces it with a tableId property in the web-component. The property is automatically initialised to a random string so the user doesn't have to set it themselves.

![Screenshot 2022-11-22 at 11 42 38](https://user-images.githubusercontent.com/8556022/203293960-fd552e34-c3b8-41eb-923b-d483e0dec2bd.png)
