### PR TITLE
docs: add a readme for the tegel package

### DIFF
--- a/tegel/readme.md
+++ b/tegel/readme.md
@@ -29,6 +29,17 @@ Please read through our [contributing guidelines](https://github.com/scania-digi
 - [Report bug](https://github.com/scania-digital-design-system/sdds/issues)
 - [Request feature](https://github.com/scania-digital-design-system/sdds/issues/new)
 
+### Setting up the development environment
+
+1. Make sure you are using the required node.js version specified in `tegel/package.json` (node 16 at the time of writing).
+2. Run `npm install` in the /tegel directory.
+3. Create a `.env` file in the /tegel directory with the following contents:
+
+  ```
+  STORYBOOK_ENV=development
+  ```
+4. Make sure you are in the /tegel directory, and start the dev server with `npm run tegel`.
+
 ## Community
 
 Get in touch with the team and the community:

--- a/tegel/readme.md
+++ b/tegel/readme.md
@@ -3,7 +3,7 @@
 [![Github release](https://img.shields.io/github/v/release/scania-digital-design-system/sdds?color=1081C2)](https://github.com/scania-digital-design-system/sdds/releases) -->
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 ![](https://img.shields.io/github/license/scania-digital-design-system/sdds)
-[![Getting Started](https://img.shields.io/badge/Available%20components-digitaldesign.scania.com-orange)](https://tegel.scania.com/getting-started/development)
+[![Getting Started](https://img.shields.io/badge/Available%20components-tegel.scania.com-orange)](https://tegel.scania.com/getting-started/development)
 
 # Tegel Design System - Components
 

--- a/tegel/readme.md
+++ b/tegel/readme.md
@@ -13,35 +13,12 @@ Check out [Tegel Design System](https://tegel.scania.com/) for implementation an
 
 ## Quick start
 
-How to add components in the project:
-
-Install components via NPM package by running the command below.
-
-<!-- TODO: update if we rename package when we release tegel -->
-```
-npm i @scania/tegel
-```
-
-Import component as a module with `defineCustomElements` function.
-
-```js
-import { defineCustomElements } from '@scania/tegel';
-
-defineCustomElements();
-```
-
-Import the global CSS.
-
-<!-- TODO: update when we know path/package name -->
-```js
-import '@scania/tegel/dist/tegel/tegel.css';
-```
-
+- Installation: [https://tegel.scania.com/development/getting-started-development/installation](https://tegel.scania.com/development/getting-started-development/installation)
 See all available components in the [Tegel Design System](https://tegel.scania.com/components).
 
 ## Browser support
 
-See the Tegel [website](https://tegel.scania.com/development/getting-started-development/introduction#browser-support).
+See the browser support section on [the Tegel website](https://tegel.scania.com/development/getting-started-development/introduction#browser-support).
 
 ## Contributing
 

--- a/tegel/readme.md
+++ b/tegel/readme.md
@@ -1,75 +1,61 @@
-![Built With Stencil](https://img.shields.io/badge/-Built%20With%20Stencil-16161d.svg?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDE5LjIuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA1MTIgNTEyIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI%2BCjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI%2BCgkuc3Qwe2ZpbGw6I0ZGRkZGRjt9Cjwvc3R5bGU%2BCjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik00MjQuNywzNzMuOWMwLDM3LjYtNTUuMSw2OC42LTkyLjcsNjguNkgxODAuNGMtMzcuOSwwLTkyLjctMzAuNy05Mi43LTY4LjZ2LTMuNmgzMzYuOVYzNzMuOXoiLz4KPHBhdGggY2xhc3M9InN0MCIgZD0iTTQyNC43LDI5Mi4xSDE4MC40Yy0zNy42LDAtOTIuNy0zMS05Mi43LTY4LjZ2LTMuNkgzMzJjMzcuNiwwLDkyLjcsMzEsOTIuNyw2OC42VjI5Mi4xeiIvPgo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNNDI0LjcsMTQxLjdIODcuN3YtMy42YzAtMzcuNiw1NC44LTY4LjYsOTIuNy02OC42SDMzMmMzNy45LDAsOTIuNywzMC43LDkyLjcsNjguNlYxNDEuN3oiLz4KPC9zdmc%2BCg%3D%3D&colorA=16161d&style=flat-square)
+<!-- TODO: add release -->
+<!-- [![Github release](https://img.shields.io/npm/v/@scania/components?color=1081C2)](https://www.npmjs.com/package/@scania/components)
+[![Github release](https://img.shields.io/github/v/release/scania-digital-design-system/sdds?color=1081C2)](https://github.com/scania-digital-design-system/sdds/releases) -->
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+![](https://img.shields.io/github/license/scania-digital-design-system/sdds)
+[![Getting Started](https://img.shields.io/badge/Available%20components-digitaldesign.scania.com-orange)](https://tegel.scania.com/getting-started/development)
 
-# Stencil Component Starter
+# Tegel Design System - Components
 
-This is a starter project for building a standalone Web Component using Stencil.
+**Technical documentation**
 
-Stencil is also great for building entire apps. For that, use the [stencil-app-starter](https://github.com/ionic-team/stencil-app-starter) instead.
+Check out [Tegel Design System](https://tegel.scania.com/) for implementation and technical documentation.
 
-# Stencil
+## Quick start
 
-Stencil is a compiler for building fast web apps using Web Components.
+How to add components in the project:
 
-Stencil combines the best concepts of the most popular frontend frameworks into a compile-time rather than run-time tool.  Stencil takes TypeScript, JSX, a tiny virtual DOM layer, efficient one-way data binding, an asynchronous rendering pipeline (similar to React Fiber), and lazy-loading out of the box, and generates 100% standards-based Web Components that run in any browser supporting the Custom Elements v1 spec.
+Install components via NPM package by running the command below.
 
-Stencil components are just Web Components, so they work in any major framework or with no framework at all.
-
-## Getting Started
-
-To start building a new web component using Stencil, clone this repo to a new directory:
-
-```bash
-git clone https://github.com/ionic-team/stencil-component-starter.git my-component
-cd my-component
-git remote rm origin
+<!-- TODO: update if we rename package when we release tegel -->
+```
+npm i @scania/tegel
 ```
 
-and run:
+Import component as a module with `defineCustomElements` function.
 
-```bash
-npm install
-npm start
+```js
+import { defineCustomElements } from '@scania/tegel';
+
+defineCustomElements();
 ```
 
-To build the component for production, run:
+Import the global CSS.
 
-```bash
-npm run build
+<!-- TODO: update when we know path/package name -->
+```js
+import '@scania/tegel/dist/tegel/tegel.css';
 ```
 
-To run the unit tests for the components, run:
+See all available components in the [Tegel Design System](https://tegel.scania.com/components).
 
-```bash
-npm test
-```
+## Browser support
 
-Need help? Check out our docs [here](https://stenciljs.com/docs/my-first-component).
+See the Tegel [website](https://tegel.scania.com/development/getting-started-development/introduction#browser-support).
 
+## Contributing
 
-## Naming Components
+Please read through our [contributing guidelines](https://github.com/scania-digital-design-system/sdds/blob/master/CONTRIBUTING.md) for the directions to **develop components**, **create a pull request** and **coding standard**.
 
-When creating new component tags, we recommend _not_ using `stencil` in the component name (ex: `<stencil-datepicker>`). This is because the generated component has little to nothing to do with Stencil; it's just a web component!
+- [Report bug](https://github.com/scania-digital-design-system/sdds/issues)
+- [Request feature](https://github.com/scania-digital-design-system/sdds/issues/new)
 
-Instead, use a prefix that fits your company or any name for a group of related components. For example, all of the Ionic generated web components use the prefix `ion`.
+## Community
 
+Get in touch with the team and the community:
 
-## Using this component
+- [Teams](https://teams.microsoft.com/l/team/19%3a1257007a64d44c64954acca27a9d4b46%40thread.skype/conversations?groupId=79f9bfeb-73e2-424d-9477-b236191ece5e&tenantId=3bc062e4-ac9d-4c17-b4dd-3aad637ff1ac)
 
-There are three strategies we recommend for using web components built with Stencil.
+## License
 
-The first step for all three of these strategies is to [publish to NPM](https://docs.npmjs.com/getting-started/publishing-npm-packages).
-
-### Script tag
-
-- Put a script tag similar to this `<script type='module' src='https://unpkg.com/my-component@0.0.1/dist/my-component.esm.js'></script>` in the head of your index.html
-- Then you can use the element anywhere in your template, JSX, html etc
-
-### Node Modules
-- Run `npm install my-component --save`
-- Put a script tag similar to this `<script type='module' src='node_modules/my-component/dist/my-component.esm.js'></script>` in the head of your index.html
-- Then you can use the element anywhere in your template, JSX, html etc
-
-### In a stencil-starter app
-- Run `npm install my-component --save`
-- Add an import to the npm packages `import my-component;`
-- Then you can use the element anywhere in your template, JSX, html etc
+All CSS, HTML and JS code are available under the MIT license. The Scania brand identity, logos and photographs found in this repository are copyrighted Scania CV AB and are not available on an open source basis or to be used as examples or in any other way, if not specifically ordered by Scania CV AB.

--- a/tegel/readme.md
+++ b/tegel/readme.md
@@ -16,7 +16,7 @@ Check out [Tegel Design System](https://tegel.scania.com/) for implementation an
 - Installation: [https://tegel.scania.com/development/getting-started-development/installation](https://tegel.scania.com/development/getting-started-development/installation)
 
 
-See all available components in the [Tegel Design System](https://tegel.scania.com/components).
+See all available components in the [Tegel Design System](https://tegel.scania.com/components/overview).
 
 ## Browser support
 

--- a/tegel/readme.md
+++ b/tegel/readme.md
@@ -14,6 +14,8 @@ Check out [Tegel Design System](https://tegel.scania.com/) for implementation an
 ## Quick start
 
 - Installation: [https://tegel.scania.com/development/getting-started-development/installation](https://tegel.scania.com/development/getting-started-development/installation)
+
+
 See all available components in the [Tegel Design System](https://tegel.scania.com/components).
 
 ## Browser support


### PR DESCRIPTION
Adds a readme for the tegel package.

**Solving issue**  
Fixes: [AB#2485](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2485)

**How to test**
Go to branch and look at readme
Link: https://github.com/scania-digital-design-system/sdds/tree/docs/add-tegel-readme/tegel#readme
