### PR TITLE
feat(accordion): rename affix

### DIFF
--- a/tegel/src/components/accordion/accordion-item/accordion-item.tsx
+++ b/tegel/src/components/accordion/accordion-item/accordion-item.tsx
@@ -9,9 +9,8 @@ export class AccordionItem {
   /** The header gives users the context about the additional information available inside the panel */
   @Prop() header: string = '';
 
-  /** Icon can be placed after or before accordion header. Values accepted: `prefix` or `suffix`
-   *  Default value is `suffix` */
-  @Prop() affix: 'prefix' | 'suffix' = 'suffix';
+  /** Changes where the expand icon is placed. */
+  @Prop() expandIconPosition: 'start' | 'end' = 'end';
 
   /** Disabled option in `boolean`. */
   @Prop() disabled: boolean = false;
@@ -45,7 +44,10 @@ export class AccordionItem {
         ${this.expanded ? 'expanded' : ''}
         `}
       >
-        <div class={`sdds-accordion-header-${this.affix}`} onClick={() => this.openAccordion()}>
+        <div
+          class={`sdds-accordion-header-icon-${this.expandIconPosition}`}
+          onClick={() => this.openAccordion()}
+        >
           <div class="sdds-accordion-title">{this.header}</div>
           <div class="sdds-accordion-icon">
             <svg

--- a/tegel/src/components/accordion/accordion-item/readme.md
+++ b/tegel/src/components/accordion/accordion-item/readme.md
@@ -6,13 +6,13 @@
 
 ## Properties
 
-| Property       | Attribute       | Description                                                                                                          | Type                   | Default    |
-| -------------- | --------------- | -------------------------------------------------------------------------------------------------------------------- | ---------------------- | ---------- |
-| `affix`        | `affix`         | Icon can be placed after or before accordion header. Values accepted: `prefix` or `suffix` Default value is `suffix` | `"prefix" \| "suffix"` | `'suffix'` |
-| `disabled`     | `disabled`      | Disabled option in `boolean`.                                                                                        | `boolean`              | `false`    |
-| `expanded`     | `expanded`      | Set to true to expand panel open                                                                                     | `boolean`              | `false`    |
-| `header`       | `header`        | The header gives users the context about the additional information available inside the panel                       | `string`               | `''`       |
-| `paddingReset` | `padding-reset` | When true 16px on right padding instead of 64px                                                                      | `boolean`              | `false`    |
+| Property             | Attribute              | Description                                                                                    | Type               | Default |
+| -------------------- | ---------------------- | ---------------------------------------------------------------------------------------------- | ------------------ | ------- |
+| `disabled`           | `disabled`             | Disabled option in `boolean`.                                                                  | `boolean`          | `false` |
+| `expandIconPosition` | `expand-icon-position` | Changes where the expand icon is placed.                                                       | `"end" \| "start"` | `'end'` |
+| `expanded`           | `expanded`             | Set to true to expand panel open                                                               | `boolean`          | `false` |
+| `header`             | `header`               | The header gives users the context about the additional information available inside the panel | `string`           | `''`    |
+| `paddingReset`       | `padding-reset`        | When true 16px on right padding instead of 64px                                                | `boolean`          | `false` |
 
 
 ## Events

--- a/tegel/src/components/accordion/accordion.scss
+++ b/tegel/src/components/accordion/accordion.scss
@@ -16,8 +16,8 @@
     cursor: not-allowed;
   }
 
-  .sdds-accordion-header-prefix,
-  .sdds-accordion-header-suffix {
+  .sdds-accordion-header-icon-start,
+  .sdds-accordion-header-icon-end {
     background-color: var(--sdds-accordion-bg);
     outline: none;
     pointer-events: none;
@@ -37,8 +37,8 @@
     box-sizing: border-box;
   }
 
-  .sdds-accordion-header-prefix,
-  .sdds-accordion-header-suffix {
+  .sdds-accordion-header-icon-start,
+  .sdds-accordion-header-icon-end {
     cursor: pointer;
     display: flex;
     align-items: center;
@@ -62,7 +62,8 @@
 
   .sdds-accordion-panel {
     cursor: default;
-    padding: var(--sdds-spacing-element-8) var(--sdds-spacing-layout-64) var(--sdds-spacing-element-32) var(--sdds-spacing-element-16);
+    padding: var(--sdds-spacing-element-8) var(--sdds-spacing-layout-64)
+      var(--sdds-spacing-element-32) var(--sdds-spacing-element-16);
     display: none;
     font: var(--sdds-detail-03);
     letter-spacing: var(--sdds-detail-03-ls);
@@ -77,13 +78,13 @@
     }
   }
 
-  .sdds-accordion-header-suffix {
+  .sdds-accordion-header-icon-end {
     .sdds-accordion-icon {
       margin: 0 0 0 var(--sdds-spacing-element-32);
     }
   }
 
-  .sdds-accordion-header-prefix {
+  .sdds-accordion-header-icon-start {
     .sdds-accordion-title {
       order: 1;
     }
@@ -95,8 +96,8 @@
   }
 
   &:hover {
-    .sdds-accordion-header-prefix,
-    .sdds-accordion-header-suffix {
+    .sdds-accordion-header-icon-start,
+    .sdds-accordion-header-icon-end {
       background-color: var(--sdds-accordion-bg-hover);
     }
   }
@@ -104,8 +105,8 @@
   &:focus {
     @include sdds-focus-state;
 
-    .sdds-accordion-header-prefix,
-    .sdds-accordion-header-suffix {
+    .sdds-accordion-header-icon-start,
+    .sdds-accordion-header-icon-end {
       background-color: var(--sdds-accordion-bg-focus);
       outline: none;
     }
@@ -113,8 +114,8 @@
 
   &:active,
   &.active {
-    .sdds-accordion-header-prefix,
-    .sdds-accordion-header-suffix {
+    .sdds-accordion-header-icon-start,
+    .sdds-accordion-header-icon-end {
       background-color: var(--sdds-accordion-bg-active);
       outline: none;
     }
@@ -122,8 +123,8 @@
 
   &.disabled {
     &,
-    .sdds-accordion-header-suffix,
-    .sdds-accordion-header-prefix,
+    .sdds-accordion-header-icon-end,
+    .sdds-accordion-header-icon-start,
     .sdds-accordion-panel {
       color: var(--sdds-accordion-colour-disabled);
       cursor: not-allowed;
@@ -150,14 +151,14 @@
       transform: rotate(180deg);
     }
 
-    .sdds-accordion-header-suffix {
+    .sdds-accordion-header-icon-end {
       .sdds-accordion-icon {
         margin-right: 0;
         margin-left: var(--sdds-spacing-element-32);
       }
     }
 
-    .sdds-accordion-header-prefix {
+    .sdds-accordion-header-icon-start {
       .sdds-accordion-icon {
         margin-left: 0;
         margin-right: var(--sdds-spacing-element-16);
@@ -169,8 +170,8 @@
 :host {
   display: block;
 
-  .sdds-accordion-header-prefix,
-  .sdds-accordion-header-suffix {
+  .sdds-accordion-header-icon-start,
+  .sdds-accordion-header-icon-end {
     position: relative;
 
     &::after {
@@ -209,8 +210,8 @@
   @include sdds-focus-state;
 
   .sdds-accordion-item {
-    .sdds-accordion-header-prefix,
-    .sdds-accordion-header-suffix {
+    .sdds-accordion-header-icon-start,
+    .sdds-accordion-header-icon-end {
       background-color: var(--sdds-accordion-bg-focus);
       outline: none;
 
@@ -226,8 +227,8 @@
 }
 
 :host(:active) {
-  .sdds-accordion-header-prefix,
-  .sdds-accordion-header-suffix {
+  .sdds-accordion-header-icon-start,
+  .sdds-accordion-header-icon-end {
     background-color: var(--sdds-accordion-bg-active);
     outline: none;
   }

--- a/tegel/src/components/accordion/accordion.stories.ts
+++ b/tegel/src/components/accordion/accordion.stories.ts
@@ -6,20 +6,35 @@ export default {
   title: 'Components/Accordion',
   argTypes: {
     iconPosition: {
-      name: 'Icon position',
+      name: 'Expand icon position',
       control: {
         type: 'radio',
       },
       options: { End: 'end', Start: 'start' },
-      description: 'Icon position',
+      description: 'The horizontal position of the expand icon.',
+      table: {
+        defaultValue: { summary: 'end' },
+      },
     },
     disabled: {
-      name: 'Disabled',
-      description: 'Disabled',
+      name: 'Disable all items',
+      description: 'Disable all accordion items.',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: 'false' },
+      },
     },
     paddingReset: {
       name: 'Less padding right',
-      description: 'Less padding on the right in accordion items',
+      description: 'Less padding on the right inside accordion items.',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: 'false' },
+      },
     },
   },
   parameters: {
@@ -33,7 +48,7 @@ export default {
 };
 
 const Template = ({ disabled, iconPosition, paddingReset }) => {
-  const affixAttr = iconPosition === 'start' ? 'affix="prefix"' : '';
+  const affixAttr = iconPosition === 'start' ? 'expand-icon-position="start"' : '';
   const disabledAttr = disabled ? 'disabled' : '';
   const paddingResetAttr = paddingReset ? 'padding-reset' : '';
   const tabIndexAttr = 'tabindex="0"';
@@ -46,30 +61,11 @@ const Template = ({ disabled, iconPosition, paddingReset }) => {
       </sdds-accordion-item>
       <sdds-accordion-item header="Second item" ${tabIndexAttr} ${affixAttr} ${disabledAttr} ${paddingResetAttr} expanded>
         This is the panel, which contains associated information with the header. Usually it contains text, set in the same size as the header. 
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis laoreet vestibulum fermentum. Proin ac odio sed tellus fermentum placerat. Nam sit amet orci dui. Proin commodo tellus at mauris accumsan blandit. Donec eget suscipit lorem, sit amet ultrices tellus. Cras massa ligula, rhoncus non elementum non, molestie sed nibh.
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis laoreet vestibulum fermentum. 
       </sdds-accordion-item>
-      <sdds-accordion-item header="Third item" ${tabIndexAttr} ${affixAttr} ${disabledAttr} ${paddingResetAttr}>
-         This is the panel, which contains associated information with the header. Usually it contains text, set in the same size as the header. 
-         Lorem ipsum doler sit amet.
-       </sdds-accordion-item>
     </sdds-accordion>
   `);
 };
 
 export const Default = Template.bind({});
 Default.args = {};
-
-export const Prefix = Template.bind({});
-Prefix.args = {
-  iconPosition: 'start',
-};
-
-export const Disabled = Template.bind({});
-Disabled.args = {
-  disabled: true,
-};
-
-export const PaddingReset = Template.bind({});
-PaddingReset.args = {
-  paddingReset: true, // Allows item text to expand past suffix icon
-};

--- a/tegel/src/components/dropdown/dropdown-filter/dropdown-filter.stories.ts
+++ b/tegel/src/components/dropdown/dropdown-filter/dropdown-filter.stories.ts
@@ -21,27 +21,11 @@ export default {
       type: 'string',
       description: 'Placeholder text when no option is selected',
     },
-    labelPosition: {
-      name: 'Label position',
-      control: {
-        type: 'radio',
-      },
-      options: ['None', 'Outside'],
-      description: 'Label text position',
-    },
     disabled: {
       name: 'Disabled',
       control: {
         type: 'boolean',
       },
-    },
-    state: {
-      name: 'State',
-      control: {
-        type: 'radio',
-      },
-      options: ['Default', 'Error'],
-      description: 'Support error state',
     },
     helper: {
       name: 'Helper text',
@@ -49,11 +33,6 @@ export default {
         type: 'text',
       },
       description: 'Helper text assists the user with additional information about the dropdown',
-    },
-    label: {
-      name: 'Label text',
-      type: 'string',
-      description: 'Label text helps to describe what the dropdown contains',
     },
     defaultOption: {
       description: 'Sets a pre-selected option and replaces placeholder',
@@ -67,29 +46,14 @@ export default {
   args: {
     size: 'Large',
     placeholder: 'Placeholder',
-    label: 'Label text',
-    labelPosition: 'None',
-    helper: '',
     disabled: false,
+    helper: '',
     defaultOption: 'Option 1',
-    state: 'Default',
   },
 };
 
-const FilterTemplate = ({
-  size,
-  disabled = false,
-  helper = '',
-  label,
-  state = 'default',
-  placeholder,
-  labelPosition,
-  defaultOption,
-}) => {
-  const stateValue = state === 'Error' ? 'error' : 'default';
+const FilterTemplate = ({ size, disabled = false, helper = '', placeholder, defaultOption }) => {
   const sizeLookup = { Large: 'lg', Medium: 'md', Small: 'sm' };
-  const labelPosLookup = { None: 'no-default', Outside: 'outside' };
-
   const defaultOptionLookup = {
     'No default': 'no-default',
     'Option 1': 'option-1',
@@ -108,11 +72,8 @@ const FilterTemplate = ({
         id="sdds-dropdown-filter"
         size="${sizeLookup[size]}"
         placeholder="${placeholder}"
-        disabled="${disabled}"
-        label-position="${labelPosLookup[labelPosition]}"
-        ${labelPosLookup[labelPosition] !== 'no-default' ? `label="${label}"` : ''}
-        ${helper !== '' ? `helper="${helper}"` : ''}
-        state="${stateValue}"
+        disabled="${disabled}"\
+        ${helper !== '' ? `\n    helper="${helper}"` : ''}
         data='[
           {
             "value": "option-1",
@@ -127,8 +88,7 @@ const FilterTemplate = ({
             "label":"Barcelona"
           }
         ]'
-        default-option="${defaultOptionLookup[defaultOption]}"
-        >
+        default-option="${defaultOptionLookup[defaultOption]}">
       </sdds-dropdown-filter>
     </div>
   `);

--- a/tegel/src/components/dropdown/dropdown-wc-default.stories.ts
+++ b/tegel/src/components/dropdown/dropdown-wc-default.stories.ts
@@ -23,11 +23,6 @@ export default {
       type: 'string',
       description: 'Placeholder text when no option is selected',
     },
-    label: {
-      name: 'Label text',
-      type: 'string',
-      description: 'Label text helps to describe what the dropdown contains',
-    },
     labelPosition: {
       name: 'Label position',
       control: {
@@ -55,6 +50,11 @@ export default {
       control: 'boolean',
       description: 'Helper text assists the user with additional information about the dropdown',
     },
+    label: {
+      name: 'Label text',
+      type: 'string',
+      description: 'Label text helps to describe what the dropdown contains',
+    },
     defaultOption: {
       if: { arg: 'type', neq: 'Multiselect' },
       description: 'Sets a pre-selected option and replaces placeholder',
@@ -66,14 +66,14 @@ export default {
     },
   },
   args: {
+    defaultOption: 'Option 1',
     size: 'Large',
     placeholder: 'Placeholder',
-    label: 'Label text',
     labelPosition: 'None',
-    helper: false,
     disabled: false,
-    defaultOption: 'Option 1',
     state: 'Default',
+    helper: false,
+    label: 'Label text',
   },
 };
 

--- a/tegel/src/components/dropdown/dropdown-wc-multiselect.stories.ts
+++ b/tegel/src/components/dropdown/dropdown-wc-multiselect.stories.ts
@@ -67,12 +67,12 @@ export default {
   args: {
     size: 'Large',
     placeholder: 'Placeholder',
-    label: 'Label text',
     labelPosition: 'None',
-    helper: '',
     disabled: false,
-    multiDefaultOption: ['Option 1', 'Option 2'],
     state: 'Default',
+    helper: false,
+    label: 'Label text',
+    multiDefaultOption: ['Option 1', 'Option 2'],
   },
 };
 

--- a/tegel/src/stories/Migration/Migration.stories.mdx
+++ b/tegel/src/stories/Migration/Migration.stories.mdx
@@ -9,9 +9,39 @@ Here is where we document all the breaking changes that we are introducing while
 
 ---
 
-### MD cheatsheet
 
-https://www.markdownguide.org/cheat-sheet/
+<!-- TODO: remove link to markdownguide.org -->
+<!-- ### MD cheatsheet
+https://www.markdownguide.org/cheat-sheet/ -->
+
+## Accordion
+
+[Webcomponent](/docs/components-accordion--default/)
+
+#### Replaced `affix` with `expand-icon-position`
+
+The attribute `affix` was replaced by `expand-icon-position`, since `affix` is not descriptive enough of what it does.
+
+##### What action is required?
+
+Replace `affix="prefix"` with `expand-icon-position="start"` and remove `affix="suffix"`.
+
+```jsx
+// Old ❌
+<sdds-accordion>
+  <sdds-accordion-item header="Lorem ipsum" affix="prefix" tabindex="0">
+    // ...
+  </sdds-accordion-item>
+</sdds-accordion>
+
+// New ✅
+<sdds-accordion>
+  <sdds-accordion-item header="Lorem ipsum" expand-icon-position="start" tabindex="0">
+    // ...
+  </sdds-accordion-item>
+</sdds-accordion>
+```
+
 
 ## Banner
 


### PR DESCRIPTION
- Renames accordion item affix attribute to expand-icon-position.
- Slims down accordion story.

**Solving issue**  
Fixes: [AB#2642](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2642)