### PR TITLE
fix(badge): used correct color

### DIFF
--- a/tegel/src/components/badge/badges.scss
+++ b/tegel/src/components/badge/badges.scss
@@ -2,7 +2,7 @@
 
 :host {
   // Variables
-  --sdds-badges-bg-color: var(--sdds-red-500);
+  --sdds-badges-bg-color: var(--sdds-negative);
   --sdds-badges-color-text: var(--sdds-white);
 
   // Styling


### PR DESCRIPTION
**Describe pull-request**  
Changed bg-color of the badge to use correct (--sdds-negative) color.

**Solving issue**  
Fixes: [AB#2677](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2677)

**How to test**  
1. Go to storybook link below
2. Check in Components -> Badge
3. Check that the bg of the badge is the correct --sdds-negative.

**Screenshots**  
-

**Additional context**  
-
