### PR TITLE
fix(navigation-tabs): changed the class names for navigation-tabs to conform with convention

### DIFF
--- a/tegel/src/components/tabs/navigation-tabs/navigation-tabs.scss
+++ b/tegel/src/components/tabs/navigation-tabs/navigation-tabs.scss
@@ -27,7 +27,7 @@
     }
   }
 
-  &--forward {
+  &-forward {
     cursor: pointer;
     width: 48px;
     height: 100%;
@@ -61,7 +61,7 @@
     }
   }
 
-  &--back {
+  &-back {
     cursor: pointer;
     width: 48px;
     height: 100%;
@@ -95,7 +95,7 @@
   }
 
   /* tab */
-  ::slotted(&--tab) {
+  ::slotted(&-tab) {
     //fixme: headline-07 has a line-height that is not matching old storybook
     font: var(--sdds-headline-07);
     letter-spacing: var(--sdds-headline-07-ls);
@@ -126,16 +126,16 @@
     }
   }
 
-  ::slotted(&--tab:first-child) {
+  ::slotted(&-tab:first-child) {
     margin-left: 32px;
   }
 
-  ::slotted(&--tab:last-child) {
+  ::slotted(&-tab:last-child) {
     margin-right: 32px;
   }
 
   /* tab states */
-  ::slotted(&--tab:hover) {
+  ::slotted(&-tab:hover) {
     color: var(--sdds-navigation-tabs-tab-hover-color);
 
     &::after {
@@ -143,7 +143,7 @@
     }
   }
 
-  ::slotted(&--tab:focus) {
+  ::slotted(&-tab:focus) {
     @include sdds-focus-state;
 
     color: var(--sdds-navigation-tabs-tab-focus-color);
@@ -153,7 +153,7 @@
     }
   }
 
-  ::slotted(&--tab__active) {
+  ::slotted(&-tab-active) {
     color: var(--sdds-navigation-tabs-tab-active-color);
 
     &::after {
@@ -165,11 +165,11 @@
     }
   }
 
-  ::slotted(&--tab__active:focus)::after {
+  ::slotted(&-tab-active:focus)::after {
     width: 100%;
   }
 
-  ::slotted(&--tab__disabled) {
+  ::slotted(&-tab-disabled) {
     color: var(--sdds-navigation-tabs-tab-active-color);
     opacity: 0.16;
     pointer-events: none;

--- a/tegel/src/components/tabs/navigation-tabs/navigation-tabs.stories.ts
+++ b/tegel/src/components/tabs/navigation-tabs/navigation-tabs.stories.ts
@@ -24,11 +24,11 @@ export default {
 const Template = () =>
   formatHtmlPreview(`
     <sdds-navigation-tabs>
-      <a href="#" class="sdds-navigation-tabs--tab__active">Active tab</a>
+      <a href="#" class="sdds-navigation-tabs-tab-active">Active tab</a>
       <a href="#">Tab name</a>
       <a href="#">Tab name</a>
       <a href="#">Tab name</a>
-      <a role="link" aria-disabled="true" class="sdds-navigation-tabs--tab__disabled">Disabled tab</a>
+      <a role="link" aria-disabled="true" class="sdds-navigation-tabs-tab-disabled">Disabled tab</a>
     </sdds-navigation-tabs>
     `);
 

--- a/tegel/src/components/tabs/navigation-tabs/navigation-tabs.tsx
+++ b/tegel/src/components/tabs/navigation-tabs/navigation-tabs.tsx
@@ -29,7 +29,7 @@ export class NavigationTabs {
   }
 
   componentDidLoad() {
-    const resizeObserver = new ResizeObserver(entries => {
+    const resizeObserver = new ResizeObserver((entries) => {
       for (const entry of entries) {
         const componentWidth = entry.contentRect.width;
         let buttonsWidth = 0;
@@ -37,9 +37,10 @@ export class NavigationTabs {
         const navButtons = Array.from(this.host.children);
         navButtons.forEach((navButton: HTMLElement) => {
           const style = window.getComputedStyle(navButton);
-          buttonsWidth += navButton.clientWidth + parseFloat(style.marginLeft) + parseFloat(style.marginRight);
+          buttonsWidth +=
+            navButton.clientWidth + parseFloat(style.marginLeft) + parseFloat(style.marginRight);
 
-          navButton.classList.add('sdds-navigation-tabs--tab');
+          navButton.classList.add('sdds-navigation-tabs-tab');
         });
 
         this.componentWidth = componentWidth;
@@ -65,7 +66,8 @@ export class NavigationTabs {
     const navButtons = Array.from(this.host.children);
     navButtons.forEach((navButton: HTMLElement) => {
       const style = window.getComputedStyle(navButton);
-      const width = navButton.clientWidth + parseFloat(style.marginLeft) + parseFloat(style.marginRight);
+      const width =
+        navButton.clientWidth + parseFloat(style.marginLeft) + parseFloat(style.marginRight);
 
       if (width > best) {
         best = width;
@@ -109,12 +111,26 @@ export class NavigationTabs {
     return (
       <Host>
         <div class="sdds-navigation-tabs">
-          <div class="sdds-navigation-tabs-wrapper" ref={el => (this.navWrapperElement = el as HTMLElement)}>
+          <div
+            class="sdds-navigation-tabs-wrapper"
+            ref={(el) => (this.navWrapperElement = el as HTMLElement)}
+          >
             <slot />
           </div>
           <div class="sdds-navigation-tabs-navigation">
-            <button class={`sdds-navigation-tabs--forward ${this.showRightScroll ? 'sdds-navigation-tabs--forward__show' : ''}`} onClick={() => this._scrollRight()}>
-              <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <button
+              class={`sdds-navigation-tabs-forward ${
+                this.showRightScroll ? 'sdds-navigation-tabs-forward-show' : ''
+              }`}
+              onClick={() => this._scrollRight()}
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 20 20"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
                 <path
                   fill-rule="evenodd"
                   clip-rule="evenodd"
@@ -123,8 +139,19 @@ export class NavigationTabs {
                 ></path>
               </svg>
             </button>
-            <button class={`sdds-navigation-tabs--back ${this.showLeftScroll ? 'sdds-navigation-tabs--back__show' : ''}`} onClick={() => this._scrollLeft()}>
-              <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <button
+              class={`sdds-navigation-tabs-back ${
+                this.showLeftScroll ? 'sdds-navigation-tabs-back-show' : ''
+              }`}
+              onClick={() => this._scrollLeft()}
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 20 20"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
                 <path
                   fill-rule="evenodd"
                   clip-rule="evenodd"

--- a/tegel/src/stories/Migration/Migration.stories.mdx
+++ b/tegel/src/stories/Migration/Migration.stories.mdx
@@ -237,6 +237,42 @@ Rename all instances of `sdds-stepper--small` to `sdds-stepper-sm`.
 </div>
 ```
 
+## Navigation Tabs
+
+[Webcomponent](/docs/components-tabs--navigation-tabs)
+
+#### Changed class names `sdds-navigation-tabs--tab__active` and `sdds-navigation-tabs--tab__disabled` 
+
+The class names `sdds-navigation-tabs--tab__active` and `sdds-navigation-tabs--tab__disabled` was
+changed to `sdds-navigation-tabs-tab-active` and `sdds-navigation-tabs-tab-disabled` to conform
+with convention.  
+
+##### What action is required?
+
+Changed all instaces of `sdds-navigation-tabs--tab__active` and `sdds-navigation-tabs--tab__disabled`
+to `sdds-navigation-tabs-tab-active` and `sdds-navigation-tabs-tab-disabled`.
+
+```jsx
+// Old ❌
+<sdds-navigation-tabs>
+  <a href="#" class="sdds-navigation-tabs--tab__active">Active tab</a>
+  <a href="#">Tab name</a>
+  <a href="#">Tab name</a>
+  <a href="#">Tab name</a>
+  <a role="link" aria-disabled="true" class="sdds-navigation-tabs--tab__disabled">Disabled tab</a>
+</sdds-navigation-tabs>
+
+// New ✅
+<sdds-navigation-tabs>
+  <a href="#" class="sdds-navigation-tabs-tab-active">Active tab</a>
+  <a href="#">Tab name</a>
+  <a href="#">Tab name</a>
+  <a href="#">Tab name</a>
+  <a role="link" aria-disabled="true" class="sdds-navigation-tabs-tab-disabled">Disabled tab</a>
+</sdds-navigation-tabs>
+
+```
+
 ## Textarea
 
 [Webcomponent](/docs/components-textarea--default)


### PR DESCRIPTION
**Describe pull-request**  
Refactored both the external and the components internal class names to conform with convention (single dash). Also updated the migration.mdx

BREAKING CHANGE: Classes the previously had -- or __ was changed to single dash.

**Solving issue**  
Fixes: [AB#2702](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2702)

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Tabs -> Navigation tabs
3. Check that the component has the correct styling and that the migration.mdx updates makes sence.

**Screenshots**  
-

**Additional context**  
-
