### PR TITLE
fix(textfield): changed the nominwidth prop to noMinWidth

### DIFF
--- a/tegel/src/components/textfield/readme.md
+++ b/tegel/src/components/textfield/readme.md
@@ -13,7 +13,7 @@
 | `labelPosition` | `label-position` | Position of the label for the textfield.    | `"inside" \| "no-label" \| "outside"` | `'no-label'` |
 | `maxLength`     | `max-length`     | Max length of input                         | `number`                              | `undefined`  |
 | `name`          | `name`           | Name property                               | `string`                              | `''`         |
-| `nominwidth`    | `nominwidth`     | With setting                                | `boolean`                             | `false`      |
+| `noMinWidth`    | `no-min-width`   | With setting                                | `boolean`                             | `false`      |
 | `placeholder`   | `placeholder`    | Placeholder text                            | `string`                              | `''`         |
 | `readonly`      | `readonly`       | Set input in readonly state                 | `boolean`                             | `false`      |
 | `size`          | `size`           | Size of the input                           | `"lg" \| "md" \| "sm"`                | `'lg'`       |

--- a/tegel/src/components/textfield/textfield.stories.ts
+++ b/tegel/src/components/textfield/textfield.stories.ts
@@ -200,7 +200,13 @@ const Template = ({
 
   return formatHtmlPreview(
     `
-  <div style="width: 208px">
+    <style>
+      .demo-wrapper {
+        width: 200px;
+        height: 150px;
+      }
+    </style>
+  <div class="demo-wrapper">
     <sdds-textfield
       type="${type}"
       size="${sizeLookUp[size]}"

--- a/tegel/src/components/textfield/textfield.stories.ts
+++ b/tegel/src/components/textfield/textfield.stories.ts
@@ -44,11 +44,13 @@ export default {
       },
     },
     minWidth: {
-      name: 'Min width',
-      description: 'Toggle min width',
+      name: 'No minimum width',
+      description: 'Toggle the minimum width.',
       control: {
-        type: 'radio',
-        options: ['Default', 'No min width'],
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
       },
     },
     disabled: {
@@ -209,7 +211,7 @@ const Template = ({
       ${maxlength}
       ${disabled ? 'disabled' : ''}
       ${readonly ? 'readonly' : ''}
-      ${minWidth === 'No min width' ? 'no-min-width' : ''}
+      ${minWidth ? 'no-min-width' : ''}
       placeholder="${placeholderText}" >
         ${
           prefix

--- a/tegel/src/components/textfield/textfield.stories.ts
+++ b/tegel/src/components/textfield/textfield.stories.ts
@@ -209,7 +209,7 @@ const Template = ({
       ${maxlength}
       ${disabled ? 'disabled' : ''}
       ${readonly ? 'readonly' : ''}
-      ${minWidth === 'No min width' ? 'noMinWidth' : ''}
+      ${minWidth === 'No min width' ? 'no-min-width' : ''}
       placeholder="${placeholderText}" >
         ${
           prefix

--- a/tegel/src/components/textfield/textfield.tsx
+++ b/tegel/src/components/textfield/textfield.tsx
@@ -37,7 +37,7 @@ export class Textfield {
   @Prop() variant: 'default' | 'variant' = 'default';
 
   /** With setting */
-  @Prop() nominwidth: boolean = false;
+  @Prop() noMinWidth: boolean = false;
 
   /** Name property */
   @Prop() name = '';
@@ -89,7 +89,7 @@ export class Textfield {
     return (
       <div
         class={`
-        ${this.nominwidth ? 'sdds-form-textfield-nomin' : ''}
+        ${this.noMinWidth ? 'sdds-form-textfield-nomin' : ''}
         ${
           this.focusInput && !this.disabled
             ? 'sdds-form-textfield sdds-textfield-focus'

--- a/tegel/src/stories/Migration/Migration.stories.mdx
+++ b/tegel/src/stories/Migration/Migration.stories.mdx
@@ -344,7 +344,7 @@ Rename all instances of `autofocus` to `auto-focus`.
 
 [Webcomponent](/docs/components-textarea--default)
 
-#### Changed prop name 'max-length'
+#### Changed prop name 'maxlength'
 
 The prop `maxlength` was changed to `max-length` to conform with other prop names.
 
@@ -419,6 +419,26 @@ and `label="Your label text"` props instead.
   label="Label text"
   label-position="outside"
   placeholder="Placeholder"
+  ></sdds-textfield>
+```
+
+#### Changed prop name 'nominwidth'
+
+The prop `nominwidth` was changed to `no-min-width` to conform with other prop names.
+
+##### What action is required?
+
+Rename all instances of `nominwidth` to `no-min-width`.
+
+```jsx
+// Old ❌
+<sdds-textfield
+    nominwidth
+></sdds-textfield>
+
+// New ✅
+<sdds-textfield
+    no-min-width
 ></sdds-textfield>
 ```
 


### PR DESCRIPTION
**Describe pull-request**  
Changed the prop name to conform with convention and refactored story to include a demo-wrapper.

BREAKING CHANGE: Changed the prop name from nominwidth to no-min-width

**Solving issue**  
Fixes: [AB#2743](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2743)

**How to test**  
1. Go to storybook link below
2. Check in Components -> Textfield
3. Check that the no-min-width prop works as intended. Also check the migration.mdx.

**Screenshots**  
-

**Additional context**  
-
