### PR TITLE
docs(dropdown-filter): adding missing controls

### DIFF
--- a/tegel/src/components/dropdown/dropdown-filter/dropdown-filter.stories.ts
+++ b/tegel/src/components/dropdown/dropdown-filter/dropdown-filter.stories.ts
@@ -21,11 +21,27 @@ export default {
       type: 'string',
       description: 'Placeholder text when no option is selected',
     },
+    labelPosition: {
+      name: 'Label position',
+      control: {
+        type: 'radio',
+      },
+      options: ['None', 'Outside'],
+      description: 'Label text position',
+    },
     disabled: {
       name: 'Disabled',
       control: {
         type: 'boolean',
       },
+    },
+    state: {
+      name: 'State',
+      control: {
+        type: 'radio',
+      },
+      options: ['Default', 'Error'],
+      description: 'Support error state',
     },
     helper: {
       name: 'Helper text',
@@ -33,6 +49,11 @@ export default {
         type: 'text',
       },
       description: 'Helper text assists the user with additional information about the dropdown',
+    },
+    label: {
+      name: 'Label text',
+      type: 'string',
+      description: 'Label text helps to describe what the dropdown contains',
     },
     defaultOption: {
       description: 'Sets a pre-selected option and replaces placeholder',
@@ -47,13 +68,28 @@ export default {
     size: 'Large',
     placeholder: 'Placeholder',
     disabled: false,
+    labelPosition: 'None',
     helper: '',
     defaultOption: 'Option 1',
+    state: 'Default',
+    label: 'Label text',
   },
 };
 
-const FilterTemplate = ({ size, disabled = false, helper = '', placeholder, defaultOption }) => {
+const FilterTemplate = ({
+  size,
+  disabled = false,
+  helper = '',
+  label,
+  state = 'default',
+  placeholder,
+  labelPosition,
+  defaultOption,
+}) => {
+  const stateValue = state === 'Error' ? 'error' : 'default';
   const sizeLookup = { Large: 'lg', Medium: 'md', Small: 'sm' };
+  const labelPosLookup = { None: 'no-default', Outside: 'outside' };
+
   const defaultOptionLookup = {
     'No default': 'no-default',
     'Option 1': 'option-1',
@@ -72,8 +108,11 @@ const FilterTemplate = ({ size, disabled = false, helper = '', placeholder, defa
         id="sdds-dropdown-filter"
         size="${sizeLookup[size]}"
         placeholder="${placeholder}"
-        disabled="${disabled}"\
-        ${helper !== '' ? `\n    helper="${helper}"` : ''}
+        disabled="${disabled}"
+        label-position="${labelPosLookup[labelPosition]}"
+        ${labelPosLookup[labelPosition] !== 'no-default' ? `label="${label}"` : ''}
+        ${helper !== '' ? `helper="${helper}"` : ''}
+        state="${stateValue}"
         data='[
           {
             "value": "option-1",
@@ -88,7 +127,8 @@ const FilterTemplate = ({ size, disabled = false, helper = '', placeholder, defa
             "label":"Barcelona"
           }
         ]'
-        default-option="${defaultOptionLookup[defaultOption]}">
+        default-option="${defaultOptionLookup[defaultOption]}"
+        >
       </sdds-dropdown-filter>
     </div>
   `);

--- a/tegel/src/components/dropdown/dropdown-filter/dropdown-filter.stories.ts
+++ b/tegel/src/components/dropdown/dropdown-filter/dropdown-filter.stories.ts
@@ -67,12 +67,12 @@ export default {
   args: {
     size: 'Large',
     placeholder: 'Placeholder',
-    disabled: false,
+    label: 'Label text',
     labelPosition: 'None',
     helper: '',
+    disabled: false,
     defaultOption: 'Option 1',
     state: 'Default',
-    label: 'Label text',
   },
 };
 

--- a/tegel/src/components/dropdown/dropdown-wc-default.stories.ts
+++ b/tegel/src/components/dropdown/dropdown-wc-default.stories.ts
@@ -23,6 +23,11 @@ export default {
       type: 'string',
       description: 'Placeholder text when no option is selected',
     },
+    label: {
+      name: 'Label text',
+      type: 'string',
+      description: 'Label text helps to describe what the dropdown contains',
+    },
     labelPosition: {
       name: 'Label position',
       control: {
@@ -50,11 +55,6 @@ export default {
       control: 'boolean',
       description: 'Helper text assists the user with additional information about the dropdown',
     },
-    label: {
-      name: 'Label text',
-      type: 'string',
-      description: 'Label text helps to describe what the dropdown contains',
-    },
     defaultOption: {
       if: { arg: 'type', neq: 'Multiselect' },
       description: 'Sets a pre-selected option and replaces placeholder',
@@ -66,14 +66,14 @@ export default {
     },
   },
   args: {
-    defaultOption: 'Option 1',
     size: 'Large',
     placeholder: 'Placeholder',
-    labelPosition: 'None',
-    disabled: false,
-    state: 'Default',
-    helper: false,
     label: 'Label text',
+    labelPosition: 'None',
+    helper: false,
+    disabled: false,
+    defaultOption: 'Option 1',
+    state: 'Default',
   },
 };
 

--- a/tegel/src/components/dropdown/dropdown-wc-multiselect.stories.ts
+++ b/tegel/src/components/dropdown/dropdown-wc-multiselect.stories.ts
@@ -67,12 +67,12 @@ export default {
   args: {
     size: 'Large',
     placeholder: 'Placeholder',
-    labelPosition: 'None',
-    disabled: false,
-    state: 'Default',
-    helper: false,
     label: 'Label text',
+    labelPosition: 'None',
+    helper: '',
+    disabled: false,
     multiDefaultOption: ['Option 1', 'Option 2'],
+    state: 'Default',
   },
 };
 


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Adding missing controls to Dropdown filter component (label position, state, label text)

**Solving issue**  
Fixes: [AB#2577](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2577)

**How to test**  
1. Open Netlify PR link
2. Go to the Dropdown-filter component
3. Check if controls there are as in regular Dropdown WebComponent variation

**Additional context**  
Dropdown-filter seems not to accept label-inside as an option so one is removed from Storybook controls. I am adding a ticket for it for further investigation. 
