### PR TITLE
feat(inline-tabs/inline-tabs-fullbleed): added variant prop

### DIFF
--- a/components/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.scss
+++ b/components/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.scss
@@ -176,7 +176,7 @@
   }
 }
 
-.sdds-inline-tabs-fullbleed__onwhite {
+.sdds-inline-tabs-fullbleed-primary {
   background-color: var(--sdds-white);
 
   .sdds-inline-tabs-fullbleed--forward {
@@ -188,7 +188,7 @@
   }
 }
 
-.sdds-inline-tabs-fullbleed__ongrey50 {
+.sdds-inline-tabs-fullbleed-secondary {
   background-color: var(--sdds-grey-50);
 
   .sdds-inline-tabs-fullbleed--forward {

--- a/components/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.stories.js
+++ b/components/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.stories.js
@@ -4,8 +4,8 @@ export default {
     layout: 'fullpage',
   },
   argTypes: {
-    variant: {
-      name: "Variant",
+    modeVariant: {
+      name: "Mode variant",
       control: {
         type: 'radio'
       }, 
@@ -15,8 +15,8 @@ export default {
   }
 };
 
-const Template = ({variant}) => `
-  <sdds-inline-tabs-fullbleed id="inline-tabs-fullbleed-example" variant="${variant.toLowerCase()}">
+const Template = ({modeVariant}) => `
+  <sdds-inline-tabs-fullbleed id="inline-tabs-fullbleed-example" mode-variant="${modeVariant.toLowerCase()}">
     <a href="#">Tab name</a>
     <a href="#" class="sdds-inline-tabs-fullbleed--tab__active">Tab name</a>
     <a href="#">Tab name</a>

--- a/components/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.stories.js
+++ b/components/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.stories.js
@@ -3,10 +3,20 @@ export default {
   parameters: {
     layout: 'fullpage',
   },
+  argTypes: {
+    variant: {
+      name: "Variant",
+      control: {
+        type: 'radio'
+      }, 
+      options: ['Primary', 'Secondary'],
+      defaultValue: 'Primary'
+    }
+  }
 };
 
-const Template = () => `
-  <sdds-inline-tabs-fullbleed id="inline-tabs-fullbleed-example">
+const Template = ({variant}) => `
+  <sdds-inline-tabs-fullbleed id="inline-tabs-fullbleed-example" variant="${variant.toLowerCase()}">
     <a href="#">Tab name</a>
     <a href="#" class="sdds-inline-tabs-fullbleed--tab__active">Tab name</a>
     <a href="#">Tab name</a>

--- a/components/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.tsx
+++ b/components/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, State, Element, h } from '@stencil/core';
+import { Component, Host, State, Element, h, Prop } from '@stencil/core';
 
 @Component({
   tag: 'sdds-inline-tabs-fullbleed',
@@ -6,6 +6,9 @@ import { Component, Host, State, Element, h } from '@stencil/core';
   shadow: true,
 })
 export class InlineTabsFullbleed {
+  /** Variant of the tabs, primary= on white, secondary= on grey50 */
+  @Prop() variant: 'primary' | 'secondary' = 'primary';
+
   @Element() host: HTMLElement;
 
   @State() tabs: Array<any> = []; // array with metadata for slotted children
@@ -38,9 +41,7 @@ export class InlineTabsFullbleed {
         navButtons.forEach((navButton: HTMLElement) => {
           const style = window.getComputedStyle(navButton);
           buttonsWidth +=
-            navButton.clientWidth +
-            parseFloat(style.marginLeft) +
-            parseFloat(style.marginRight);
+            navButton.clientWidth + parseFloat(style.marginLeft) + parseFloat(style.marginRight);
 
           navButton.classList.add('sdds-inline-tabs-fullbleed--tab');
         });
@@ -69,9 +70,7 @@ export class InlineTabsFullbleed {
     navButtons.forEach((navButton: HTMLElement) => {
       const style = window.getComputedStyle(navButton);
       const width =
-        navButton.clientWidth +
-        parseFloat(style.marginLeft) +
-        parseFloat(style.marginRight);
+        navButton.clientWidth + parseFloat(style.marginLeft) + parseFloat(style.marginRight);
 
       if (width > best) {
         best = width;
@@ -114,7 +113,7 @@ export class InlineTabsFullbleed {
   render() {
     return (
       <Host>
-        <div class="sdds-inline-tabs-fullbleed">
+        <div class={`sdds-inline-tabs-fullbleed sdds-inline-tabs-fullbleed-${this.variant}`}>
           <div
             class="sdds-inline-tabs-fullbleed-wrapper"
             ref={(el) => (this.navWrapperElement = el as HTMLElement)}
@@ -124,9 +123,7 @@ export class InlineTabsFullbleed {
           <div class="sdds-inline-tabs-fullbleed-navigation">
             <button
               class={`sdds-inline-tabs-fullbleed--forward ${
-                this.showRightScroll
-                  ? 'sdds-inline-tabs-fullbleed--back__show'
-                  : ''
+                this.showRightScroll ? 'sdds-inline-tabs-fullbleed--back__show' : ''
               }`}
               onClick={() => this._scrollRight()}
             >
@@ -147,9 +144,7 @@ export class InlineTabsFullbleed {
             </button>
             <button
               class={`sdds-inline-tabs-fullbleed--back ${
-                this.showLeftScroll
-                  ? 'sdds-inline-tabs-fullbleed--back__show'
-                  : ''
+                this.showLeftScroll ? 'sdds-inline-tabs-fullbleed--back__show' : ''
               }`}
               onClick={() => this._scrollLeft()}
             >

--- a/components/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.tsx
+++ b/components/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.tsx
@@ -7,7 +7,7 @@ import { Component, Host, State, Element, h, Prop } from '@stencil/core';
 })
 export class InlineTabsFullbleed {
   /** Variant of the tabs, primary= on white, secondary= on grey50 */
-  @Prop() variant: 'primary' | 'secondary' = 'primary';
+  @Prop() modeVariant: 'primary' | 'secondary' = 'primary';
 
   @Element() host: HTMLElement;
 
@@ -113,7 +113,7 @@ export class InlineTabsFullbleed {
   render() {
     return (
       <Host>
-        <div class={`sdds-inline-tabs-fullbleed sdds-inline-tabs-fullbleed-${this.variant}`}>
+        <div class={`sdds-inline-tabs-fullbleed sdds-inline-tabs-fullbleed-${this.modeVariant}`}>
           <div
             class="sdds-inline-tabs-fullbleed-wrapper"
             ref={(el) => (this.navWrapperElement = el as HTMLElement)}

--- a/components/src/components/tabs/inline-tabs-fullbleed/readme.md
+++ b/components/src/components/tabs/inline-tabs-fullbleed/readme.md
@@ -5,6 +5,13 @@
 <!-- Auto Generated Below -->
 
 
+## Properties
+
+| Property  | Attribute | Description                                                  | Type                       | Default     |
+| --------- | --------- | ------------------------------------------------------------ | -------------------------- | ----------- |
+| `variant` | `variant` | Variant of the tabs, primary= on white, secondary= on grey50 | `"primary" \| "secondary"` | `'primary'` |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/components/src/components/tabs/inline-tabs/inline-tabs.scss
+++ b/components/src/components/tabs/inline-tabs/inline-tabs.scss
@@ -161,7 +161,9 @@
   }
 }
 
-.sdds-inline-tabs-onwhite {
+
+//On white
+.sdds-inline-tabs-primary {
   .sdds-inline-tabs--tab__active {
     background-color: var(--sdds-grey-50);
   }
@@ -171,7 +173,8 @@
   }
 }
 
-.sdds-inline-tabs-ongrey50 {
+//On grey50
+.sdds-inline-tabs-secondary {
   .sdds-inline-tabs--tab__active {
     background-color: var(--sdds-white);
   }

--- a/components/src/components/tabs/inline-tabs/inline-tabs.stories.js
+++ b/components/src/components/tabs/inline-tabs/inline-tabs.stories.js
@@ -11,10 +11,18 @@ export default {
       },
       defaultValue: false,
     },
+    variant: {
+      name: "Variant",
+      control: {
+        type: 'radio'
+      },
+      options: [ 'Primary', 'Secondary' ],
+      defaultValue: 'Primary'
+    }
   },
 };
 
-const Template = ({ autoHeight = false }) => `
+const Template = ({ autoHeight = false, variant }) => `
   <style>
     /* Style just for demo */
     #root {
@@ -24,7 +32,7 @@ const Template = ({ autoHeight = false }) => `
     }
   </style>
 
-  <sdds-inline-tabs ${autoHeight ? 'auto-height' : ''}>
+  <sdds-inline-tabs ${autoHeight ? 'auto-height' : ''} variant="${variant.toLowerCase()}">
     <div data-name="Tab very long name">
       Content for tab 1<br>
       This tabs has a lot of content so this is the one that decides the height of the container if height="auto" is specified on the component.

--- a/components/src/components/tabs/inline-tabs/inline-tabs.stories.js
+++ b/components/src/components/tabs/inline-tabs/inline-tabs.stories.js
@@ -11,8 +11,8 @@ export default {
       },
       defaultValue: false,
     },
-    variant: {
-      name: "Variant",
+    modeVariant: {
+      name: "Mode variant",
       control: {
         type: 'radio'
       },
@@ -22,7 +22,7 @@ export default {
   },
 };
 
-const Template = ({ autoHeight = false, variant }) => `
+const Template = ({ autoHeight = false, modeVariant }) => `
   <style>
     /* Style just for demo */
     #root {
@@ -32,7 +32,7 @@ const Template = ({ autoHeight = false, variant }) => `
     }
   </style>
 
-  <sdds-inline-tabs ${autoHeight ? 'auto-height' : ''} variant="${variant.toLowerCase()}">
+  <sdds-inline-tabs ${autoHeight ? 'auto-height' : ''} mode-variant="${modeVariant.toLowerCase()}">
     <div data-name="Tab very long name">
       Content for tab 1<br>
       This tabs has a lot of content so this is the one that decides the height of the container if height="auto" is specified on the component.

--- a/components/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/components/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -23,7 +23,7 @@ export class InlineTabs {
   @Prop() autoHeight: boolean = false;
 
   /** Variant of the tabs, primary= on white, secondary= on grey50 */
-  @Prop() variant: 'primary' | 'secondary' = 'primary'; 
+  @Prop() modeVariant: 'primary' | 'secondary' = 'primary'; 
 
   /** array with metadata for slotted children */
   @State() tabs: Array<any> = [];
@@ -287,7 +287,7 @@ export class InlineTabs {
 
     return (
       <Host>
-        <div class={`sdds-inline-tabs sdds-inline-tabs-${this.variant}`}>
+        <div class={`sdds-inline-tabs sdds-inline-tabs-${this.modeVariant}`}>
           <nav class="sdds-inline-tabs-header">
             <div
               ref={(el) => (this.navWrapperElement = el as HTMLElement)}

--- a/components/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/components/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -22,6 +22,9 @@ export class InlineTabs {
   /** different height settings. right now only supports "auto", otherwise ignored */
   @Prop() autoHeight: boolean = false;
 
+  /** Variant of the tabs, primary= on white, secondary= on grey50 */
+  @Prop() variant: 'primary' | 'secondary' = 'primary'; 
+
   /** array with metadata for slotted children */
   @State() tabs: Array<any> = [];
 
@@ -284,7 +287,7 @@ export class InlineTabs {
 
     return (
       <Host>
-        <div class="sdds-inline-tabs sdds-inline-tabs-onwhite">
+        <div class={`sdds-inline-tabs sdds-inline-tabs-${this.variant}`}>
           <nav class="sdds-inline-tabs-header">
             <div
               ref={(el) => (this.navWrapperElement = el as HTMLElement)}

--- a/components/src/components/tabs/inline-tabs/readme.md
+++ b/components/src/components/tabs/inline-tabs/readme.md
@@ -7,10 +7,11 @@
 
 ## Properties
 
-| Property     | Attribute     | Description                                                                                       | Type      | Default |
-| ------------ | ------------- | ------------------------------------------------------------------------------------------------- | --------- | ------- |
-| `autoHeight` | `auto-height` | different height settings. right now only supports "auto", otherwise ignored                      | `boolean` | `false` |
-| `defaultTab` | `default-tab` | either use this (default-tab="...") or read attribute "default" from one of the slotted children. | `string`  | `''`    |
+| Property     | Attribute     | Description                                                                                       | Type                       | Default     |
+| ------------ | ------------- | ------------------------------------------------------------------------------------------------- | -------------------------- | ----------- |
+| `autoHeight` | `auto-height` | different height settings. right now only supports "auto", otherwise ignored                      | `boolean`                  | `false`     |
+| `defaultTab` | `default-tab` | either use this (default-tab="...") or read attribute "default" from one of the slotted children. | `string`                   | `''`        |
+| `variant`    | `variant`     | Variant of the tabs, primary= on white, secondary= on grey50                                      | `"primary" \| "secondary"` | `'primary'` |
 
 
 ## Methods

--- a/tegel/src/components/tabs/inline-tabs-default/inline-tabs.scss
+++ b/tegel/src/components/tabs/inline-tabs-default/inline-tabs.scss
@@ -171,7 +171,7 @@
   }
 }
 
-.sdds-inline-tabs-onwhite {
+.sdds-inline-tabs-primary {
   .sdds-inline-tabs--tab__active {
     background-color: var(--sdds-inline-tabs-tab-active-bg);
   }
@@ -181,7 +181,7 @@
   }
 }
 
-.sdds-inline-tabs-ongrey50 {
+.sdds-inline-tabs-secondary {
   .sdds-inline-tabs--tab__active {
     background-color: var(--sdds-inline-tabs-tab-active-ongrey-bg);
   }

--- a/tegel/src/components/tabs/inline-tabs-default/inline-tabs.stories.ts
+++ b/tegel/src/components/tabs/inline-tabs-default/inline-tabs.stories.ts
@@ -42,7 +42,7 @@ export default {
   },
   args: {
     autoHeight: false,
-    variant: 'Primary'
+    modeVariant: 'Primary'
   },
 };
 // eslint-disable-next-line arrow-body-style

--- a/tegel/src/components/tabs/inline-tabs-default/inline-tabs.stories.ts
+++ b/tegel/src/components/tabs/inline-tabs-default/inline-tabs.stories.ts
@@ -27,8 +27,8 @@ export default {
         type: 'boolean',
       },
     },
-    variant: {
-      name: "Variant",
+    modeVariant: {
+      name: "Mode variant",
       control: {
         type: 'radio'
       },
@@ -46,9 +46,9 @@ export default {
   },
 };
 // eslint-disable-next-line arrow-body-style
-const Template = ({ autoHeight = false, variant }) => {
+const Template = ({ autoHeight = false, modeVariant }) => {
   return formatHtmlPreview(`
-    <sdds-inline-tabs ${autoHeight ? 'auto-height' : ''}  variant="${variant.toLowerCase()}">
+    <sdds-inline-tabs ${autoHeight ? 'auto-height' : ''}  mode-variant="${modeVariant.toLowerCase()}">
       <div data-name="Tab with tall content">
         Tab panel 1
         <div style="width:200px; height:200px; background: linear-gradient(125deg,rgba(255, 0, 0, 1) 0%,rgba(255, 255, 0, 1) 33%,rgba(0, 192, 255, 1) 66%,rgba(192, 0, 255, 1) 100%);"></div>

--- a/tegel/src/components/tabs/inline-tabs-default/inline-tabs.stories.ts
+++ b/tegel/src/components/tabs/inline-tabs-default/inline-tabs.stories.ts
@@ -27,12 +27,12 @@ export default {
         type: 'boolean',
       },
     },
-    altBgColor: {
-      name: 'Alternative background color',
-      description: 'Style for display on the alternative background color',
+    variant: {
+      name: "Variant",
       control: {
-        type: 'boolean',
+        type: 'radio'
       },
+      options: [ 'Primary', 'Secondary' ],
     },
     backgrounds: {
       table: {
@@ -42,15 +42,13 @@ export default {
   },
   args: {
     autoHeight: false,
-    altBgColor: false,
+    variant: 'Primary'
   },
 };
 // eslint-disable-next-line arrow-body-style
-const Template = ({ autoHeight = false, altBgColor = false }) => {
+const Template = ({ autoHeight = false, variant }) => {
   return formatHtmlPreview(`
-    <sdds-inline-tabs ${autoHeight ? 'auto-height' : ''} ${
-    altBgColor ? 'color-variant="on-grey"' : ''
-  }>
+    <sdds-inline-tabs ${autoHeight ? 'auto-height' : ''}  variant="${variant.toLowerCase()}">
       <div data-name="Tab with tall content">
         Tab panel 1
         <div style="width:200px; height:200px; background: linear-gradient(125deg,rgba(255, 0, 0, 1) 0%,rgba(255, 255, 0, 1) 33%,rgba(0, 192, 255, 1) 66%,rgba(192, 0, 255, 1) 100%);"></div>

--- a/tegel/src/components/tabs/inline-tabs-default/inline-tabs.tsx
+++ b/tegel/src/components/tabs/inline-tabs-default/inline-tabs.tsx
@@ -15,7 +15,7 @@ export class InlineTabs {
   @Prop() autoHeight: boolean = false;
 
   /** Variant of the tabs, primary= on white, secondary= on grey50 */
-  @Prop() variant: 'primary' | 'secondary' = 'primary'; 
+  @Prop() modeVariant: 'primary' | 'secondary' = 'primary'; 
 
   /** array with metadata for slotted children */
   @State() tabs: Array<any> = [];
@@ -260,7 +260,7 @@ export class InlineTabs {
 
     return (
       <Host>
-        <div class={`sdds-inline-tabs sdds-inline-tabs sdds-inline-tabs-${this.variant}`}>
+        <div class={`sdds-inline-tabs sdds-inline-tabs sdds-inline-tabs-${this.modeVariant}`}>
           <nav class="sdds-inline-tabs-header">
             <div ref={el => (this.navWrapperElement = el as HTMLElement)} class="sdds-inline-tabs-wrapper">
               {this.tabs.map(tab => (

--- a/tegel/src/components/tabs/inline-tabs-default/inline-tabs.tsx
+++ b/tegel/src/components/tabs/inline-tabs-default/inline-tabs.tsx
@@ -14,8 +14,8 @@ export class InlineTabs {
   /** different height settings. right now only supports "auto", otherwise ignored */
   @Prop() autoHeight: boolean = false;
 
-  /** color variant. right now only supports "on-grey", otherwise ignored */
-  @Prop() colorVariant: 'on-grey' | null = null;
+  /** Variant of the tabs, primary= on white, secondary= on grey50 */
+  @Prop() variant: 'primary' | 'secondary' = 'primary'; 
 
   /** array with metadata for slotted children */
   @State() tabs: Array<any> = [];
@@ -260,7 +260,7 @@ export class InlineTabs {
 
     return (
       <Host>
-        <div class={`sdds-inline-tabs ${this.colorVariant === 'on-grey' ? 'sdds-inline-tabs-ongrey50' : 'sdds-inline-tabs-onwhite'}`}>
+        <div class={`sdds-inline-tabs sdds-inline-tabs sdds-inline-tabs-${this.variant}`}>
           <nav class="sdds-inline-tabs-header">
             <div ref={el => (this.navWrapperElement = el as HTMLElement)} class="sdds-inline-tabs-wrapper">
               {this.tabs.map(tab => (

--- a/tegel/src/components/tabs/inline-tabs-default/readme.md
+++ b/tegel/src/components/tabs/inline-tabs-default/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property       | Attribute       | Description                                                                                       | Type        | Default |
-| -------------- | --------------- | ------------------------------------------------------------------------------------------------- | ----------- | ------- |
-| `autoHeight`   | `auto-height`   | different height settings. right now only supports "auto", otherwise ignored                      | `boolean`   | `false` |
-| `colorVariant` | `color-variant` | color variant. right now only supports "on-grey", otherwise ignored                               | `"on-grey"` | `null`  |
-| `defaultTab`   | `default-tab`   | either use this (default-tab="...") or read attribute "default" from one of the slotted children. | `string`    | `''`    |
+| Property     | Attribute     | Description                                                                                       | Type                       | Default     |
+| ------------ | ------------- | ------------------------------------------------------------------------------------------------- | -------------------------- | ----------- |
+| `autoHeight` | `auto-height` | different height settings. right now only supports "auto", otherwise ignored                      | `boolean`                  | `false`     |
+| `defaultTab` | `default-tab` | either use this (default-tab="...") or read attribute "default" from one of the slotted children. | `string`                   | `''`        |
+| `variant`    | `variant`     | Variant of the tabs, primary= on white, secondary= on grey50                                      | `"primary" \| "secondary"` | `'primary'` |
 
 
 ## Methods

--- a/tegel/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.scss
+++ b/tegel/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.scss
@@ -173,3 +173,27 @@
     opacity: 0.16;
   }
 }
+
+.sdds-inline-tabs-fullbleed-primary {
+  background-color: var(--sdds-white);
+
+  .sdds-inline-tabs-fullbleed--forward {
+    background-color: var(--sdds-white);
+  }
+
+  .sdds-inline-tabs-fullbleed--back {
+    background-color: var(--sdds-white);
+  }
+}
+
+.sdds-inline-tabs-fullbleed-secondary {
+  background-color: var(--sdds-grey-50);
+
+  .sdds-inline-tabs-fullbleed--forward {
+    background-color: var(--sdds-grey-50);
+  }
+
+  .sdds-inline-tabs-fullbleed--back {
+    background-color: var(--sdds-grey-50);
+  }
+}

--- a/tegel/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.stories.ts
+++ b/tegel/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.stories.ts
@@ -19,7 +19,7 @@ export default {
     ],
   },
   argTypes: {
-    variant: {
+    modeVariant: {
       name: "Variant",
       control: {
         type: 'radio'
@@ -32,9 +32,9 @@ export default {
   }
 };
 
-const Template = ({variant}) =>
+const Template = ({modeVariant}) =>
   formatHtmlPreview(`
-  <sdds-inline-tabs-fullbleed id="inline-tabs-fullbleed-example" variant="${variant.toLowerCase()}">
+  <sdds-inline-tabs-fullbleed id="inline-tabs-fullbleed-example" mode-variant="${modeVariant.toLowerCase()}">
       <a href="#">Tab name</a>
       <a href="#" class="sdds-inline-tabs-fullbleed--tab__active">Active tab</a>
       <a href="#">Tab name</a>

--- a/tegel/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.stories.ts
+++ b/tegel/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.stories.ts
@@ -18,11 +18,23 @@ export default {
       },
     ],
   },
+  argTypes: {
+    variant: {
+      name: "Variant",
+      control: {
+        type: 'radio'
+      }, 
+      options: ['Primary', 'Secondary'],
+    }
+  },
+  args: {
+    variant: 'Primary'
+  }
 };
 
-const Template = () =>
+const Template = ({variant}) =>
   formatHtmlPreview(`
-    <sdds-inline-tabs-fullbleed>
+  <sdds-inline-tabs-fullbleed id="inline-tabs-fullbleed-example" variant="${variant.toLowerCase()}">
       <a href="#">Tab name</a>
       <a href="#" class="sdds-inline-tabs-fullbleed--tab__active">Active tab</a>
       <a href="#">Tab name</a>

--- a/tegel/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.stories.ts
+++ b/tegel/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.stories.ts
@@ -28,7 +28,7 @@ export default {
     }
   },
   args: {
-    variant: 'Primary'
+    modeVariant: 'Primary'
   }
 };
 

--- a/tegel/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.tsx
+++ b/tegel/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.tsx
@@ -7,7 +7,7 @@ import { Component, Host, State, Element, h, Prop } from '@stencil/core';
 })
 export class InlineTabsFullbleed {
   /** Variant of the tabs, primary= on white, secondary= on grey50 */
-  @Prop() variant: 'primary' | 'secondary' = 'primary';
+  @Prop() modeVariant: 'primary' | 'secondary' = 'primary';
 
   @Element() host: HTMLElement;
 
@@ -113,7 +113,7 @@ export class InlineTabsFullbleed {
   render() {
     return (
       <Host>
-        <div class={`sdds-inline-tabs-fullbleed sdds-inline-tabs-fullbleed-${this.variant}`}>
+        <div class={`sdds-inline-tabs-fullbleed sdds-inline-tabs-fullbleed-${this.modeVariant}`}>
           <div
             class="sdds-inline-tabs-fullbleed-wrapper"
             ref={(el) => (this.navWrapperElement = el as HTMLElement)}

--- a/tegel/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.tsx
+++ b/tegel/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, State, Element, h } from '@stencil/core';
+import { Component, Host, State, Element, h, Prop } from '@stencil/core';
 
 @Component({
   tag: 'sdds-inline-tabs-fullbleed',
@@ -6,6 +6,9 @@ import { Component, Host, State, Element, h } from '@stencil/core';
   shadow: true,
 })
 export class InlineTabsFullbleed {
+  /** Variant of the tabs, primary= on white, secondary= on grey50 */
+  @Prop() variant: 'primary' | 'secondary' = 'primary';
+
   @Element() host: HTMLElement;
 
   @State() tabs: Array<any> = []; // array with metadata for slotted children
@@ -29,7 +32,7 @@ export class InlineTabsFullbleed {
   }
 
   componentDidLoad() {
-    const resizeObserver = new ResizeObserver(entries => {
+    const resizeObserver = new ResizeObserver((entries) => {
       for (const entry of entries) {
         const componentWidth = entry.contentRect.width;
         let buttonsWidth = 0;
@@ -37,7 +40,8 @@ export class InlineTabsFullbleed {
         const navButtons = Array.from(this.host.children);
         navButtons.forEach((navButton: HTMLElement) => {
           const style = window.getComputedStyle(navButton);
-          buttonsWidth += navButton.clientWidth + parseFloat(style.marginLeft) + parseFloat(style.marginRight);
+          buttonsWidth +=
+            navButton.clientWidth + parseFloat(style.marginLeft) + parseFloat(style.marginRight);
 
           navButton.classList.add('sdds-inline-tabs-fullbleed--tab');
         });
@@ -65,7 +69,8 @@ export class InlineTabsFullbleed {
     const navButtons = Array.from(this.host.children);
     navButtons.forEach((navButton: HTMLElement) => {
       const style = window.getComputedStyle(navButton);
-      const width = navButton.clientWidth + parseFloat(style.marginLeft) + parseFloat(style.marginRight);
+      const width =
+        navButton.clientWidth + parseFloat(style.marginLeft) + parseFloat(style.marginRight);
 
       if (width > best) {
         best = width;
@@ -108,13 +113,27 @@ export class InlineTabsFullbleed {
   render() {
     return (
       <Host>
-        <div class="sdds-inline-tabs-fullbleed">
-          <div class="sdds-inline-tabs-fullbleed-wrapper" ref={el => (this.navWrapperElement = el as HTMLElement)}>
+        <div class={`sdds-inline-tabs-fullbleed sdds-inline-tabs-fullbleed-${this.variant}`}>
+          <div
+            class="sdds-inline-tabs-fullbleed-wrapper"
+            ref={(el) => (this.navWrapperElement = el as HTMLElement)}
+          >
             <slot />
           </div>
           <div class="sdds-inline-tabs-fullbleed-navigation">
-            <button class={`sdds-inline-tabs-fullbleed--forward ${this.showRightScroll ? 'sdds-inline-tabs-fullbleed--back__show' : ''}`} onClick={() => this._scrollRight()}>
-              <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <button
+              class={`sdds-inline-tabs-fullbleed--forward ${
+                this.showRightScroll ? 'sdds-inline-tabs-fullbleed--back__show' : ''
+              }`}
+              onClick={() => this._scrollRight()}
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 20 20"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
                 <path
                   fill-rule="evenodd"
                   clip-rule="evenodd"
@@ -123,8 +142,19 @@ export class InlineTabsFullbleed {
                 ></path>
               </svg>
             </button>
-            <button class={`sdds-inline-tabs-fullbleed--back ${this.showLeftScroll ? 'sdds-inline-tabs-fullbleed--back__show' : ''}`} onClick={() => this._scrollLeft()}>
-              <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <button
+              class={`sdds-inline-tabs-fullbleed--back ${
+                this.showLeftScroll ? 'sdds-inline-tabs-fullbleed--back__show' : ''
+              }`}
+              onClick={() => this._scrollLeft()}
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 20 20"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
                 <path
                   fill-rule="evenodd"
                   clip-rule="evenodd"

--- a/tegel/src/components/tabs/inline-tabs-fullbleed/readme.md
+++ b/tegel/src/components/tabs/inline-tabs-fullbleed/readme.md
@@ -5,6 +5,13 @@ This component neither accepts any properties, nor exposes any methods.
 <!-- Auto Generated Below -->
 
 
+## Properties
+
+| Property  | Attribute | Description                                                  | Type                       | Default     |
+| --------- | --------- | ------------------------------------------------------------ | -------------------------- | ----------- |
+| `variant` | `variant` | Variant of the tabs, primary= on white, secondary= on grey50 | `"primary" \| "secondary"` | `'primary'` |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*


### PR DESCRIPTION
**Describe pull-request**  
Added a variant prop to allow user to use the on white/on grey options. 

**Solving issue**  
Fixes: [AB#2751](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2751)

**How to test**  
1. Check out the branch and run start for components.
2. Check in that the variant controls works as intended. 
3. Check the storybook link below.
4. Check in that the variant controls works as intended for tegel. 


**Screenshots**  
-

**Additional context**  
-
