### PR TITLE
docs(canvas): made canvas the default tab

### DIFF
--- a/tegel/.storybook/preview.js
+++ b/tegel/.storybook/preview.js
@@ -76,10 +76,6 @@ export const parameters = {
     },
     expanded: true,
   },
-  previewTabs: {
-    'storybook/docs/panel': { index: -1 },
-    // https://storybook.js.org/addons/storybook-dark-mode#:~:text=%5D%0A%7D%3B-,Configuration,-Configure%20the%20dark
-  },
   viewport: { viewports: customViewports },
   docs: {
     // Fix for dark mode not working on docs tab

--- a/tegel/.storybook/preview.js
+++ b/tegel/.storybook/preview.js
@@ -76,7 +76,6 @@ export const parameters = {
     },
     expanded: true,
   },
-  viewMode: 'docs',
   previewTabs: {
     'storybook/docs/panel': { index: -1 },
     // https://storybook.js.org/addons/storybook-dark-mode#:~:text=%5D%0A%7D%3B-,Configuration,-Configure%20the%20dark


### PR DESCRIPTION
**Describe pull-request**  
Removed the parameter setting docs as the default tab.

**Solving issue**  
Fixes: [AB#2729](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2729)

**How to test**  
1. Go to storybook link below
2. Check in a couple of random stories.
3. Make sure canvas is the default tab.

**Screenshots**  
-

**Additional context**  
-
