### PR TITLE
fix(accordion): css rules for accordion

### DIFF
--- a/components/src/components/accordion/accordion.scss
+++ b/components/src/components/accordion/accordion.scss
@@ -1,9 +1,9 @@
-@import "@scania/typography/dist/scss/mixins";
-@import "@scania/typography/dist/scss/tokens";
-@import "../divider/divider.scss";
-@import "../../helpers/components-shared.scss";
+@import '@scania/typography/dist/scss/mixins';
+@import '@scania/typography/dist/scss/tokens';
+@import '../divider/divider.scss';
+@import '../../helpers/components-shared.scss';
 
-:host {
+sdds-accordion {
   // Variables
   --sdds-accordion-border: var(--sdds-grey-300);
   --sdds-accordion-bg: transparent;
@@ -14,8 +14,7 @@
   --sdds-accordion-border-focus: var(--sdds-grey-500);
   --sdds-accordion-colour-disabled: var(--sdds-grey-400);
 
-  // Styling
-  .sdds-on-white-bg {
+  &.sdds-on-white-bg {
     --sdds-accordion-bg-hover: var(--sdds-grey-50);
   }
 }
@@ -53,7 +52,7 @@
     display: flex;
     align-items: center;
 
-    @include type-style("headline-07");
+    @include type-style('headline-07');
 
     padding: var(--sdds-spacing-element-16);
     background-color: var(--sdds-accordion-bg);
@@ -71,12 +70,11 @@
 
   .sdds-accordion-panel {
     cursor: default;
-    padding:
- var(--sdds-spacing-element-8) var(--sdds-spacing-layout-64)
+    padding: var(--sdds-spacing-element-8) var(--sdds-spacing-layout-64)
       var(--sdds-spacing-element-32) var(--sdds-spacing-element-16);
     display: none;
 
-    @include type-style("detail-03");
+    @include type-style('detail-03');
 
     p {
       margin: 0;
@@ -185,7 +183,7 @@
     position: relative;
 
     &::after {
-      content: "";
+      content: '';
       position: absolute;
       width: 100%;
       height: 0;
@@ -208,7 +206,7 @@
   border-top: 1px solid var(--sdds-accordion-border-focus);
 }
 
-::slotted(sdds-accordion-item[disabled="true"]:focus) {
+::slotted(sdds-accordion-item[disabled='true']:focus) {
   border-color: var(--sdds-accordion-border);
 }
 


### PR DESCRIPTION
**Describe pull-request**  
Since this css cover both accordion and accordion-item the css rules can't specifiy a host within a host so this is why I changed it to sdds-accordion.

**Solving issue**  
Fixes: [AB#2747](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2747)

**How to test**  
1. Check out branch and run components.
2. Add a sdds-on-white-bg class to the accordion in its story.
3. Check that the hover state is correct.

**Screenshots**  
-

**Additional context**  
-
