### PR TITLE
docs: fix docs and controls gone in storybook

### DIFF
--- a/tegel/.storybook/main.js
+++ b/tegel/.storybook/main.js
@@ -5,7 +5,7 @@ module.exports = {
     '@storybook/addon-essentials',
     // '@storybook/addon-interactions',
     '@storybook/addon-notes/register',
-    'storybook-dark-mode',,
+    'storybook-dark-mode',
     'storybook-addon-designs',
     '@storybook/addon-a11y',
     'addon-screen-reader',


### PR DESCRIPTION
Removes a rouge comma to bring back the docs tab in storybook as well as the controls.