### PR TITLE
feat(dropdown-option): adding disabled state

### DIFF
--- a/components/src/components.d.ts
+++ b/components/src/components.d.ts
@@ -225,6 +225,10 @@ export namespace Components {
     }
     interface SddsDropdownOption {
         /**
+          * Sets option to disabled state if true
+         */
+        "disabled": boolean;
+        /**
           * Selected set to true if selected
          */
         "selected": boolean;
@@ -1059,6 +1063,10 @@ declare namespace LocalJSX {
         "state"?: string;
     }
     interface SddsDropdownOption {
+        /**
+          * Sets option to disabled state if true
+         */
+        "disabled"?: boolean;
         "onSelectOption"?: (event: CustomEvent<any>) => void;
         /**
           * Selected set to true if selected

--- a/components/src/components/dropdown/dropdown-option.tsx
+++ b/components/src/components/dropdown/dropdown-option.tsx
@@ -24,6 +24,9 @@ export class DropdownOption {
   /** Selected set to true if selected */
   @Prop() selected: boolean = false;
 
+  /** Sets option to disabled state if true */
+  @Prop() disabled: boolean = false;
+
   /** Value is a unique string that will be used for application logic */
   @Prop({ reflect: true }) value: string;
 
@@ -66,26 +69,28 @@ export class DropdownOption {
   }
 
   selectOptionHandler(value) {
-    const listOptions = value.parent.childNodes;
-    this.selectOption.emit(value);
-    if (!this.isMultiSelectOption) {
-      listOptions.forEach((optionEl) => {
-        // TODO: fix and enable rule
-        // eslint-disable-next-line no-param-reassign
-        optionEl.selected = false;
-      });
-    }
-    const optionCheckbox = this.host.shadowRoot.querySelector('input');
-
-    if (this.selected) {
-      this.selected = false;
-      if (optionCheckbox) {
-        optionCheckbox.checked = false;
+    if (!this.disabled) {
+      const listOptions = value.parent.childNodes;
+      this.selectOption.emit(value);
+      if (!this.isMultiSelectOption) {
+        listOptions.forEach((optionEl) => {
+          // TODO: fix and enable rule
+          // eslint-disable-next-line no-param-reassign
+          optionEl.selected = false;
+        });
       }
-    } else {
-      this.selected = true;
-      if (optionCheckbox) {
-        optionCheckbox.checked = true;
+      const optionCheckbox = this.host.shadowRoot.querySelector('input');
+
+      if (this.selected) {
+        this.selected = false;
+        if (optionCheckbox) {
+          optionCheckbox.checked = false;
+        }
+      } else {
+        this.selected = true;
+        if (optionCheckbox) {
+          optionCheckbox.checked = true;
+        }
       }
     }
   }
@@ -104,14 +109,20 @@ export class DropdownOption {
           });
         }}
         class={{
-          selected: this.selected,
+          'selected': this.selected,
+          'sdds-dropdown-option--disabled': this.disabled,
         }}
         tabindex="-1"
       >
         {this.isMultiSelectOption && (
           <div class="sdds-checkbox-item sdds-option-checkbox">
             <label class="sdds-form-label">
-              <input class="sdds-form-input" type="checkbox" checked={this.selected} />
+              <input
+                class="sdds-form-input"
+                type="checkbox"
+                checked={this.selected}
+                disabled={this.disabled}
+              />
             </label>
           </div>
         )}

--- a/components/src/components/dropdown/dropdown-option.tsx
+++ b/components/src/components/dropdown/dropdown-option.tsx
@@ -110,7 +110,7 @@ export class DropdownOption {
         }}
         class={{
           'selected': this.selected,
-          'sdds-dropdown-option--disabled': this.disabled,
+          'sdds-dropdown-option-disabled': this.disabled,
         }}
         tabindex="-1"
       >

--- a/components/src/components/dropdown/dropdown.scss
+++ b/components/src/components/dropdown/dropdown.scss
@@ -278,10 +278,9 @@
     pointer-events: none;
   }
 
-  ::slotted(sdds-dropdown-option.sdds-dropdown-option--disabled) {
+  ::slotted(sdds-dropdown-option.sdds-dropdown-option-disabled) {
     cursor: not-allowed;
     color: var(--sdds-grey-400);
-    background-color: var(--sdds-grey-50);
   }
 }
 

--- a/components/src/components/dropdown/dropdown.scss
+++ b/components/src/components/dropdown/dropdown.scss
@@ -111,19 +111,7 @@
 
     &::placeholder {
       color: var(--sdds-grey-700);
-    }
-
-    &::input-placeholder {
-      color: var(--sdds-grey-700);
-    }
-
-    &::placeholder {
-      color: var(--sdds-grey-700);
       opacity: 1;
-    }
-
-    &::input-placeholder {
-      color: var(--sdds-grey-700);
     }
   }
 
@@ -288,6 +276,12 @@
   ::slotted(sdds-dropdown-option.sdds-option--no-result) {
     cursor: not-allowed;
     pointer-events: none;
+  }
+
+  ::slotted(sdds-dropdown-option.sdds-dropdown-option--disabled) {
+    cursor: not-allowed;
+    color: var(--sdds-grey-400);
+    background-color: var(--sdds-grey-50);
   }
 }
 

--- a/components/src/components/dropdown/dropdown.scss
+++ b/components/src/components/dropdown/dropdown.scss
@@ -278,9 +278,11 @@
     pointer-events: none;
   }
 
-  ::slotted(sdds-dropdown-option.sdds-dropdown-option-disabled) {
+  ::slotted(sdds-dropdown-option.sdds-dropdown-option-disabled),
+  ::slotted(sdds-dropdown-option.selected.sdds-dropdown-option-disabled) {
     cursor: not-allowed;
     color: var(--sdds-grey-400);
+    background-color: var(--sdds-white);
   }
 }
 

--- a/components/src/components/dropdown/dropdown.stories.js
+++ b/components/src/components/dropdown/dropdown.stories.js
@@ -158,7 +158,7 @@ const Template = ({
           type="${type}"
           default-option="${defaultOption}" >     
           <sdds-dropdown-option value="option-1" tabindex="0">Stockholm & Stockholm</sdds-dropdown-option>
-          <sdds-dropdown-option value="option-2" tabindex="0">Hello 2</sdds-dropdown-option>
+          <sdds-dropdown-option value="option-2" tabindex="0" disabled>Hello 2</sdds-dropdown-option>
           <sdds-dropdown-option value="option-3" tabindex="0">Option 3</sdds-dropdown-option>          
           ${extraDropdownOptions}
                   </sdds-dropdown>
@@ -306,7 +306,7 @@ const MultiselectTemplate = ({
         label="${label}"   
         >
           <sdds-dropdown-option value="option-1" tabindex="0">Option 1</sdds-dropdown-option>
-          <sdds-dropdown-option value="option-2" tabindex="0">Option 2</sdds-dropdown-option>
+          <sdds-dropdown-option value="option-2" tabindex="0" disabled>Option 2</sdds-dropdown-option>
           <sdds-dropdown-option value="option-3" tabindex="0">Option 3 Longer</sdds-dropdown-option>
           </sdds-dropdown>
       </div>

--- a/components/src/components/dropdown/readme.md
+++ b/components/src/components/dropdown/readme.md
@@ -7,6 +7,7 @@
 
 | Property   | Attribute  | Description                                                      | Type      | Default     |
 | ---------- | ---------- | ---------------------------------------------------------------- | --------- | ----------- |
+| `disabled` | `disabled` | Sets option to disabled state if true                            | `boolean` | `false`     |
 | `selected` | `selected` | Selected set to true if selected                                 | `boolean` | `false`     |
 | `value`    | `value`    | Value is a unique string that will be used for application logic | `string`  | `undefined` |
 

--- a/tegel/src/components/badge/badge.stories.ts
+++ b/tegel/src/components/badge/badge.stories.ts
@@ -76,7 +76,7 @@ const WithDemoTemplate = ({ value, size, visible }) =>
   formatHtmlPreview(
     `
     <style>
-    <!-- Note: Demo classes used here are just for demo purposes in Storybook -->
+    /* Note: Demo classes used here are just for demo purposes in Storybook */
     .badges-demo-box {
       margin:5px;
       height: 32px;

--- a/tegel/src/components/dropdown/dropdown-option/dropdown-option.tsx
+++ b/tegel/src/components/dropdown/dropdown-option/dropdown-option.tsx
@@ -110,7 +110,7 @@ export class DropdownOption {
         }}
         class={{
           'selected': this.selected,
-          'sdds-dropdown-option--disabled': this.disabled,
+          'sdds-dropdown-option-disabled': this.disabled,
         }}
         tabindex="-1"
         aria-disabled={this.disabled}

--- a/tegel/src/components/dropdown/dropdown-option/dropdown-option.tsx
+++ b/tegel/src/components/dropdown/dropdown-option/dropdown-option.tsx
@@ -24,6 +24,9 @@ export class DropdownOption {
   /** Selected set to true if selected */
   @Prop() selected: boolean = false;
 
+  /** Sets option to disabled state if true */
+  @Prop() disabled: boolean = false;
+
   /** Value is a unique string that will be used for application logic */
   @Prop({ reflect: true }) value: string;
 
@@ -66,26 +69,28 @@ export class DropdownOption {
   }
 
   selectOptionHandler(value) {
-    const listOptions = value.parent.childNodes;
-    this.selectOption.emit(value);
-    if (!this.isMultiSelectOption) {
-      listOptions.forEach((optionEl) => {
-        // TODO: fix and enable rule
-        // eslint-disable-next-line no-param-reassign
-        optionEl.selected = false;
-      });
-    }
-    const optionCheckbox = this.host.shadowRoot.querySelector('input');
-
-    if (this.selected) {
-      this.selected = false;
-      if (optionCheckbox) {
-        optionCheckbox.checked = false;
+    if (!this.disabled) {
+      const listOptions = value.parent.childNodes;
+      this.selectOption.emit(value);
+      if (!this.isMultiSelectOption) {
+        listOptions.forEach((optionEl) => {
+          // TODO: fix and enable rule
+          // eslint-disable-next-line no-param-reassign
+          optionEl.selected = false;
+        });
       }
-    } else {
-      this.selected = true;
-      if (optionCheckbox) {
-        optionCheckbox.checked = true;
+      const optionCheckbox = this.host.shadowRoot.querySelector('input');
+
+      if (this.selected) {
+        this.selected = false;
+        if (optionCheckbox) {
+          optionCheckbox.checked = false;
+        }
+      } else {
+        this.selected = true;
+        if (optionCheckbox) {
+          optionCheckbox.checked = true;
+        }
       }
     }
   }
@@ -104,14 +109,21 @@ export class DropdownOption {
           });
         }}
         class={{
-          selected: this.selected,
+          'selected': this.selected,
+          'sdds-dropdown-option--disabled': this.disabled,
         }}
         tabindex="-1"
+        aria-disabled={this.disabled}
       >
         {this.isMultiSelectOption && (
           <div class="sdds-checkbox-item sdds-option-checkbox">
             <label class="sdds-form-label">
-              <input class="sdds-form-input" type="checkbox" checked={this.selected} />
+              <input
+                class="sdds-form-input"
+                type="checkbox"
+                checked={this.selected}
+                disabled={this.disabled}
+              />
             </label>
           </div>
         )}

--- a/tegel/src/components/dropdown/dropdown-option/readme.md
+++ b/tegel/src/components/dropdown/dropdown-option/readme.md
@@ -9,6 +9,7 @@
 
 | Property   | Attribute  | Description                                                      | Type      | Default     |
 | ---------- | ---------- | ---------------------------------------------------------------- | --------- | ----------- |
+| `disabled` | `disabled` | Sets option to disabled state if true                            | `boolean` | `false`     |
 | `selected` | `selected` | Selected set to true if selected                                 | `boolean` | `false`     |
 | `value`    | `value`    | Value is a unique string that will be used for application logic | `string`  | `undefined` |
 

--- a/tegel/src/components/dropdown/dropdown-wc-default.stories.ts
+++ b/tegel/src/components/dropdown/dropdown-wc-default.stories.ts
@@ -152,7 +152,7 @@ const Template = ({
           state="${stateValue}"
           type="default"
           default-option="${defaultOptionLookup[defaultOption]}" >
-          <sdds-dropdown-option value="option-1" tabindex="0">Option 1</sdds-dropdown-option>
+          <sdds-dropdown-option value="option-1" tabindex="0" disabled>Option 1</sdds-dropdown-option>
           <sdds-dropdown-option value="option-2" tabindex="0">Option 2</sdds-dropdown-option>
           <sdds-dropdown-option value="option-3" tabindex="0">Option 3</sdds-dropdown-option>
         </sdds-dropdown>

--- a/tegel/src/components/dropdown/dropdown-wc-multiselect.stories.ts
+++ b/tegel/src/components/dropdown/dropdown-wc-multiselect.stories.ts
@@ -149,7 +149,7 @@ const Template = ({
           type="multiselect"
           default-option="${multiDefaultOptionValue}" >
           <sdds-dropdown-option value="option-1" tabindex="0">Option 1</sdds-dropdown-option>
-          <sdds-dropdown-option value="option-2" tabindex="0">Option 2</sdds-dropdown-option>
+          <sdds-dropdown-option value="option-2" tabindex="0" disabled>Option 2</sdds-dropdown-option>
           <sdds-dropdown-option value="option-3" tabindex="0">Option 3</sdds-dropdown-option>
         </sdds-dropdown>
       </div>

--- a/tegel/src/components/dropdown/dropdown.scss
+++ b/tegel/src/components/dropdown/dropdown.scss
@@ -296,9 +296,11 @@
     pointer-events: none;
   }
 
-  ::slotted(sdds-dropdown-option.sdds-dropdown-option-disabled) {
+  ::slotted(sdds-dropdown-option.sdds-dropdown-option-disabled),
+  ::slotted(sdds-dropdown-option.selected.sdds-dropdown-option-disabled) {
     cursor: not-allowed;
     color: var(--sdds-grey-400);
+    background-color: var(--sdds-white);
   }
 }
 

--- a/tegel/src/components/dropdown/dropdown.scss
+++ b/tegel/src/components/dropdown/dropdown.scss
@@ -296,10 +296,9 @@
     pointer-events: none;
   }
 
-  ::slotted(sdds-dropdown-option.sdds-dropdown-option--disabled) {
+  ::slotted(sdds-dropdown-option.sdds-dropdown-option-disabled) {
     cursor: not-allowed;
     color: var(--sdds-grey-400);
-    background-color: var(--sdds-grey-50);
   }
 }
 

--- a/tegel/src/components/dropdown/dropdown.scss
+++ b/tegel/src/components/dropdown/dropdown.scss
@@ -128,19 +128,7 @@
 
     &::placeholder {
       color: var(--sdds-grey-700);
-    }
-
-    &::input-placeholder {
-      color: var(--sdds-grey-700);
-    }
-
-    &::placeholder {
-      color: var(--sdds-grey-700);
       opacity: 1;
-    }
-
-    &::input-placeholder {
-      color: var(--sdds-grey-700);
     }
   }
 
@@ -306,6 +294,12 @@
   ::slotted(sdds-dropdown-option.sdds-option--no-result) {
     cursor: not-allowed;
     pointer-events: none;
+  }
+
+  ::slotted(sdds-dropdown-option.sdds-dropdown-option--disabled) {
+    cursor: not-allowed;
+    color: var(--sdds-grey-400);
+    background-color: var(--sdds-grey-50);
   }
 }
 


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Adding disabled state to dropdown option

**Solving issue**  
Fixes: [AB#2549](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2549) #589 

**How to test**  
1. Go to the dropdown component
2. In both the default web component and multi-select one, there is one item that is disabled
3. Try to select it, it should not be possible

**Additional context**  
Currently, this fix is not involving filtering type of dropdown. 
The feature is done for both the component and Tegel package
The design of a disabled state has to be verified by one of our designers. 
