### PR TITLE
fix(tooltip): added show on focus and removed bad lint naming

### DIFF
--- a/tegel/src/components/tooltip/tooltip.stories.ts
+++ b/tegel/src/components/tooltip/tooltip.stories.ts
@@ -1,3 +1,4 @@
+import { formatHtmlPreview } from '../../utils/utils';
 import readme from './readme.md';
 
 export default {
@@ -41,6 +42,13 @@ export default {
         type: 'text',
       },
     },
+    slot: {
+      name: 'Tooltip slot',
+      description: 'A slot for the tooltip to pass in an element.',
+      control: {
+        type: 'text',
+      },
+    },
     mouseOverTooltip: {
       name: 'Open while hovering over tooltip',
       control: 'boolean',
@@ -50,6 +58,7 @@ export default {
   args: {
     tooltipPosition: 'Bottom',
     text: 'Text inside tooltip',
+    slot: '<p> Paragraph tag inside of Tooltip with <b>bold</b> and <i>italic</i> tags too. </p>',
     mouseOverTooltip: true,
   },
 };
@@ -69,25 +78,29 @@ const positionLookup = {
   'Right-end': 'right-end',
 };
 
-const ComponentTooltip = ({ tooltipPosition, mouseOverTooltip, text }) => `
-   <div class='demo-wrapper'>
+const ComponentTooltip = ({ tooltipPosition, mouseOverTooltip, text, slot }) =>
+  formatHtmlPreview(
+    `
+   <div class="demo-wrapper">
    <sdds-tooltip 
       placement="${positionLookup[tooltipPosition]}" 
       selector="#button-1" 
       text="${text}" 
       mouse-over-tooltip="${mouseOverTooltip}">
-      <p> Paragraph tag inside of Tooltip with <b>bold</b> and <i>italic</i> tags too. </p>
+      ${slot}
     </sdds-tooltip>
-    <sdds-button size= 'sm' id="button-1" text='Hover me'></sdds-button></div>
-
-    <style> 
-    .demo-wrapper{ 
-      height: 200px; 
-      display: flex; 
-      justify-content: center; 
-      align-items: center; 
-    } 
-    </style>
-  `;
+    <sdds-button size= 'sm' id="button-1" text='Hover me'></sdds-button>
+   </div>
+   <style>
+    /* This is only for demontration purposes */
+    .demo-wrapper{
+      height: 300px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+   </style>  
+  `,
+  );
 
 export const Default = ComponentTooltip.bind({});

--- a/tegel/src/components/tooltip/tooltip.stories.ts
+++ b/tegel/src/components/tooltip/tooltip.stories.ts
@@ -44,7 +44,7 @@ export default {
     },
     slot: {
       name: 'Tooltip html content',
-      description: 'A slot for the tooltip to pass in html content.',
+      description: 'A slot for the tooltip to pass in html.',
       control: {
         type: 'text',
       },

--- a/tegel/src/components/tooltip/tooltip.stories.ts
+++ b/tegel/src/components/tooltip/tooltip.stories.ts
@@ -43,8 +43,8 @@ export default {
       },
     },
     slot: {
-      name: 'Tooltip slot',
-      description: 'A slot for the tooltip to pass in an element.',
+      name: 'Tooltip html content',
+      description: 'A slot for the tooltip to pass in html content.',
       control: {
         type: 'text',
       },

--- a/tegel/src/components/tooltip/tooltip.tsx
+++ b/tegel/src/components/tooltip/tooltip.tsx
@@ -35,9 +35,9 @@ export class Tooltip {
 
   componentDidLoad() {
     this.target = document.querySelector(this.selector);
-    const _this = this;
+    const thisValue = this;
     createPopper(this.target, this.tooltip, {
-      placement: _this.placement,
+      placement: thisValue.placement,
       modifiers: [
         {
           name: 'positionCalc',
@@ -45,15 +45,15 @@ export class Tooltip {
           phase: 'main',
           fn({ state }) {
             if (state.placement === 'bottom-start' || state.placement === 'right-start') {
-              _this.border = 'top-left';
+              thisValue.border = 'top-left';
             } else if (state.placement === 'bottom-end' || state.placement === 'left-start') {
-              _this.border = 'top-right';
+              thisValue.border = 'top-right';
             } else if (state.placement === 'top-end' || state.placement === 'left-end') {
-              _this.border = 'bottom-right';
+              thisValue.border = 'bottom-right';
             } else if (state.placement === 'top-start' || state.placement === 'right-end') {
-              _this.border = 'bottom-left';
+              thisValue.border = 'bottom-left';
             } else if (state.placement === 'bottom' || state.placement === 'top') {
-              _this.border = 'default';
+              thisValue.border = 'default';
             }
           },
         },
@@ -73,6 +73,15 @@ export class Tooltip {
     const hideTooltip = () => {
       this.show = false;
     };
+
+    // For tabbing over element
+    this.target.addEventListener('focusin', () => {
+      showTooltip();
+    });
+
+    this.target.addEventListener('focusout', () => {
+      hideTooltip();
+    });
 
     // For hovering over element with selector
     this.target.addEventListener('mouseenter', () => {
@@ -98,7 +107,10 @@ export class Tooltip {
   /* Slot on line 118 is added to support adding HTML elements to component */
   render() {
     return (
-      <span ref={el => (this.tooltip = el as HTMLInputElement)} class={`sdds-tooltip sdds-tooltip-${this.border} ${this.show ? 'sdds-tooltip-show' : ''}`}>
+      <span
+        ref={(el) => (this.tooltip = el as HTMLInputElement)}
+        class={`sdds-tooltip sdds-tooltip-${this.border} ${this.show ? 'sdds-tooltip-show' : ''}`}
+      >
         {this.text}
         <slot />
       </span>


### PR DESCRIPTION
**Describe pull-request**  
Added show on focus and removed bad lint naming, changed '_this' to 'thisValue'. Exposed the slot as a control in storybook. Wrapped template in formatHtmlPreview.

**Solving issue**  
Fixes: [AB#2641](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2641) [AB#2646](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2646)

**How to test**  
1. Go to storybook link below
2. Check in Components -> Tooltip
3. Try tabbing through the page and test if the tooltip shows

**Screenshots**  
-

**Additional context**  
-
