### PR TITLE
fix(side-menu): changed anchors to buttons for side-menu

### DIFF
--- a/tegel/src/components/side-menu/side-menu.scss
+++ b/tegel/src/components/side-menu/side-menu.scss
@@ -123,6 +123,8 @@
     }
 
     &__close {
+      all: unset;
+      cursor: pointer;
       height: 64px;
       width: 68px;
       display: flex;
@@ -200,6 +202,17 @@
     }
 
     // SINGLE ITEM
+    &__extended {
+      .sdds-sidebar-nav__item-link {
+        border: none;
+        background: none;
+        cursor: pointer;
+        width: 100%;
+        box-sizing: border-box;
+        text-align: left;
+      }
+    }
+
     &__item {
       border-bottom: 1px solid var(--sdds-sidebar-side-menu-single-item-border-bottom);
 
@@ -217,11 +230,6 @@
         min-height: 20px;
         box-sizing: content-box;
         transition: background-color 0.15s ease-in-out;
-
-        // TODO: remove/add?
-        // &:focus {
-        //@include sdds-focus-state;
-        // }
 
         .sdds-sidebar-nav__item-text {
           margin-top: 3px;

--- a/tegel/src/components/side-menu/side-menu.stories.ts
+++ b/tegel/src/components/side-menu/side-menu.stories.ts
@@ -48,7 +48,7 @@ const Template = ({ showIcons, collapsed }) => {
 <nav class="sdds-nav">
   <div class="sdds-nav__left">
     <button class="sdds-nav__mob-menu-btn">
-    <sdds-icon name="burger" size="20px" /> 
+      <sdds-icon name="burger" size="20px" /> 
     </button>
     <div class="sdds-nav__app-name">My application</div>
   </div>
@@ -56,18 +56,16 @@ const Template = ({ showIcons, collapsed }) => {
     <a class="sdds-nav__item sdds-nav__app-logo" href="#"></a>
   </div>
 </nav>
-
 <div class="sdds-push sdds-demo-container">
   <div class="sdds-sidebar side-menu ${collapsed ? 'collapsed' : ''}">
     <div class="sdds-sidebar-mheader">
-      <a href="#" class="sdds-sidebar-mheader__close">
-        <sdds-icon name="cross" size="20px" /> 
-      </a>
+    <button class="sdds-sidebar-mheader__close">
+      <sdds-icon name="cross" size="20px" /> 
+    </button>
     </div>
-
     <ul class="sdds-sidebar-nav sdds-sidebar-nav--main ${icons}">
       <li class="sdds-sidebar-nav__item sdds-sidebar-nav__extended">
-        <a class="sdds-sidebar-nav__item-link" href="#">
+        <button class="sdds-sidebar-nav__item-link">
           <div>
             <sdds-icon class="sdds-sidebar-nav__icon" name="truck" size="20px"/>
           </div>
@@ -75,7 +73,7 @@ const Template = ({ showIcons, collapsed }) => {
           <div>
             <sdds-icon class="sdds-sidebar-nav__chevron" name="chevron_down" size="16px"/>
           </div>
-        </a>
+        </button>
         <ul class="sdds-sidebar-nav-subnav">
           <li class="sdds-sidebar-nav-subnav__item">
             <span class="sdds-sidebar-nav__item-title">Sub-menu</span>
@@ -98,7 +96,7 @@ const Template = ({ showIcons, collapsed }) => {
         </ul>
       </li>
       <li class="sdds-sidebar-nav__item sdds-sidebar-nav__extended">
-      <a class="sdds-sidebar-nav__item-link" href="#">
+      <button class="sdds-sidebar-nav__item-link">
       <div>
         <sdds-icon class="sdds-sidebar-nav__icon" name="truck" size="20px"/>
       </div>
@@ -106,7 +104,7 @@ const Template = ({ showIcons, collapsed }) => {
       <div>
         <sdds-icon class="sdds-sidebar-nav__chevron" name="chevron_down" size="16px"/>
       </div>
-       </a>
+      </button>
         <ul class="sdds-sidebar-nav-subnav">
           <li class="sdds-sidebar-nav-subnav__item">
             <span class="sdds-sidebar-nav__item-title">Sub-menu</span>
@@ -151,21 +149,20 @@ const Template = ({ showIcons, collapsed }) => {
   </div>
 </div>
 <script>
+  document.querySelector('button.sdds-nav__mob-menu-btn').addEventListener('click', () => {
+    document.querySelector('.side-menu').classList.toggle('mobile-menu-open')
+  })
+  document.querySelector('button.sdds-sidebar-mheader__close').addEventListener('click', () => {
+    document.querySelector('.side-menu').classList.toggle('mobile-menu-open')
+  })
   expandableListItems = document.getElementsByClassName('sdds-sidebar-nav__extended');
-
   for (let i = 0; i < expandableListItems.length; i++) {
     expandableListItems[i].addEventListener('click', (event) => {
-      event.preventDefault();
-      document
-        .getElementsByClassName('sdds-sidebar-nav__extended')
-        [i].classList.toggle('subnav-open');
+      document.getElementsByClassName('sdds-sidebar-nav__extended')[i].classList.toggle('subnav-open');
     });
   }
 </script>
-
   `);
 };
 
 export const Default = Template.bind({});
-
-Default.args = {};

--- a/tegel/src/stories/Migration/Migration.stories.mdx
+++ b/tegel/src/stories/Migration/Migration.stories.mdx
@@ -302,7 +302,7 @@ Change all instances of `<a class="sdds-sidebar-nav__item-link">` to `<button cl
       </path>
     </svg>
   </a>
-    ...
+  // ...
 </li>
 // New ✅
 <li class="sdds-sidebar-nav__item sdds-sidebar-nav__extended">
@@ -315,7 +315,7 @@ Change all instances of `<a class="sdds-sidebar-nav__item-link">` to `<button cl
       <sdds-icon class="sdds-sidebar-nav__chevron" name="chevron_down" size="16px"/>
     </div>
   </button>
-  ...
+  // ...
 </li>
 ```
 

--- a/tegel/src/stories/Migration/Migration.stories.mdx
+++ b/tegel/src/stories/Migration/Migration.stories.mdx
@@ -228,7 +228,7 @@ Rename all instances of `maxlength` to `max-length`.
 <sdds-textfield
     max-length="10"
 ></sdds-textfield>
-
+```
 
 ### Not breaing but highly suggested changes
 
@@ -262,6 +262,95 @@ Change all instances of `<svg>` to `<sdds-icon>`
     <sdds-icon name="burger" size="20px" /> 
 </button>
 ```
+
+#### Used `<button>` instead of `<a>` for `sdds-sidebar-nav__item-link` inside `sdds-sidebar-nav__extended`
+
+The header was previously using `<a>` for the `sdds-sidebar-nav__item-link` that was a child of `sdds-sidebar-nav__extended`, we have now changed this
+to a `<button>` instead. 
+
+##### What action is required?
+
+Change all instances of `<a class="sdds-sidebar-nav__item-link">` to `<button class="sdds-sidebar-nav__item-link">` if it's child of `sdds-sidebar-nav__extended`.
+
+```jsx
+// Old ❌
+<li class="sdds-sidebar-nav__item sdds-sidebar-nav__extended">
+  <a class="sdds-sidebar-nav__item-link" href="#">
+    <svg
+      class="sdds-sidebar-nav__icon"
+      width="20"
+      height="20"
+      viewBox="0 0 20 20"
+      fill="#e2e2e4"
+      xmlns="http://www.w3.org/2000/svg">
+      <rect y="0.334473" width="20" height="20" />
+    </svg>
+      <span class="sdds-sidebar-nav__item-text">Sub-menu</span>
+    <svg
+      class="sdds-sidebar-nav__chevron"
+      width="12"
+      height="7"
+      viewBox="0 0 12 7"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M1 1L6 6L11 1"
+        stroke="currentColor"
+        stroke-width="1.25"
+        stroke-linecap="round"
+        stroke-linejoin="round">
+      </path>
+    </svg>
+  </a>
+    ...
+</li>
+// New ✅
+<li class="sdds-sidebar-nav__item sdds-sidebar-nav__extended">
+  <button class="sdds-sidebar-nav__item-link">
+    <div>
+      <sdds-icon class="sdds-sidebar-nav__icon" name="truck" size="20px"/>
+    </div>
+      <span class="sdds-sidebar-nav__item-text">Sub-menu</span>
+    <div>
+      <sdds-icon class="sdds-sidebar-nav__chevron" name="chevron_down" size="16px"/>
+    </div>
+  </button>
+  ...
+</li>
+```
+
+#### Used `<button>` instead of `<a>` for `sdds-sidebar-mheader__close` and used `<sdds-icon>` instead of hard `<svg>`
+
+The `sdds-sidebar-mheader` was previously using an `<a>` for it close button, we have changed this to be a button instead. 
+
+##### What action is required?
+
+Change all instances of `<a href="#" class="sdds-sidebar-mheader__close">` to `<button class="sdds-sidebar-mheader__close">` and change all instances of `<svg>` to `<sdds-icon>`.
+
+
+```jsx
+// Old ❌
+<a href="#" class="sdds-sidebar-mheader__close">
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg">
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M3.40338 2.34308C3.11048 2.05019 2.63561 2.05019 2.34272 2.34308C2.04982 2.63598 2.04982 3.11085 2.34272 3.40374L6.93897 8L2.34283 12.5961C2.04994 12.889 2.04994 13.3639 2.34283 13.6568C2.63572 13.9497 3.1106 13.9497 3.40349 13.6568L7.99963 9.06066L12.5958 13.6568C12.8887 13.9497 13.3635 13.9497 13.6564 13.6568C13.9493 13.3639 13.9493 12.889 13.6564 12.5961L9.06029 8L13.6565 3.40376C13.9494 3.11086 13.9494 2.63599 13.6565 2.3431C13.3636 2.0502 12.8888 2.0502 12.5959 2.3431L7.99963 6.93934L3.40338 2.34308Z"
+      fill="#171719"/>
+  </svg>
+</a>
+// New ✅
+<button class="sdds-sidebar-mheader__close">
+  <sdds-icon name="cross" size="20px" /> 
+</button>
+```
+
+
 
 ## Header
 

--- a/tegel/src/stories/Migration/Migration.stories.mdx
+++ b/tegel/src/stories/Migration/Migration.stories.mdx
@@ -13,11 +13,9 @@ Here is where we document all the breaking changes that we are introducing while
 
 https://www.markdownguide.org/cheat-sheet/
 
-
 ## Banner
 
 [Native](/docs/components-banner--default/)
-
 
 #### Replaced built in icon with icon component
 
@@ -40,8 +38,6 @@ For accessibility reasons, we recommend wrapping the icon in a native `button` e
   </button>
 </div>
 ```
-
-
 
 ## Button
 
@@ -180,7 +176,6 @@ Rename all instances of `sdds-stepper--small` to `sdds-stepper-sm`.
 </div>
 ```
 
-
 ## Textarea
 
 [Webcomponent](/docs/components-textarea--default)
@@ -254,19 +249,19 @@ Change all instances of `<svg>` to `<sdds-icon>`
         d="M3.97 6.998a1 1 0 0 1 1-1h22.05a1 1 0 0 1 0 2H4.97a1 1 0 0 1-1-1ZM3.97 15.982a1 1 0 0 1 1-1h22.05a1 1 0 0 1 0 2H4.97a1 1 0 0 1-1-1ZM3.97 24.966a1 1 0 0 1 1-1h22.05a1 1 0 0 1 0 2H4.97a1 1 0 0 1-1-1Z"
         fill="currentColor"
       />
-    </svg> 
+    </svg>
 </button>
 
 // New ✅
 <button class="sdds-nav__mob-menu-btn">
-    <sdds-icon name="burger" size="20px" /> 
+    <sdds-icon name="burger" size="20px" />
 </button>
 ```
 
 #### Used `<button>` instead of `<a>` for `sdds-sidebar-nav__item-link` inside `sdds-sidebar-nav__extended`
 
 The header was previously using `<a>` for the `sdds-sidebar-nav__item-link` that was a child of `sdds-sidebar-nav__extended`, we have now changed this
-to a `<button>` instead. 
+to a `<button>` instead.
 
 ##### What action is required?
 
@@ -321,12 +316,11 @@ Change all instances of `<a class="sdds-sidebar-nav__item-link">` to `<button cl
 
 #### Used `<button>` instead of `<a>` for `sdds-sidebar-mheader__close` and used `<sdds-icon>` instead of hard `<svg>`
 
-The `sdds-sidebar-mheader` was previously using an `<a>` for it close button, we have changed this to be a button instead. 
+The `sdds-sidebar-mheader` was previously using an `<a>` for it close button, we have changed this to be a button instead.
 
 ##### What action is required?
 
 Change all instances of `<a href="#" class="sdds-sidebar-mheader__close">` to `<button class="sdds-sidebar-mheader__close">` and change all instances of `<svg>` to `<sdds-icon>`.
-
 
 ```jsx
 // Old ❌
@@ -346,11 +340,9 @@ Change all instances of `<a href="#" class="sdds-sidebar-mheader__close">` to `<
 </a>
 // New ✅
 <button class="sdds-sidebar-mheader__close">
-  <sdds-icon name="cross" size="20px" /> 
+  <sdds-icon name="cross" size="20px" />
 </button>
 ```
-
-
 
 ## Header
 
@@ -400,6 +392,6 @@ Change all instances of `<svg>` to `<sdds-icon>`
 
 // New ✅
 <span class='sdds-footer-top-icon'>
-  <sdds-icon name="chevron_down" size="16px" /> 
+  <sdds-icon name="chevron_down" size="16px" />
 </span>
 ```


### PR DESCRIPTION
BREAKING CHANGE: Changed all invalid anchors to buttons for the side-menu, also updated in migration docs

**Describe pull-request**  
Changed all <a> being used as buttons to simple buttons instead. Also updated the migration docs.

**Solving issue**  
Fixes: [AB#2706](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2706)

**How to test**  
1. Go to storybook link below
2. Check in Components -> Side-menu
3. Check that the close/expand buttons still works as intended.

**Screenshots**  
-

**Additional context**  
-
