### PR TITLE
fix: capital letters to story names

### DIFF
--- a/tegel/src/components/dropdown/dropdown-filter/dropdown-filter.stories.ts
+++ b/tegel/src/components/dropdown/dropdown-filter/dropdown-filter.stories.ts
@@ -2,7 +2,7 @@ import { formatHtmlPreview } from '../../../utils/utils';
 import readme from './readme.md';
 
 export default {
-  title: 'Components/Dropdown-filter',
+  title: 'Components/Dropdown Filter',
   parameters: {
     layout: 'centered',
     notes: readme,

--- a/tegel/src/components/side-menu/side-menu.stories.ts
+++ b/tegel/src/components/side-menu/side-menu.stories.ts
@@ -1,7 +1,7 @@
 import { formatHtmlPreview } from '../../utils/utils';
 
 export default {
-  title: 'Components/Side menu',
+  title: 'Components/Side Menu',
   parameters: {
     layout: 'fullscreen',
     docs: {
@@ -60,7 +60,7 @@ const Template = ({ showIcons, collapsed }) => {
 <nav class="sdds-nav">
   <div class="sdds-nav__left">
     <button class="sdds-nav__mob-menu-btn">
-      <sdds-icon name="burger" size="20px" /> 
+      <sdds-icon name="burger" size="20px" />
     </button>
     <div class="sdds-nav__app-name">My application</div>
   </div>
@@ -72,7 +72,7 @@ const Template = ({ showIcons, collapsed }) => {
   <div class="sdds-sidebar side-menu ${collapsed ? 'collapsed' : ''}">
     <div class="sdds-sidebar-mheader">
     <button class="sdds-sidebar-mheader__close">
-      <sdds-icon name="cross" size="20px" /> 
+      <sdds-icon name="cross" size="20px" />
     </button>
     </div>
     <ul class="sdds-sidebar-nav sdds-sidebar-nav--main ${icons}">
@@ -157,7 +157,7 @@ const Template = ({ showIcons, collapsed }) => {
     </ul>
   </div>
   <div class="sdds-container" style="padding-top: 30px">
-   
+
   </div>
 </div>
 <script>
@@ -169,7 +169,7 @@ const Template = ({ showIcons, collapsed }) => {
   })
   expandableListItems = document.getElementsByClassName('sdds-sidebar-nav__extended');
   for (let i = 0; i < expandableListItems.length; i++) {
-    expandableListItems[i].addEventListener('click', (event) => {
+    expandableListItems[i].addEventListener('click', () => {
       document.getElementsByClassName('sdds-sidebar-nav__extended')[i].classList.toggle('subnav-open');
     });
   }


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Capital letters to story names

**Solving issue**  
Fixes: [AB#2648](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2648)

**How to test**  
1. Go to the Netlify preview link
2. Check that the Side menu and Dropdown filter have capital letters for all words in the story name


**Additional context**  
Introduction stories I have left as they are.
