### PR TITLE
feat(textfield): added color to suffix/prefix icons

### DIFF
--- a/tegel/src/components/textfield/textfield.scss
+++ b/tegel/src/components/textfield/textfield.scss
@@ -422,6 +422,13 @@ slot[name="sdds-suffix"]::slotted(*) {
     margin-left: 16px;
     color: var(--sdds-textfield-ps-color);
   }
+
+  &.sdds-textfield-error {
+    sdds-icon,
+    .sdds-icon {
+      color: var(--sdds-negative);
+    }
+  }
 }
 
 .sdds-textfield-slot-wrap-suffix {
@@ -432,6 +439,13 @@ slot[name="sdds-suffix"]::slotted(*) {
     letter-spacing: var(--sdds-detail-02-ls);
     margin-right: 16px;
     color: var(--sdds-textfield-ps-color);
+  }
+
+  &.sdds-textfield-error {
+    sdds-icon,
+    .sdds-icon {
+      color: var(--sdds-negative);
+    }
   }
 }
 

--- a/tegel/src/components/textfield/textfield.tsx
+++ b/tegel/src/components/textfield/textfield.tsx
@@ -115,7 +115,7 @@ export class Textfield {
         </div>
 
         <div onClick={() => this.handleFocusClick()} class="sdds-textfield-container">
-          <div class="sdds-textfield-slot-wrap-prefix">
+          <div class={`sdds-textfield-slot-wrap-prefix sdds-textfield-${this.state}`}>
             <slot name="sdds-prefix" />
           </div>
 
@@ -151,7 +151,7 @@ export class Textfield {
           </div>
           <div class="sdds-textfield-bar"></div>
 
-          <div class="sdds-textfield-slot-wrap-suffix">
+          <div class={`sdds-textfield-slot-wrap-suffix sdds-textfield-${this.state}`}>
             <slot name="sdds-suffix" />
           </div>
 


### PR DESCRIPTION
**Describe pull-request**  
Added a class to get the state of the textfield in the icon and added the correct color to this icon if state === 'error'.

**Solving issue**  
Fixes: [AB#2741](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2741)

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Textfield
3. Add a suffix and/or prefix icon and set the component to error state.

**Screenshots**  
-

**Additional context**  
-
