### PR TITLE
docs(data-table): added default value for multiselect

### DIFF
--- a/tegel/src/components/data-table/table-component-multiselect.stories.ts
+++ b/tegel/src/components/data-table/table-component-multiselect.stories.ts
@@ -106,6 +106,7 @@ export default {
     verticalDivider: false,
     responsiveDesign: false,
     noMinWidth: false,
+    enableMultiselect: true,
   },
 };
 


### PR DESCRIPTION
**Describe pull-request**  
Added a default value for the multiselect story.

**Solving issue**  
Fixes: [AB#2824](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2824)

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Data-table -> Multiselect
3. Check that multiselect is enabled by default.

**Screenshots**  
-

**Additional context**  
-
