### PR TITLE
fix(textarea/textfield): label position label props

### DIFF
--- a/tegel/src/components/textarea/readme.md
+++ b/tegel/src/components/textarea/readme.md
@@ -5,22 +5,22 @@
 
 ## Properties
 
-| Property        | Attribute        | Description                                               | Type                     | Default      |
-| --------------- | ---------------- | --------------------------------------------------------- | ------------------------ | ------------ |
-| `autoFocus`     | `auto-focus`     | Control of autofocus                                      | `boolean`                | `false`      |
-| `cols`          | `cols`           | Textarea cols attribute                                   | `number`                 | `undefined`  |
-| `disabled`      | `disabled`       | Set input in disabled state                               | `boolean`                | `false`      |
-| `helper`        | `helper`         | Helper text                                               | `string`                 | `''`         |
-| `label`         | `label`          | Label text                                                | `string`                 | `''`         |
-| `labelPosition` | `label-position` | Label position: `no-label` (default), `inside`, `outside` | `string`                 | `'no-label'` |
-| `maxLength`     | `max-length`     | Max length of input                                       | `number`                 | `undefined`  |
-| `name`          | `name`           | Name attribute                                            | `string`                 | `''`         |
-| `placeholder`   | `placeholder`    | Placeholder text                                          | `string`                 | `''`         |
-| `readOnly`      | `read-only`      | Set input in readonly state                               | `boolean`                | `false`      |
-| `rows`          | `rows`           | Textarea rows attribute                                   | `number`                 | `undefined`  |
-| `state`         | `state`          | Error state of input                                      | `string`                 | `undefined`  |
-| `value`         | `value`          | Value of the input text                                   | `string`                 | `''`         |
-| `variant`       | `variant`        | Variant of the textarea                                   | `"default" \| "variant"` | `'default'`  |
+| Property        | Attribute        | Description                              | Type                                  | Default      |
+| --------------- | ---------------- | ---------------------------------------- | ------------------------------------- | ------------ |
+| `autoFocus`     | `auto-focus`     | Control of autofocus                     | `boolean`                             | `false`      |
+| `cols`          | `cols`           | Textarea cols attribute                  | `number`                              | `undefined`  |
+| `disabled`      | `disabled`       | Set input in disabled state              | `boolean`                             | `false`      |
+| `helper`        | `helper`         | Helper text                              | `string`                              | `''`         |
+| `label`         | `label`          | Label text                               | `string`                              | `''`         |
+| `labelPosition` | `label-position` | Position of the label for the textfield. | `"inside" \| "no-label" \| "outside"` | `'no-label'` |
+| `maxLength`     | `max-length`     | Max length of input                      | `number`                              | `undefined`  |
+| `name`          | `name`           | Name attribute                           | `string`                              | `''`         |
+| `placeholder`   | `placeholder`    | Placeholder text                         | `string`                              | `''`         |
+| `readOnly`      | `read-only`      | Set input in readonly state              | `boolean`                             | `false`      |
+| `rows`          | `rows`           | Textarea rows attribute                  | `number`                              | `undefined`  |
+| `state`         | `state`          | Error state of input                     | `string`                              | `undefined`  |
+| `value`         | `value`          | Value of the input text                  | `string`                              | `''`         |
+| `variant`       | `variant`        | Variant of the textarea                  | `"default" \| "variant"`              | `'default'`  |
 
 
 ## Events

--- a/tegel/src/components/textarea/textarea.stories.ts
+++ b/tegel/src/components/textarea/textarea.stories.ts
@@ -104,7 +104,7 @@ export default {
     placeholder: 'Placeholder',
     disabled: false,
     readonly: false,
-    label: '',
+    label: 'Label',
     labelPosition: 'None',
     helper: '',
     maxLength: 0,

--- a/tegel/src/components/textarea/textarea.stories.ts
+++ b/tegel/src/components/textarea/textarea.stories.ts
@@ -55,12 +55,12 @@ export default {
       },
     },
     labelPosition: {
-      description: 'Label can be placed inside the textfield',
       name: 'Label position',
       control: {
         type: 'radio',
       },
-      options: ['No label', 'Inside', 'Outside'],
+      options: ['None', 'Inside', 'Outside'],
+      description: 'Label text position',
     },
     helper: {
       name: 'Helper text',
@@ -105,7 +105,7 @@ export default {
     disabled: false,
     readonly: false,
     label: '',
-    labelPosition: 'No label',
+    labelPosition: 'None',
     helper: '',
     maxLength: 0,
     rows: 5,
@@ -130,9 +130,9 @@ const Template = ({
   const variantValue = variant === 'Variant' ? 'variant' : 'default';
   const stateValue = state.toLowerCase();
   const labelPosLookup = {
-    'No label': 'no-label',
-    'Inside': 'inside',
-    'Outside': 'outside',
+    None: 'no-label',
+    Inside: 'inside',
+    Outside: 'outside',
   };
   return formatHtmlPreview(`
   <style>

--- a/tegel/src/components/textarea/textarea.tsx
+++ b/tegel/src/components/textarea/textarea.tsx
@@ -92,7 +92,9 @@ export class Textarea {
         `}
         onClick={() => this.handleFocusClick()}
       >
-        {this.label.length > 0 && <span class={'sdds-textarea-label'}>{this.label}</span>}
+        {this.labelPosition !== 'no-label' && (
+          <span class={'sdds-textarea-label'}>{this.label}</span>
+        )}
         <div class="sdds-textarea-wrapper">
           <textarea
             onFocus={() => {

--- a/tegel/src/components/textarea/textarea.tsx
+++ b/tegel/src/components/textarea/textarea.tsx
@@ -24,8 +24,8 @@ export class Textarea {
   /** Textarea rows attribute */
   @Prop() rows: number;
 
-  /** Label position: `no-label` (default), `inside`, `outside` */
-  @Prop() labelPosition = 'no-label';
+  /** Position of the label for the textfield. */
+  @Prop() labelPosition: 'inside' | 'outside' | 'no-label' = 'no-label';
 
   /** Placeholder text */
   @Prop() placeholder: string = '';

--- a/tegel/src/components/textfield/readme.md
+++ b/tegel/src/components/textfield/readme.md
@@ -5,21 +5,22 @@
 
 ## Properties
 
-| Property      | Attribute      | Description                                 | Type                     | Default     |
-| ------------- | -------------- | ------------------------------------------- | ------------------------ | ----------- |
-| `autofocus`   | `autofocus`    | Autofocus for input                         | `boolean`                | `false`     |
-| `disabled`    | `disabled`     | Set input in disabled state                 | `boolean`                | `false`     |
-| `labelInside` | `label-inside` | Label that will be put inside the input     | `string`                 | `''`        |
-| `maxLength`   | `max-length`   | Max length of input                         | `number`                 | `undefined` |
-| `name`        | `name`         | Name property                               | `string`                 | `''`        |
-| `nominwidth`  | `nominwidth`   | With setting                                | `boolean`                | `false`     |
-| `placeholder` | `placeholder`  | Placeholder text                            | `string`                 | `''`        |
-| `readonly`    | `readonly`     | Set input in readonly state                 | `boolean`                | `false`     |
-| `size`        | `size`         | Size of the input                           | `"lg" \| "md" \| "sm"`   | `'lg'`      |
-| `state`       | `state`        | Error state of input                        | `string`                 | `undefined` |
-| `type`        | `type`         | Which input type, text, password or similar | `"password" \| "text"`   | `'text'`    |
-| `value`       | `value`        | Value of the input text                     | `string`                 | `''`        |
-| `variant`     | `variant`      | Variant of the textfield                    | `"default" \| "variant"` | `'default'` |
+| Property        | Attribute        | Description                                 | Type                                  | Default      |
+| --------------- | ---------------- | ------------------------------------------- | ------------------------------------- | ------------ |
+| `autofocus`     | `autofocus`      | Autofocus for input                         | `boolean`                             | `false`      |
+| `disabled`      | `disabled`       | Set input in disabled state                 | `boolean`                             | `false`      |
+| `label`         | `label`          | Label text                                  | `string`                              | `''`         |
+| `labelPosition` | `label-position` | Position of the label for the textfield.    | `"inside" \| "no-label" \| "outside"` | `'no-label'` |
+| `maxLength`     | `max-length`     | Max length of input                         | `number`                              | `undefined`  |
+| `name`          | `name`           | Name property                               | `string`                              | `''`         |
+| `nominwidth`    | `nominwidth`     | With setting                                | `boolean`                             | `false`      |
+| `placeholder`   | `placeholder`    | Placeholder text                            | `string`                              | `''`         |
+| `readonly`      | `readonly`       | Set input in readonly state                 | `boolean`                             | `false`      |
+| `size`          | `size`           | Size of the input                           | `"lg" \| "md" \| "sm"`                | `'lg'`       |
+| `state`         | `state`          | Error state of input                        | `string`                              | `undefined`  |
+| `type`          | `type`           | Which input type, text, password or similar | `"password" \| "text"`                | `'text'`     |
+| `value`         | `value`          | Value of the input text                     | `string`                              | `''`         |
+| `variant`       | `variant`        | Variant of the textfield                    | `"default" \| "variant"`              | `'default'`  |
 
 
 ## Events

--- a/tegel/src/components/textfield/textfield.scss
+++ b/tegel/src/components/textfield/textfield.scss
@@ -103,7 +103,7 @@
 } */
 
 //Textfield label
-.sdds-textfield-slot-wrap-label > * {
+.sdds-textfield-label-outside > * {
   font: var(--sdds-detail-05);
   letter-spacing: var(--sdds-detail-05-ls);
   display: block;
@@ -292,7 +292,7 @@
     }
   }
 
-  .sdds-textfield-slot-wrap-label {
+  .sdds-textfield-label-outside {
     > * {
       color: var(--sdds-textfield-disabled-label);
     }

--- a/tegel/src/components/textfield/textfield.stories.ts
+++ b/tegel/src/components/textfield/textfield.stories.ts
@@ -163,7 +163,6 @@ export default {
     suffixType: 'Icon',
     prefix: false,
     prefixType: 'Icon',
-    labelplacement: false,
     minWidth: 'Default',
     size: 'Large',
     type: 'text',

--- a/tegel/src/components/textfield/textfield.stories.ts
+++ b/tegel/src/components/textfield/textfield.stories.ts
@@ -72,13 +72,13 @@ export default {
         type: 'text',
       },
     },
-    labelplacement: {
-      description: 'Label can be placed inside the textfield',
-      name: 'Label inside',
+    labelPosition: {
+      name: 'Label position',
       control: {
-        type: 'boolean',
+        type: 'radio',
       },
-      if: { arg: 'label', neq: '' },
+      options: ['None', 'Inside', 'Outside'],
+      description: 'Label text position',
     },
     prefix: {
       name: 'Prefix',
@@ -137,16 +137,16 @@ export default {
       description: 'Switch between success or error state',
       control: {
         type: 'radio',
-        options: ['None', 'Success', 'Error'],
       },
+      options: ['None', 'Success', 'Error'],
     },
     variant: {
       name: 'Variant',
       description: 'The variant of the textarea',
       control: {
         type: 'radio',
-        options: ['Default', 'Variant'],
       },
+      options: ['Default', 'Variant'],
     },
   },
   args: {
@@ -154,7 +154,7 @@ export default {
     disabled: false,
     readonly: false,
     label: '',
-    labelPosition: 'No label',
+    labelPosition: 'None',
     helper: '',
     maxLength: 0,
     state: 'None',
@@ -178,7 +178,7 @@ const Template = ({
   disabled,
   readonly,
   label,
-  labelplacement,
+  labelPosition,
   state,
   variant,
   helper,
@@ -205,8 +205,9 @@ const Template = ({
       size="${sizeLookUp[size]}"
       state="${stateValue}"
       variant="${variantValue}"
+      label="${label}"
+      label-position="${labelPosition.toLowerCase()}"
       ${maxlength}
-      ${label && labelplacement ? `label-inside="${label}"` : ''}
       ${disabled ? 'disabled' : ''}
       ${readonly ? 'readonly' : ''}
       ${minWidth === 'No min width' ? 'noMinWidth' : ''}
@@ -219,7 +220,6 @@ const Template = ({
         </span>`
             : ''
         }
-        ${label && !labelplacement ? `<label slot='sdds-label'>${label}</label>` : ''}
         ${helper ? `<span slot='sdds-helper'>${helper}</span>` : ''}
         ${
           suffix

--- a/tegel/src/components/textfield/textfield.stories.ts
+++ b/tegel/src/components/textfield/textfield.stories.ts
@@ -153,7 +153,7 @@ export default {
     placeholderText: 'Placeholder',
     disabled: false,
     readonly: false,
-    label: '',
+    label: 'Label',
     labelPosition: 'None',
     helper: '',
     maxLength: 0,

--- a/tegel/src/components/textfield/textfield.tsx
+++ b/tegel/src/components/textfield/textfield.tsx
@@ -12,8 +12,11 @@ export class Textfield {
   /** Which input type, text, password or similar */
   @Prop({ reflect: true }) type: 'text' | 'password' = 'text';
 
-  /** Label that will be put inside the input */
-  @Prop() labelInside: string = '';
+  /** Position of the label for the textfield. */
+  @Prop() labelPosition: 'inside' | 'outside' | 'no-label' = 'no-label';
+
+  /** Label text */
+  @Prop() label: string = '';
 
   /** Placeholder text */
   @Prop() placeholder: string = '';
@@ -94,7 +97,7 @@ export class Textfield {
         }
         ${this.value ? 'sdds-textfield-data' : ''}
         ${
-          this.labelInside.length > 0 && this.size !== 'sm'
+          this.labelPosition === 'inside' && this.size !== 'sm'
             ? 'sdds-textfield-container-label-inside'
             : ''
         }
@@ -110,10 +113,11 @@ export class Textfield {
         }
         `}
       >
-        <div class="sdds-textfield-slot-wrap-label">
-          <slot name="sdds-label" />
-        </div>
-
+        {this.labelPosition === 'outside' && (
+          <div class="sdds-textfield-label-outside">
+            <div>{this.label}</div>
+          </div>
+        )}
         <div onClick={() => this.handleFocusClick()} class="sdds-textfield-container">
           <div class={`sdds-textfield-slot-wrap-prefix sdds-textfield-${this.state}`}>
             <slot name="sdds-prefix" />
@@ -145,8 +149,8 @@ export class Textfield {
               onChange={(e) => this.handleChange(e)}
             />
 
-            {this.labelInside.length > 0 && this.size !== 'sm' && (
-              <label class="sdds-textfield-label-inside">{this.labelInside}</label>
+            {this.labelPosition === 'inside' && this.size !== 'sm' && (
+              <label class="sdds-textfield-label-inside">{this.label}</label>
             )}
           </div>
           <div class="sdds-textfield-bar"></div>

--- a/tegel/src/stories/Migration/Migration.stories.mdx
+++ b/tegel/src/stories/Migration/Migration.stories.mdx
@@ -364,6 +364,64 @@ Rename all instances of `maxlength` to `max-length`.
 ></sdds-textfield>
 ```
 
+#### Changed props for label and label-position to align with convention.
+
+The prop `label-inside` was used to set an inside label, and to set an outside label you would pass a `<slot>`.
+This has been changed and aligned with convention. This component now accepts a `label` prop for the text to 
+be displayed and a `label-position` to set the position of this label. For no label just leave out the `label`
+and `label-position` props.
+
+##### What action is required?
+
+For all labels inside remove the `label-inside` prop and add `label-position="inside"` and `label="Your label text"`
+props. For label outside remove the `<label slot="sdds-label">Label text</label>` and add `label-position="outside"`
+and `label="Your label text"` props instead.
+
+```jsx
+// Old ❌ - Inside label
+<sdds-textfield
+  type="text"
+  size="lg"
+  state="none"
+  variant="default"
+  label-inside="Label text"
+  placeholder="Placeholder">
+</sdds-textfield>
+
+// Old ❌ - Outside label
+<sdds-textfield
+  type="text"
+  size="lg"
+  state="none"
+  variant="default"
+  placeholder="Placeholder">
+   <label slot="sdds-label">Label text</label>
+</sdds-textfield>
+
+
+// New ✅ - Inside label
+<sdds-textfield
+  type="text"
+  size="lg"
+  state="none"
+  variant="default"
+  label="Label text"
+  label-position="inside"
+  placeholder="Placeholder"
+></sdds-textfield>
+
+// New ✅ - Outside label
+<sdds-textfield
+  type="text"
+  size="lg"
+  state="none"
+  variant="default"
+  label="Label text"
+  label-position="outside"
+  placeholder="Placeholder"
+></sdds-textfield>
+```
+
 ### Not breaing but highly suggested changes
 
 ## Side menu


### PR DESCRIPTION
**Describe pull-request**  
Changed the label/labelPosition props to align the component with each other. After this change both components have label="Label text" and label-position="inside | outside | no-label". 

**Solving issue**  
Fixes: [AB#2742](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2742)

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Textarea/Textfield
3. Check that the controls and the example code works as they should.

**Screenshots**  
-

**Additional context**  
-
