### PR TITLE
fix(textarea): refactored css so width styles is used for all states

### DIFF
--- a/tegel/src/components/textarea/textarea.scss
+++ b/tegel/src/components/textarea/textarea.scss
@@ -80,9 +80,16 @@
   border-bottom: 0;
 }
 
+.sdds-textarea-container {
+  .sdds-textarea-wrapper {
+    position: relative;
+    width: unset;
+    min-width: 100%;
+  }
+}
+
 .sdds-textarea-container:not(.sdds-textarea-disabled) {
   .sdds-textarea-wrapper {
-    //@extend .sdds-textfield-bar;
     &::before,
     &::after {
       content: '';
@@ -100,12 +107,6 @@
     &::after {
       right: 50%;
     }
-
-    //@extend end
-
-    position: relative;
-    width: unset;
-    min-width: 100%;
 
     &::after,
     &::before {


### PR DESCRIPTION
**Describe pull-request**  
The textarea width did was not used on disabled state due to it being part of the focus state css (which was removed from disabled). This PR refactors the css to include the width, min-width and positioning for all states.

**Solving issue** 
Fixes: [AB#2709](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2709)

**How to test**  
1. Go to storybook link below
2. Check in Components -> Textarea
3. Check that the component behaves as expected for all states. 

**Screenshots**  
-

**Additional context**  
-
