### PR TITLE
docs(data-table): adding storybook control for disablePadding prop in…

### DIFF
--- a/tegel/src/components/data-table/table-body-cell/readme.md
+++ b/tegel/src/components/data-table/table-body-cell/readme.md
@@ -11,7 +11,7 @@
 | ---------------- | ----------------- | --------------------------------------------------------------------------------------------------------------- | ------------------ | ----------- |
 | `cellKey`        | `cell-key`        | Passing same cell key for all body cells which is used in head cell enables features of text align and hovering | `any`              | `undefined` |
 | `cellValue`      | `cell-value`      | Value that will be presented as text inside a cell                                                              | `number \| string` | `undefined` |
-| `disablePadding` | `disable-padding` | Disables internal padding. Useful when passing other tegel to cell.                                             | `boolean`          | `false`     |
+| `disablePadding` | `disable-padding` | Disables internal padding. Useful when passing other components to cell.                                        | `boolean`          | `false`     |
 
 
 ## Dependencies

--- a/tegel/src/components/data-table/table-body-cell/table-body-cell.tsx
+++ b/tegel/src/components/data-table/table-body-cell/table-body-cell.tsx
@@ -12,7 +12,7 @@ export class TableBodyCell {
   /** Passing same cell key for all body cells which is used in head cell enables features of text align and hovering */
   @Prop({ reflect: true }) cellKey: any;
 
-  /** Disables internal padding. Useful when passing other tegel to cell. */
+  /** Disables internal padding. Useful when passing other components to cell. */
   @Prop({ reflect: true }) disablePadding: boolean = false;
 
   @State() textAlignState: string;
@@ -37,7 +37,13 @@ export class TableBodyCell {
 
   @Listen('commonTableStylesEvent', { target: 'body' })
   commonTableStyleListener(event: CustomEvent<any>) {
-    const [receiverID, receiverVerticalDividers, receiverCompactDesign, receiverNoMinWidth, receiverWhiteBackground] = event.detail;
+    const [
+      receiverID,
+      receiverVerticalDividers,
+      receiverCompactDesign,
+      receiverNoMinWidth,
+      receiverWhiteBackground,
+    ] = event.detail;
 
     if (this.uniqueTableIdentifier === receiverID) {
       this.verticalDividers = receiverVerticalDividers;

--- a/tegel/src/components/data-table/table-component-basic.stories.ts
+++ b/tegel/src/components/data-table/table-component-basic.stories.ts
@@ -75,12 +75,26 @@ export default {
         },
       },
     },
+    disablePadding: {
+      name: 'Disable cell padding',
+      description:
+        'By default each cell comes with padding. Disabling padding rule can be useful when a users want to insert another HTML element in cell, eg. input.',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: {
+          summary: false,
+        },
+      },
+    },
   },
   args: {
     compactDesign: false,
     onWhiteBackground: false,
     verticalDivider: false,
     responsiveDesign: false,
+    disablePadding: false,
   },
 };
 
@@ -101,40 +115,40 @@ const BasicTemplate = (args) =>
       </sdds-table-header>
       <sdds-table-body>
           <sdds-table-body-row>
-              <sdds-body-cell cell-value="Test value 1" cell-key="truck"></sdds-body-cell>
-              <sdds-body-cell cell-value="Test value 2" cell-key="driver"></sdds-body-cell>
-              <sdds-body-cell cell-value="Test value 3" cell-key="country"></sdds-body-cell>
-              <sdds-body-cell cell-value="Test value 4" cell-key="mileage"></sdds-body-cell>
+              <sdds-body-cell cell-value="Test value 1" cell-key="truck" disable-padding="${args.disablePadding}"></sdds-body-cell>
+              <sdds-body-cell cell-value="Test value 2" cell-key="driver" disable-padding="${args.disablePadding}"></sdds-body-cell>
+              <sdds-body-cell cell-value="Test value 3" cell-key="country" disable-padding="${args.disablePadding}"></sdds-body-cell>
+              <sdds-body-cell cell-value="Test value 4" cell-key="mileage" disable-padding="${args.disablePadding}"></sdds-body-cell>
           </sdds-table-body-row>
           <sdds-table-body-row>
-              <sdds-body-cell cell-value="Test value 5" cell-key="truck"></sdds-body-cell>
-              <sdds-body-cell cell-value="Test value 6" cell-key="driver"></sdds-body-cell>
-              <sdds-body-cell cell-value="Test value 7" cell-key="country"></sdds-body-cell>
-              <sdds-body-cell cell-value="Test value 8" cell-key="mileage"></sdds-body-cell>
+              <sdds-body-cell cell-value="Test value 5" cell-key="truck" disable-padding="${args.disablePadding}"></sdds-body-cell>
+              <sdds-body-cell cell-value="Test value 6" cell-key="driver" disable-padding="${args.disablePadding}"></sdds-body-cell>
+              <sdds-body-cell cell-value="Test value 7" cell-key="country" disable-padding="${args.disablePadding}"></sdds-body-cell>
+              <sdds-body-cell cell-value="Test value 8" cell-key="mileage" disable-padding="${args.disablePadding}"></sdds-body-cell>
           </sdds-table-body-row>
           <sdds-table-body-row>
-              <sdds-body-cell cell-value="Test value 1" cell-key="truck"></sdds-body-cell>
-              <sdds-body-cell cell-value="Test value 2" cell-key="driver"></sdds-body-cell>
-              <sdds-body-cell cell-value="Test value 3" cell-key="country"></sdds-body-cell>
-              <sdds-body-cell cell-value="Test value 4" cell-key="mileage"></sdds-body-cell>
+              <sdds-body-cell cell-value="Test value 1" cell-key="truck" disable-padding="${args.disablePadding}"></sdds-body-cell>
+              <sdds-body-cell cell-value="Test value 2" cell-key="driver" disable-padding="${args.disablePadding}"></sdds-body-cell>
+              <sdds-body-cell cell-value="Test value 3" cell-key="country" disable-padding="${args.disablePadding}"></sdds-body-cell>
+              <sdds-body-cell cell-value="Test value 4" cell-key="mileage" disable-padding="${args.disablePadding}"></sdds-body-cell>
           </sdds-table-body-row>
           <sdds-table-body-row>
-              <sdds-body-cell cell-value="Test value 5" cell-key="truck"></sdds-body-cell>
-              <sdds-body-cell cell-value="Test value 6" cell-key="driver"></sdds-body-cell>
-              <sdds-body-cell cell-value="Test value 7" cell-key="country"></sdds-body-cell>
-              <sdds-body-cell cell-value="Test value 8" cell-key="mileage"></sdds-body-cell>
+              <sdds-body-cell cell-value="Test value 5" cell-key="truck" disable-padding="${args.disablePadding}"></sdds-body-cell>
+              <sdds-body-cell cell-value="Test value 6" cell-key="driver" disable-padding="${args.disablePadding}"></sdds-body-cell>
+              <sdds-body-cell cell-value="Test value 7" cell-key="country" disable-padding="${args.disablePadding}"></sdds-body-cell>
+              <sdds-body-cell cell-value="Test value 8" cell-key="mileage" disable-padding="${args.disablePadding}"></sdds-body-cell>
           </sdds-table-body-row>
           <sdds-table-body-row>
-              <sdds-body-cell cell-value="Test value 1" cell-key="truck"></sdds-body-cell>
-              <sdds-body-cell cell-value="Test value 2" cell-key="driver"></sdds-body-cell>
-              <sdds-body-cell cell-value="Test value 3" cell-key="country"></sdds-body-cell>
-              <sdds-body-cell cell-value="Test value 4" cell-key="mileage"></sdds-body-cell>
+              <sdds-body-cell cell-value="Test value 1" cell-key="truck" disable-padding="${args.disablePadding}"></sdds-body-cell>
+              <sdds-body-cell cell-value="Test value 2" cell-key="driver" disable-padding="${args.disablePadding}"></sdds-body-cell>
+              <sdds-body-cell cell-value="Test value 3" cell-key="country" disable-padding="${args.disablePadding}"></sdds-body-cell>
+              <sdds-body-cell cell-value="Test value 4" cell-key="mileage" disable-padding="${args.disablePadding}"></sdds-body-cell>
           </sdds-table-body-row>
           <sdds-table-body-row>
-              <sdds-body-cell cell-value="Test value 5" cell-key="truck"></sdds-body-cell>
-              <sdds-body-cell cell-value="Test value 6" cell-key="driver"></sdds-body-cell>
-              <sdds-body-cell cell-value="Test value 7" cell-key="country"></sdds-body-cell>
-              <sdds-body-cell cell-value="Test value 8" cell-key="mileage"></sdds-body-cell>
+              <sdds-body-cell cell-value="Test value 5" cell-key="truck" disable-padding="${args.disablePadding}"></sdds-body-cell>
+              <sdds-body-cell cell-value="Test value 6" cell-key="driver" disable-padding="${args.disablePadding}"></sdds-body-cell>
+              <sdds-body-cell cell-value="Test value 7" cell-key="country" disable-padding="${args.disablePadding}"></sdds-body-cell>
+              <sdds-body-cell cell-value="Test value 8" cell-key="mileage" disable-padding="${args.disablePadding}"></sdds-body-cell>
           </sdds-table-body-row>
       </sdds-table-body>
   </sdds-table>`);


### PR DESCRIPTION
… default story

<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Adding Storybook control for disablePadding prop of table cell sub-component

**Solving issue**  
Fixes: [AB#2585](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2585)

**How to test**  
1. Go to PR Netlify link
2. Open Data-table -> WebComponent -> Default
3. Toggle on/off padding control
4. Padding should be added/removed from cells