### PR TITLE
fix(data-table): native component caption fixes

### DIFF
--- a/tegel/src/components/data-table/native-table.scss
+++ b/tegel/src/components/data-table/native-table.scss
@@ -8,7 +8,9 @@
     font: var(--sdds-headline-07);
     letter-spacing: var(--sdds-headline-07-ls);
     text-align: left;
-    height: 64px;
+
+    // 24px to account for header component that overlaps
+    height: 32px;
     display: table-caption;
     position: relative;
     background-color: var(--sdds-grey-400);
@@ -119,7 +121,8 @@
   // SDDS GLOBAL STYLES:
   &.sdds-table--compact {
     .sdds-table__title {
-      height: 56px;
+      // 24px to account for header component that overlaps
+      height: 24px;
     }
 
     .sdds-table__body-cell,


### PR DESCRIPTION
**Describe pull-request**  
Corrected the height of the caption for native component.

**Solving issue**  
Fixes: [AB#2825](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2825)

**How to test**  
1. Go to storybook link below
2. Check in Components -> Data-table -> Native
3. Check that the caption is 64px by default and 56px in compact design

**Screenshots**  
-

**Additional context**  
-
