### PR TITLE
chore: make sb addons work in dev mode

### DIFF
--- a/tegel/.storybook/main.js
+++ b/tegel/.storybook/main.js
@@ -1,3 +1,5 @@
+require('dotenv').config();
+
 let addons = [
   '@storybook/addon-links',
   '@storybook/addon-essentials',

--- a/tegel/package-lock.json
+++ b/tegel/package-lock.json
@@ -14,6 +14,7 @@
         "@stencil/core": "^2.13.0",
         "@storybook/addon-google-analytics": "^6.2.9",
         "concurrently": "^7.4.0",
+        "dotenv": "^16.0.3",
         "html-format": "^1.0.2",
         "prettier": "^2.7.1"
       },
@@ -11410,6 +11411,14 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/dotenv-expand": {
       "version": "5.1.0",
@@ -35182,6 +35191,11 @@
           "dev": true
         }
       }
+    },
+    "dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
     "dotenv-expand": {
       "version": "5.1.0",

--- a/tegel/package.json
+++ b/tegel/package.json
@@ -41,7 +41,7 @@
     "build-storybook": "build-storybook --quiet",
     "deploy-storybook": "npm install && npm run build && npm run build-storybook",
     "build-stencil:watch": "stencil build --docs-readme --watch",
-    "start-storybook": "STORYBOOK_ENV=development start-storybook -p 6006 -s dist",
+    "start-storybook": "start-storybook -p 6006 -s dist",
     "tegel": "concurrently --raw  'npm:build-stencil:watch' 'npm:start-storybook'",
     "commit": "npm run --prefix ../ commit"
   },
@@ -51,6 +51,7 @@
     "@stencil/core": "^2.13.0",
     "@storybook/addon-google-analytics": "^6.2.9",
     "concurrently": "^7.4.0",
+    "dotenv": "^16.0.3",
     "html-format": "^1.0.2",
     "prettier": "^2.7.1"
   },


### PR DESCRIPTION
Need to add an .env file in tegel dir with the line "STORYBOOK_ENV=development" locally