### PR TITLE
fix(chips): added font-size for icon in component css

### DIFF
--- a/tegel/src/components/chips/chips.scss
+++ b/tegel/src/components/chips/chips.scss
@@ -24,6 +24,7 @@
     height: 16px;
     width: 16px;
     position: absolute;
+    font-size: 16px;
 
     path {
       fill: var(--sdds-chips-icon-fill);

--- a/tegel/src/components/chips/chips.stories.ts
+++ b/tegel/src/components/chips/chips.stories.ts
@@ -90,24 +90,25 @@ const Template = ({ icon, iconPosition, iconType, state, placeholderText, size }
     ${
       iconType === 'Native'
         ? '<i class="sdds-chip-icon sdds-icon notification"></i>'
-        : '<div><sdds-icon class="sdds-chip-icon" name="notification" size="16px" /></div>'
+        : '<sdds-icon class="sdds-chip-icon" name="notification" size="16px"></sdds-icon>'
     }
     `;
 
   return formatHtmlPreview(`
-   
-      ${
-        iconType === 'Native'
-          ? ` <style>
-          @import url('https://cdn.digitaldesign.scania.com/icons/webfont/css/sdds-icons.css');
+  ${
+    iconType === 'Native'
+      ? `<style>
+    @import url('https://cdn.digitaldesign.scania.com/icons/webfont/css/sdds-icons.css');
+    .sdds-chip-icon {
+      font-size: 16px;
+    }
           </style>`
-          : ''
-      }
+      : ''
+  }
     <div class="sdds-chip ${
       icon ? iconPositionLookup[iconPosition] : ''
     } ${stateValue} ${sizeValue}">
-      ${icon ? iconSvg : ''}
-      <span class="sdds-chip-text">${placeholderText}</span>
+      ${icon ? iconSvg : ''}<span class="sdds-chip-text">${placeholderText}</span>
     </div>
     `);
 };

--- a/tegel/src/components/chips/chips.stories.ts
+++ b/tegel/src/components/chips/chips.stories.ts
@@ -95,16 +95,14 @@ const Template = ({ icon, iconPosition, iconType, state, placeholderText, size }
     `;
 
   return formatHtmlPreview(`
-    <style>
+   
       ${
         iconType === 'Native'
-          ? `@import url('https://cdn.digitaldesign.scania.com/icons/webfont/css/sdds-icons.css');`
+          ? ` <style>
+          @import url('https://cdn.digitaldesign.scania.com/icons/webfont/css/sdds-icons.css');
+          </style>`
           : ''
       }
-      .sdds-chip-icon {
-        font-size: 16px;
-      }
-    </style>
     <div class="sdds-chip ${
       icon ? iconPositionLookup[iconPosition] : ''
     } ${stateValue} ${sizeValue}">


### PR DESCRIPTION
**Describe pull-request**  
Added the for the web font icon to the component styling. Removed unused styles from story.

**Solving issue**  
Fixes: [AB#2819](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2819)

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Chip
3. Add a native icon and make sure it's 16px in font-size.

**Screenshots**  
-

**Additional context**  
-
