### PR TITLE
docs: add storybook-addon-html

### DIFF
--- a/tegel/.storybook/main.js
+++ b/tegel/.storybook/main.js
@@ -6,6 +6,7 @@ module.exports = {
     '@storybook/addon-interactions',
     '@storybook/addon-notes/register',
     'storybook-dark-mode',
+    '@whitespace/storybook-addon-html',
   ],
   framework: '@storybook/html',
 };

--- a/tegel/.storybook/preview.js
+++ b/tegel/.storybook/preview.js
@@ -133,6 +133,13 @@ export const parameters = {
     },
   },
   layout: 'padded',
+  html: {
+    prettier: {
+      tabWidth: 4,
+      useTabs: false,
+      htmlWhitespaceSensitivity: 'strict',
+    },
+  },
 };
 
 // Below is some hacky code that changes selected background when the theme changes

--- a/tegel/package-lock.json
+++ b/tegel/package-lock.json
@@ -13,9 +13,7 @@
         "@scania/typography": "^1.2.1",
         "@stencil/core": "^2.13.0",
         "@storybook/addon-google-analytics": "^6.2.9",
-        "concurrently": "^7.4.0",
-        "html-format": "^1.0.2",
-        "prettier": "^2.7.1"
+        "concurrently": "^7.4.0"
       },
       "devDependencies": {
         "@babel/core": "^7.19.1",
@@ -32,10 +30,15 @@
         "@storybook/manager-webpack4": "^6.5.12",
         "@storybook/testing-library": "^0.0.13",
         "@types/jest": "^27.0.3",
+        "@whitespace/storybook-addon-html": "^5.0.3",
         "babel-loader": "^8.2.5",
         "jest": "^27.4.5",
         "jest-cli": "^27.4.5",
+        "prettier": "^2.8.0",
         "puppeteer": "^10.0.0",
+        "react": "^16.14.0",
+        "react-dom": "^16.14.0",
+        "react-syntax-highlighter": "^15.5.0",
         "storybook-dark-mode": "^1.1.2"
       },
       "engines": {
@@ -4856,6 +4859,33 @@
       "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
       "dev": true
     },
+    "node_modules/@storybook/addon-notes/node_modules/hastscript": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
+      "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
+      "dev": true,
+      "dependencies": {
+        "comma-separated-tokens": "^1.0.0",
+        "hast-util-parse-selector": "^2.0.0",
+        "property-information": "^5.0.0",
+        "space-separated-tokens": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@storybook/addon-notes/node_modules/highlight.js": {
+      "version": "9.18.5",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.5.tgz",
+      "integrity": "sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==",
+      "deprecated": "Support has ended for 9.x series. Upgrade to @latest",
+      "dev": true,
+      "hasInstallScript": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@storybook/addon-notes/node_modules/isobject": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
@@ -4863,6 +4893,40 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@storybook/addon-notes/node_modules/lowlight": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.11.0.tgz",
+      "integrity": "sha512-xrGGN6XLL7MbTMdPD6NfWPwY43SNkjf/d0mecSx/CW36fUZTjRHEq0/Cdug3TWKtRXLWi7iMl1eP0olYxj/a4A==",
+      "dev": true,
+      "dependencies": {
+        "fault": "^1.0.2",
+        "highlight.js": "~9.13.0"
+      }
+    },
+    "node_modules/@storybook/addon-notes/node_modules/lowlight/node_modules/highlight.js": {
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
+      "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
+      "deprecated": "Version no longer supported. Upgrade to @latest",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@storybook/addon-notes/node_modules/parse-entities": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+      "dev": true,
+      "dependencies": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
       }
     },
     "node_modules/@storybook/addon-notes/node_modules/polished": {
@@ -4875,6 +4939,46 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@storybook/addon-notes/node_modules/prismjs": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
+      "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
+      "dev": true,
+      "optionalDependencies": {
+        "clipboard": "^2.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-notes/node_modules/react-syntax-highlighter": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-11.0.3.tgz",
+      "integrity": "sha512-0v0ET2qn9oAam4K/Te9Q/2jtS4R2d6wUFqgk5VcxrCBm+4MB5BE+oQf2CA0RanUHbYaYFuagt/AugICU87ufxQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "highlight.js": "~9.18.2",
+        "lowlight": "~1.11.0",
+        "prismjs": "^1.8.4",
+        "refractor": "^2.4.1"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
+      }
+    },
+    "node_modules/@storybook/addon-notes/node_modules/refractor": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-2.10.1.tgz",
+      "integrity": "sha512-Xh9o7hQiQlDbxo5/XkOX6H+x/q8rmlmZKr97Ie1Q8ZM32IRRd3B/UxuA/yXDW79DBSXGWxm2yRTbcTVmAciJRw==",
+      "dev": true,
+      "dependencies": {
+        "hastscript": "^5.0.0",
+        "parse-entities": "^1.1.2",
+        "prismjs": "~1.17.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/@storybook/addon-notes/node_modules/telejson": {
@@ -7151,6 +7255,31 @@
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/wast-parser": "1.9.0",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@whitespace/storybook-addon-html": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@whitespace/storybook-addon-html/-/storybook-addon-html-5.0.3.tgz",
+      "integrity": "sha512-aR9eRMST/NxEPxtF0Sne7uyFuieXmBKB3hDbB6L+Vh5c/dPtAM0sVLaA62xW/iJS8P8oLW84fShFHUOv190qCQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@storybook/addons": "^6.5.8",
+        "@storybook/api": "^6.5.8",
+        "@storybook/components": "^6.5.8",
+        "@storybook/core-events": "^6.5.8",
+        "@storybook/theming": "^6.5.8",
+        "prettier": "^2.0.0",
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-syntax-highlighter": "^15.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -13248,12 +13377,10 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "9.18.5",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.5.tgz",
-      "integrity": "sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==",
-      "deprecated": "Support has ended for 9.x series. Upgrade to @latest",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
       "dev": true,
-      "hasInstallScript": true,
       "engines": {
         "node": "*"
       }
@@ -13311,11 +13438,6 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
-    },
-    "node_modules/html-format": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/html-format/-/html-format-1.0.2.tgz",
-      "integrity": "sha512-J8OFF3Q9jPcrxKxziJR0aLy5tCr4GDIrI3XblOXdMz9dFQ6DOad06wdFsBItH1Y9tLy9Im+W4Wcoe6H5QffpbA=="
     },
     "node_modules/html-loader": {
       "version": "1.3.2",
@@ -17940,23 +18062,17 @@
       "dev": true
     },
     "node_modules/lowlight": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.11.0.tgz",
-      "integrity": "sha512-xrGGN6XLL7MbTMdPD6NfWPwY43SNkjf/d0mecSx/CW36fUZTjRHEq0/Cdug3TWKtRXLWi7iMl1eP0olYxj/a4A==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
+      "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
       "dev": true,
       "dependencies": {
-        "fault": "^1.0.2",
-        "highlight.js": "~9.13.0"
-      }
-    },
-    "node_modules/lowlight/node_modules/highlight.js": {
-      "version": "9.13.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
-      "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
-      "deprecated": "Version no longer supported. Upgrade to @latest",
-      "dev": true,
-      "engines": {
-        "node": "*"
+        "fault": "^1.0.0",
+        "highlight.js": "~10.7.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/lru-cache": {
@@ -19914,9 +20030,10 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
+      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
+      "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -20665,16 +20782,16 @@
       }
     },
     "node_modules/react-syntax-highlighter": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-11.0.3.tgz",
-      "integrity": "sha512-0v0ET2qn9oAam4K/Te9Q/2jtS4R2d6wUFqgk5VcxrCBm+4MB5BE+oQf2CA0RanUHbYaYFuagt/AugICU87ufxQ==",
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.5.0.tgz",
+      "integrity": "sha512-+zq2myprEnQmH5yw6Gqc8lD55QHnpKaU8TOcFeC/Lg/MQSs8UknEA0JC4nTZGFAXC2J2Hyj/ijJ7NlabyPi2gg==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.3.1",
-        "highlight.js": "~9.18.2",
-        "lowlight": "~1.11.0",
-        "prismjs": "^1.8.4",
-        "refractor": "^2.4.1"
+        "highlight.js": "^10.4.1",
+        "lowlight": "^1.17.0",
+        "prismjs": "^1.27.0",
+        "refractor": "^3.6.0"
       },
       "peerDependencies": {
         "react": ">= 0.14.0"
@@ -20836,57 +20953,27 @@
       }
     },
     "node_modules/refractor": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/refractor/-/refractor-2.10.1.tgz",
-      "integrity": "sha512-Xh9o7hQiQlDbxo5/XkOX6H+x/q8rmlmZKr97Ie1Q8ZM32IRRd3B/UxuA/yXDW79DBSXGWxm2yRTbcTVmAciJRw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.6.0.tgz",
+      "integrity": "sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==",
       "dev": true,
       "dependencies": {
-        "hastscript": "^5.0.0",
-        "parse-entities": "^1.1.2",
-        "prismjs": "~1.17.0"
+        "hastscript": "^6.0.0",
+        "parse-entities": "^2.0.0",
+        "prismjs": "~1.27.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/refractor/node_modules/hastscript": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
-      "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
-      "dev": true,
-      "dependencies": {
-        "comma-separated-tokens": "^1.0.0",
-        "hast-util-parse-selector": "^2.0.0",
-        "property-information": "^5.0.0",
-        "space-separated-tokens": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/refractor/node_modules/parse-entities": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-      "dev": true,
-      "dependencies": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
-      }
-    },
     "node_modules/refractor/node_modules/prismjs": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
-      "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
+      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
       "dev": true,
-      "optionalDependencies": {
-        "clipboard": "^2.0.0"
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/regenerate": {
@@ -29205,11 +29292,61 @@
           "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
           "dev": true
         },
+        "hastscript": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
+          "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
+          "dev": true,
+          "requires": {
+            "comma-separated-tokens": "^1.0.0",
+            "hast-util-parse-selector": "^2.0.0",
+            "property-information": "^5.0.0",
+            "space-separated-tokens": "^1.0.0"
+          }
+        },
+        "highlight.js": {
+          "version": "9.18.5",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.5.tgz",
+          "integrity": "sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==",
+          "dev": true
+        },
         "isobject": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
           "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
           "dev": true
+        },
+        "lowlight": {
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.11.0.tgz",
+          "integrity": "sha512-xrGGN6XLL7MbTMdPD6NfWPwY43SNkjf/d0mecSx/CW36fUZTjRHEq0/Cdug3TWKtRXLWi7iMl1eP0olYxj/a4A==",
+          "dev": true,
+          "requires": {
+            "fault": "^1.0.2",
+            "highlight.js": "~9.13.0"
+          },
+          "dependencies": {
+            "highlight.js": {
+              "version": "9.13.1",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
+              "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
+              "dev": true
+            }
+          }
+        },
+        "parse-entities": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+          "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+          "dev": true,
+          "requires": {
+            "character-entities": "^1.0.0",
+            "character-entities-legacy": "^1.0.0",
+            "character-reference-invalid": "^1.0.0",
+            "is-alphanumerical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-hexadecimal": "^1.0.0"
+          }
         },
         "polished": {
           "version": "3.7.2",
@@ -29218,6 +29355,39 @@
           "dev": true,
           "requires": {
             "@babel/runtime": "^7.12.5"
+          }
+        },
+        "prismjs": {
+          "version": "1.17.1",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
+          "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
+          "dev": true,
+          "requires": {
+            "clipboard": "^2.0.0"
+          }
+        },
+        "react-syntax-highlighter": {
+          "version": "11.0.3",
+          "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-11.0.3.tgz",
+          "integrity": "sha512-0v0ET2qn9oAam4K/Te9Q/2jtS4R2d6wUFqgk5VcxrCBm+4MB5BE+oQf2CA0RanUHbYaYFuagt/AugICU87ufxQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "highlight.js": "~9.18.2",
+            "lowlight": "~1.11.0",
+            "prismjs": "^1.8.4",
+            "refractor": "^2.4.1"
+          }
+        },
+        "refractor": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/refractor/-/refractor-2.10.1.tgz",
+          "integrity": "sha512-Xh9o7hQiQlDbxo5/XkOX6H+x/q8rmlmZKr97Ie1Q8ZM32IRRd3B/UxuA/yXDW79DBSXGWxm2yRTbcTVmAciJRw==",
+          "dev": true,
+          "requires": {
+            "hastscript": "^5.0.0",
+            "parse-entities": "^1.1.2",
+            "prismjs": "~1.17.0"
           }
         },
         "telejson": {
@@ -31014,6 +31184,13 @@
         "@webassemblyjs/wast-parser": "1.9.0",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "@whitespace/storybook-addon-html": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@whitespace/storybook-addon-html/-/storybook-addon-html-5.0.3.tgz",
+      "integrity": "sha512-aR9eRMST/NxEPxtF0Sne7uyFuieXmBKB3hDbB6L+Vh5c/dPtAM0sVLaA62xW/iJS8P8oLW84fShFHUOv190qCQ==",
+      "dev": true,
+      "requires": {}
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -35823,9 +36000,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "9.18.5",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.5.tgz",
-      "integrity": "sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
       "dev": true
     },
     "hmac-drbg": {
@@ -35880,11 +36057,6 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
-    },
-    "html-format": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/html-format/-/html-format-1.0.2.tgz",
-      "integrity": "sha512-J8OFF3Q9jPcrxKxziJR0aLy5tCr4GDIrI3XblOXdMz9dFQ6DOad06wdFsBItH1Y9tLy9Im+W4Wcoe6H5QffpbA=="
     },
     "html-loader": {
       "version": "1.3.2",
@@ -39386,21 +39558,13 @@
       }
     },
     "lowlight": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.11.0.tgz",
-      "integrity": "sha512-xrGGN6XLL7MbTMdPD6NfWPwY43SNkjf/d0mecSx/CW36fUZTjRHEq0/Cdug3TWKtRXLWi7iMl1eP0olYxj/a4A==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
+      "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
       "dev": true,
       "requires": {
-        "fault": "^1.0.2",
-        "highlight.js": "~9.13.0"
-      },
-      "dependencies": {
-        "highlight.js": {
-          "version": "9.13.1",
-          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
-          "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
-          "dev": true
-        }
+        "fault": "^1.0.0",
+        "highlight.js": "~10.7.0"
       }
     },
     "lru-cache": {
@@ -40969,9 +41133,10 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
+      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
+      "dev": true
     },
     "pretty-error": {
       "version": "2.1.2",
@@ -41537,16 +41702,16 @@
       }
     },
     "react-syntax-highlighter": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-11.0.3.tgz",
-      "integrity": "sha512-0v0ET2qn9oAam4K/Te9Q/2jtS4R2d6wUFqgk5VcxrCBm+4MB5BE+oQf2CA0RanUHbYaYFuagt/AugICU87ufxQ==",
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.5.0.tgz",
+      "integrity": "sha512-+zq2myprEnQmH5yw6Gqc8lD55QHnpKaU8TOcFeC/Lg/MQSs8UknEA0JC4nTZGFAXC2J2Hyj/ijJ7NlabyPi2gg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "highlight.js": "~9.18.2",
-        "lowlight": "~1.11.0",
-        "prismjs": "^1.8.4",
-        "refractor": "^2.4.1"
+        "highlight.js": "^10.4.1",
+        "lowlight": "^1.17.0",
+        "prismjs": "^1.27.0",
+        "refractor": "^3.6.0"
       }
     },
     "read-pkg": {
@@ -41669,50 +41834,21 @@
       }
     },
     "refractor": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/refractor/-/refractor-2.10.1.tgz",
-      "integrity": "sha512-Xh9o7hQiQlDbxo5/XkOX6H+x/q8rmlmZKr97Ie1Q8ZM32IRRd3B/UxuA/yXDW79DBSXGWxm2yRTbcTVmAciJRw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.6.0.tgz",
+      "integrity": "sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==",
       "dev": true,
       "requires": {
-        "hastscript": "^5.0.0",
-        "parse-entities": "^1.1.2",
-        "prismjs": "~1.17.0"
+        "hastscript": "^6.0.0",
+        "parse-entities": "^2.0.0",
+        "prismjs": "~1.27.0"
       },
       "dependencies": {
-        "hastscript": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
-          "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
-          "dev": true,
-          "requires": {
-            "comma-separated-tokens": "^1.0.0",
-            "hast-util-parse-selector": "^2.0.0",
-            "property-information": "^5.0.0",
-            "space-separated-tokens": "^1.0.0"
-          }
-        },
-        "parse-entities": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-          "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-          "dev": true,
-          "requires": {
-            "character-entities": "^1.0.0",
-            "character-entities-legacy": "^1.0.0",
-            "character-reference-invalid": "^1.0.0",
-            "is-alphanumerical": "^1.0.0",
-            "is-decimal": "^1.0.0",
-            "is-hexadecimal": "^1.0.0"
-          }
-        },
         "prismjs": {
-          "version": "1.17.1",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
-          "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
-          "dev": true,
-          "requires": {
-            "clipboard": "^2.0.0"
-          }
+          "version": "1.27.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
+          "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
+          "dev": true
         }
       }
     },

--- a/tegel/package.json
+++ b/tegel/package.json
@@ -50,9 +50,7 @@
     "@scania/typography": "^1.2.1",
     "@stencil/core": "^2.13.0",
     "@storybook/addon-google-analytics": "^6.2.9",
-    "concurrently": "^7.4.0",
-    "html-format": "^1.0.2",
-    "prettier": "^2.7.1"
+    "concurrently": "^7.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.19.1",
@@ -69,10 +67,15 @@
     "@storybook/manager-webpack4": "^6.5.12",
     "@storybook/testing-library": "^0.0.13",
     "@types/jest": "^27.0.3",
+    "@whitespace/storybook-addon-html": "^5.0.3",
     "babel-loader": "^8.2.5",
     "jest": "^27.4.5",
     "jest-cli": "^27.4.5",
+    "prettier": "^2.8.0",
     "puppeteer": "^10.0.0",
+    "react": "^16.14.0",
+    "react-dom": "^16.14.0",
+    "react-syntax-highlighter": "^15.5.0",
     "storybook-dark-mode": "^1.1.2"
   },
   "license": "MIT",

--- a/tegel/src/components/spinner/spinner.stories.ts
+++ b/tegel/src/components/spinner/spinner.stories.ts
@@ -1,4 +1,4 @@
-import format from 'html-format';
+import { formatHtmlPreview } from '../../utils/utils';
 import readme from './readme.md';
 
 export default {
@@ -35,7 +35,7 @@ const Template = ({ size, variant }) => {
   const sizeLookup = { 'Large': 'lg', 'Medium': 'md', 'Small': 'sm', 'Extra small': 'xs' };
   const variantLookup = { Standard: 'standard', Inverted: 'inverted' };
 
-  return format(
+  return formatHtmlPreview(
     `
   <sdds-spinner 
     size="${sizeLookup[size]}"  


### PR DESCRIPTION
Just tried storybook-addon-html quickly, which works better for displaying code.

However, it hydrates the components before displaying their html, which makes much code not copy-pastable.

Related to [AB#2639](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2639)

**Screenshots**  

![storybook-addon-html](https://user-images.githubusercontent.com/8556022/204500518-dc14005b-e200-4863-a613-be128cb7373d.gif)

<img width="983" alt="Screenshot 2022-11-29 at 11 10 23" src="https://user-images.githubusercontent.com/8556022/204501073-eab76745-3db3-4694-9312-824d418e382a.png">
