### PR TITLE
feat(modal): added 16px gap between buttons on modal

### DIFF
--- a/tegel/src/components/modal/modal.scss
+++ b/tegel/src/components/modal/modal.scss
@@ -148,10 +148,6 @@ $modals: (
   }
 }
 
-@mixin modal-actions {
-  margin-right: var(--sdds-spacing-element-16);
-}
-
 /* MODAL STYLING */
 
 .sdds-modal {
@@ -233,12 +229,6 @@ $modals: (
 
 .sdds-modal-body {
   @include modal-body;
-}
-
-.sdds-modal-actions {
-  & > * {
-    @include modal-actions;
-  }
 }
 
 .sdds-modal-backdrop {

--- a/tegel/src/components/modal/modal.scss
+++ b/tegel/src/components/modal/modal.scss
@@ -185,6 +185,7 @@ $modals: (
       background-color: var(--sdds-modal-bg);
       padding: var(--sdds-spacing-element-16);
       display: flex;
+      gap: 16px;
     }
   }
 
@@ -192,6 +193,7 @@ $modals: (
     .sdds-modal-actions {
       background-color: var(--sdds-modal-bg);
       display: flex;
+      gap: 16px;
     }
   }
 }


### PR DESCRIPTION
**Describe pull-request**  
Added a 16px gap between buttons on modal.

**Solving issue**  
Fixes: [AB#2671](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2671)

**How to test**  
1. Go to storybook link below
2. Check in Components -> Modal -> Web component
3. Check that there is a 16px gap between the buttons on the modal.

**Screenshots**  
-

**Additional context**  
-
