### PR TITLE
fix(textarea): changed readonly and autofocus props to camelCase

### DIFF
--- a/tegel/src/components/textarea/readme.md
+++ b/tegel/src/components/textarea/readme.md
@@ -7,7 +7,7 @@
 
 | Property        | Attribute        | Description                                               | Type                     | Default      |
 | --------------- | ---------------- | --------------------------------------------------------- | ------------------------ | ------------ |
-| `autofocus`     | `autofocus`      | Control of autofocus                                      | `boolean`                | `false`      |
+| `autoFocus`     | `auto-focus`     | Control of autofocus                                      | `boolean`                | `false`      |
 | `cols`          | `cols`           | Textarea cols attribute                                   | `number`                 | `undefined`  |
 | `disabled`      | `disabled`       | Set input in disabled state                               | `boolean`                | `false`      |
 | `helper`        | `helper`         | Helper text                                               | `string`                 | `''`         |
@@ -16,7 +16,7 @@
 | `maxLength`     | `max-length`     | Max length of input                                       | `number`                 | `undefined`  |
 | `name`          | `name`           | Name attribute                                            | `string`                 | `''`         |
 | `placeholder`   | `placeholder`    | Placeholder text                                          | `string`                 | `''`         |
-| `readonly`      | `readonly`       | Set input in readonly state                               | `boolean`                | `false`      |
+| `readOnly`      | `read-only`      | Set input in readonly state                               | `boolean`                | `false`      |
 | `rows`          | `rows`           | Textarea rows attribute                                   | `number`                 | `undefined`  |
 | `state`         | `state`          | Error state of input                                      | `string`                 | `undefined`  |
 | `value`         | `value`          | Value of the input text                                   | `string`                 | `null`       |

--- a/tegel/src/components/textarea/textarea.tsx
+++ b/tegel/src/components/textarea/textarea.tsx
@@ -37,7 +37,7 @@ export class Textarea {
   @Prop() disabled: boolean = false;
 
   /** Set input in readonly state */
-  @Prop() readonly: boolean = false;
+  @Prop() readOnly: boolean = false;
 
   /** Error state of input */
   @Prop() state: string;
@@ -49,7 +49,7 @@ export class Textarea {
   @Prop() variant: 'default' | 'variant' = 'default';
 
   /** Control of autofocus */
-  @Prop() autofocus: boolean = false;
+  @Prop() autoFocus: boolean = false;
 
   /** Listen to the focus state of the input */
   @State() focusInput;
@@ -85,7 +85,7 @@ export class Textarea {
         ${this.labelPosition === 'inside' ? 'sdds-textarea-label-inside' : ''}
         ${this.focusInput ? 'sdds-textarea-focus' : ''}
         ${this.disabled ? 'sdds-textarea-disabled' : ''}
-        ${this.readonly ? 'sdds-textarea-readonly' : ''}
+        ${this.readOnly ? 'sdds-textarea-readonly' : ''}
         ${this.variant === 'default' ? '' : 'sdds-on-white-bg'}
         ${this.value ? 'sdds-textarea-data' : ''}
         ${this.state == 'error' || this.state == 'success' ? `sdds-textarea-${this.state}` : ''}
@@ -104,11 +104,11 @@ export class Textarea {
             class={'sdds-textarea-input'}
             ref={(inputEl) => (this.textEl = inputEl as HTMLTextAreaElement)}
             disabled={this.disabled}
-            readonly={this.readonly}
+            readonly={this.readOnly}
             placeholder={this.placeholder}
             value={this.value}
             name={this.name}
-            autofocus={this.autofocus}
+            autofocus={this.autoFocus}
             maxlength={this.maxLength}
             cols={this.cols}
             rows={this.rows}

--- a/tegel/src/stories/Migration/Migration.stories.mdx
+++ b/tegel/src/stories/Migration/Migration.stories.mdx
@@ -231,6 +231,48 @@ Rename all instances of `maxlength` to `max-length`.
 
 ```
 
+#### Changed prop name 'readonly'
+
+The prop `readonly` was changed to `read-only` to conform with other prop names.
+
+##### What action is required?
+
+Rename all instances of `readonly` to `read-only`.
+
+```jsx
+// Old ❌
+<sdds-textarea
+    readonly
+></sdds-textarea>
+
+// New ✅
+<sdds-textarea
+    read-only
+></sdds-textarea>
+
+```
+
+#### Changed prop name 'autofocus'
+
+The prop `autofocus` was changed to `auto-focus` to conform with other prop names.
+
+##### What action is required?
+
+Rename all instances of `autofocus` to `auto-focus`.
+
+```jsx
+// Old ❌
+<sdds-textarea
+    autofocus
+></sdds-textarea>
+
+// New ✅
+<sdds-textarea
+    auto-focus
+></sdds-textarea>
+
+```
+
 ## Textfield
 
 [Webcomponent](/docs/components-textarea--default)


### PR DESCRIPTION
**Describe pull-request**  
Changed readonly and autofocus props to camelCase to conform with other propnames

BREAKING CHANGE: Changed readonly to read-only and autofocus to auto-focus


**Solving issue**  
Fixes: [AB#2744](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2744)

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Textarea
3. Check the props in the story and the migration.mdx

**Screenshots**  
-

**Additional context**  
-
