### PR TITLE
fix(icon): dynamic import of scania/icons for icon-component

### DIFF
--- a/components/src/components/icon/icon.tsx
+++ b/components/src/components/icon/icon.tsx
@@ -14,7 +14,7 @@ export class Icon {
   async loadIcon() {
     try {
       // dynamic import icon from @scania/icons
-      this.icon = await import(`../../../theme/core/icons/dist/${this.name}.js`);
+      this.icon = await import(`@scania/icons/dist/${this.name}.js`);
     } catch (err) {
       this.name = 'scania-truck'; // If icon not found, display a truck icon
     }


### PR DESCRIPTION
**Describe pull-request**  
Reverted the dynamic import of icon package to @scania/icons instead of local folder

**Solving issue**  
Fixes: -

**How to test**  
1. Check out the branch
2. Run npm start in components folder
3. Check in storybook that the icons component still works as intended.

**Screenshots**  
-

**Additional context**  
-
