### PR TITLE
fix(block): changed the class names for block to conform with convention

### DIFF
--- a/tegel/src/components/block/block.scss
+++ b/tegel/src/components/block/block.scss
@@ -11,7 +11,7 @@
     background-color: var(--sdds-block-bg-default-nested);
   }
 
-  &__variant {
+  &-variant {
     background-color: var(--sdds-block-bg-variant);
 
     .sdds-block {

--- a/tegel/src/components/block/block.stories.ts
+++ b/tegel/src/components/block/block.stories.ts
@@ -34,7 +34,7 @@ export default {
 
 const Template = ({ type }) =>  formatHtmlPreview(
     `
-      <div class="sdds-block sdds-block__${type.toLowerCase()}">
+      <div class="sdds-block sdds-block-${type.toLowerCase()}">
       <h2 class="sdds-headline-02">Block</h2>
         <p class="sdds-body-01">Lorem ipsum dolor sit amet, consectetur adipiscing elit. In condimentum nisi ut eleifend ultrices. Nunc venenatis maximus sapien, ac bibendum nisl aliquam in. Morbi ac velit et ligula consectetur interdum. Vestibulum condimentum, augue vitae lobortis rhoncus, mi est ultricies mi, sed tincidunt magna nibh in lectus. Pellentesque vel vulputate orci, vel lacinia orci. Sed suscipit leo at diam ullamcorper, vitae volutpat neque dapibus. Maecenas sit amet rhoncus arcu. Sed sed molestie elit. Nullam in interdum est, vitae aliquam ipsum. Nunc rutrum nibh ut arcu egestas egestas.</p>
         <div class="sdds-block">
@@ -47,4 +47,3 @@ const Template = ({ type }) =>  formatHtmlPreview(
 
 
 export const Default = Template.bind({});
-Default.args = {};

--- a/tegel/src/components/textfield/textfield.stories.ts
+++ b/tegel/src/components/textfield/textfield.stories.ts
@@ -89,7 +89,15 @@ export default {
       table: {
         defaultValue: { summary: false },
       },
-      if: { arg: 'icon', eq: false },
+    },
+    prefixType: {
+      name: 'Prefix type',
+      description: 'Choose icon or text for prefix.',
+      control: {
+        type: 'radio',
+      },
+      options: ['Icon', 'Text'],
+      if: { arg: 'prefix', eq: true },
     },
     suffix: {
       name: 'Suffix',
@@ -101,16 +109,14 @@ export default {
         defaultValue: { summary: false },
       },
     },
-    icon: {
-      name: 'Icon',
-      description: 'Add icon before or after the textfield',
+    suffixType: {
+      name: 'Suffix type',
+      description: 'Choose icon or text for suffix.',
       control: {
-        type: 'boolean',
+        type: 'radio',
       },
-      if: { arg: 'prefix', eq: false },
-      table: {
-        defaultValue: { summary: false },
-      },
+      options: ['Icon', 'Text'],
+      if: { arg: 'suffix', eq: true },
     },
     helper: {
       name: 'Helper text',
@@ -153,9 +159,10 @@ export default {
     maxLength: 0,
     state: 'None',
     variant: 'Default',
-    icon: false,
     suffix: false,
+    suffixType: 'Icon',
     prefix: false,
+    prefixType: 'Icon',
     labelplacement: false,
     minWidth: 'Default',
     size: 'Large',
@@ -176,8 +183,9 @@ const Template = ({
   variant,
   helper,
   prefix,
+  prefixType,
   suffix,
-  icon,
+  suffixType,
   maxLength,
 }) => {
   const maxlength = maxLength > 0 ? `max-length="${maxLength}"` : '';
@@ -203,16 +211,31 @@ const Template = ({
       ${readonly ? 'readonly' : ''}
       ${minWidth === 'No min width' ? 'noMinWidth' : ''}
       placeholder="${placeholderText}" >
-        ${prefix ? '<span slot="sdds-prefix">$</span>' : ''}
+        ${
+          prefix
+            ? `
+        <span slot="sdds-prefix">
+          ${prefixType === 'Text' ? '$' : '<sdds-icon name="truck" size="20px"/>'}
+        </span>`
+            : ''
+        }
         ${label && !labelplacement ? `<label slot='sdds-label'>${label}</label>` : ''}
         ${helper ? `<span slot='sdds-helper'>${helper}</span>` : ''}
-        ${suffix ? '<span slot="sdds-suffix">$</span>' : ''}
-        ${icon ? '<sdds-icon name="cross" slot="sdds-prefix"></sdds-icon>' : ''}
-    </sdds-textfield>
+        ${
+          suffix
+            ? `
+        <span slot="sdds-suffix">
+          ${suffixType === 'Text' ? '$' : '<sdds-icon name="truck" size="20px"/>'}
+        </span>`
+            : ''
+        }
+        </sdds-textfield>
   </div>
   `,
   );
 };
+
+// ${true ? '<sdds-icon name="cross" slot="sdds-prefix"></sdds-icon>' : ''}
 
 export const Default = Template.bind({});
 

--- a/tegel/src/stories/Migration/Migration.stories.mdx
+++ b/tegel/src/stories/Migration/Migration.stories.mdx
@@ -69,6 +69,37 @@ For accessibility reasons, we recommend wrapping the icon in a native `button` e
 </div>
 ```
 
+## Block  
+
+[Native](/docs/components-block--default/)
+
+#### Renamed classes `sdds-block__default` and `sdds-block__variant` to conform with convention
+
+The classes `sdds-block__default` and `sdds-block__variant` was renamed to `sdds-block-default` and `sdds-block-variant` to conform with convention.
+
+##### What action is required?
+
+Replace all instaces of `sdds-block__default` and `sdds-block__variant` with `sdds-block-default` and `sdds-block-variant`.
+
+```jsx
+// Old ❌
+<div class="sdds-block sdds-block__default">
+  <p>Content....</p>
+</div>
+<div class="sdds-block sdds-block__variant">
+  <p>Content....</p>
+</div>
+
+
+// New ✅
+<div class="sdds-block sdds-block-default">
+  <p>Content....</p>
+</div>
+<div class="sdds-block sdds-block-variant">
+  <p>Content....</p>
+</div>
+```
+
 ## Button
 
 [Native](/docs/components-button--native/)


### PR DESCRIPTION
BREAKING CHANGE: Changed the class names sdds-block__default and sdds-block__variant to single dash, sdds-block-default and sdds-block-variant

**Describe pull-request**  
Changed sdds-block__default/variant to single dash names. 

**Solving issue**  
Fixes: [AB#2700](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2700)

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Block
3. Check that the style of the component is correct.
4. Check the migration.mdx. 

**Screenshots**  
-

**Additional context**  
-
