### PR TITLE
fix(accordion): padding and chevron fixes

### DIFF
--- a/tegel/src/components/accordion/accordion-item/accordion-item.tsx
+++ b/tegel/src/components/accordion/accordion-item/accordion-item.tsx
@@ -50,21 +50,7 @@ export class AccordionItem {
         >
           <div class="sdds-accordion-title">{this.header}</div>
           <div class="sdds-accordion-icon">
-            <svg
-              width="12"
-              height="7"
-              viewBox="0 0 12 7"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M1 1L6 6L11 1"
-                stroke="currentColor"
-                stroke-width="1.25"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
+            <sdds-icon name="chevron_down" size="18px"></sdds-icon>
           </div>
         </div>
         <div

--- a/tegel/src/components/accordion/accordion-item/accordion-item.tsx
+++ b/tegel/src/components/accordion/accordion-item/accordion-item.tsx
@@ -50,7 +50,7 @@ export class AccordionItem {
         >
           <div class="sdds-accordion-title">{this.header}</div>
           <div class="sdds-accordion-icon">
-            <sdds-icon name="chevron_down" size="18px"></sdds-icon>
+            <sdds-icon name="chevron_down" size="16px"></sdds-icon>
           </div>
         </div>
         <div

--- a/tegel/src/components/accordion/accordion-item/readme.md
+++ b/tegel/src/components/accordion/accordion-item/readme.md
@@ -22,6 +22,19 @@
 | `accordionItemToggle` | Fires after the accordion item is closed or opened, emitting the value (as boolean) of the current state of the accordion | `CustomEvent<boolean>` |
 
 
+## Dependencies
+
+### Depends on
+
+- [sdds-icon](../../icon)
+
+### Graph
+```mermaid
+graph TD;
+  sdds-accordion-item --> sdds-icon
+  style sdds-accordion-item fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/tegel/src/components/accordion/accordion.scss
+++ b/tegel/src/components/accordion/accordion.scss
@@ -145,6 +145,7 @@
   &.expanded {
     .sdds-accordion-panel {
       display: block;
+      padding-bottom: 31px;
     }
 
     .sdds-accordion-icon {

--- a/tegel/src/components/accordion/accordion.scss
+++ b/tegel/src/components/accordion/accordion.scss
@@ -53,6 +53,10 @@
       transform-origin: center;
       transition: transform 0.15s ease-in-out;
       color: var(--sdds-accordion-colour);
+
+      & > sdds-icon {
+        display: block;
+      }
     }
   }
 

--- a/tegel/src/components/icon/readme.md
+++ b/tegel/src/components/icon/readme.md
@@ -11,6 +11,19 @@
 | `size`   | `size`    | Pass a size of icon as a string, for example: 32px, 1rem, 4em...                                                               | `string` | `'16px'`           |
 
 
+## Dependencies
+
+### Used by
+
+ - [sdds-accordion-item](../accordion/accordion-item)
+
+### Graph
+```mermaid
+graph TD;
+  sdds-accordion-item --> sdds-icon
+  style sdds-icon fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*


### PR DESCRIPTION
**Describe pull-request**  
Corrected panel expanded padding and used sdds-icon instead of svg for the chevron.


**Solving issue**  
Fixes: [AB#2656](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2656)

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Accordion
3. Check the padding on the expanded panel.
4. Check the chevron icon.

**Screenshots**  
-

**Additional context**  
-
