### PR TITLE
feat(typography): removed dep on scania/typography

### DIFF
--- a/tegel/src/global/global.scss
+++ b/tegel/src/global/global.scss
@@ -12,7 +12,9 @@
 // Typography
 @import 'scania-fonts';
 @import 'scania-fonts-vars';
-@import '../theme/core/typography/selectors';
+@import 'scania-fonts-selectors';
+
+//@import '../theme/core/typography/selectors';
 
 // Spacing
 @import '../theme/core/spacing/spacing-vars.scss';

--- a/tegel/src/global/scania-fonts-selectors.scss
+++ b/tegel/src/global/scania-fonts-selectors.scss
@@ -1,0 +1,208 @@
+.sdds-headline-01 {
+  font-family: 'Scania Sans Headline', arial, helvetica, sans-serif;
+  font-weight: bold;
+  font-size: 2.5rem;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.sdds-headline-02 {
+  font-family: 'Scania Sans', arial, helvetica, sans-serif;
+  font-weight: bold;
+  font-size: 2rem;
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+.sdds-headline-03 {
+  font-family: 'Scania Sans', arial, helvetica, sans-serif;
+  font-weight: bold;
+  font-size: 1.5rem;
+  line-height: 1;
+  letter-spacing: -0.03em;
+}
+
+.sdds-headline-04 {
+  font-family: 'Scania Sans', arial, helvetica, sans-serif;
+  font-weight: bold;
+  font-size: 1.25rem;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+}
+
+.sdds-headline-05 {
+  font-family: 'Scania Sans', arial, helvetica, sans-serif;
+  font-weight: bold;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  letter-spacing: -0.02em;
+}
+
+.sdds-headline-06 {
+  font-family: 'Scania Sans', arial, helvetica, sans-serif;
+  font-weight: bold;
+  font-size: 0.875rem;
+  line-height: 1.14;
+  letter-spacing: -0.02em;
+}
+
+.sdds-headline-07 {
+  font-family: 'Scania Sans Semi Condensed', arial, helvetica, sans-serif;
+  font-weight: bold;
+  font-size: 0.875rem;
+  line-height: 1.14;
+  letter-spacing: -0.01em;
+}
+
+.sdds-paragraph-01 {
+  font-family: 'Scania Sans', arial, helvetica, sans-serif;
+  font-size: 1.5rem;
+  line-height: 1.33;
+  letter-spacing: -0.03em;
+}
+
+.sdds-paragraph-02 {
+  font-family: 'Scania Sans', arial, helvetica, sans-serif;
+  font-size: 1.25rem;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+}
+
+.sdds-body-01 {
+  font-family: 'Scania Sans', arial, helvetica, sans-serif;
+  font-size: 1rem;
+  line-height: 1.5;
+  letter-spacing: -0.02em;
+}
+
+.sdds-body-02 {
+  font-family: 'Scania Sans', arial, helvetica, sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.43;
+  letter-spacing: -0.01em;
+}
+
+.sdds-detail-01 {
+  font-family: 'Scania Sans Semi Condensed', 'Scania Sans Condensed', arial, helvetica, sans-serif;
+  font-size: 1rem;
+  line-height: 1.5;
+  letter-spacing: -0.01em;
+}
+
+.sdds-detail-02 {
+  font-family: 'Scania Sans Semi Condensed', 'Scania Sans Condensed', arial, helvetica, sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.14;
+  letter-spacing: -0.01em;
+}
+
+.sdds-detail-03 {
+  font-family: 'Scania Sans Semi Condensed', 'Scania Sans Condensed', arial, helvetica, sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.43;
+  letter-spacing: -0.01em;
+}
+
+.sdds-detail-04 {
+  font-family: 'Scania Sans', arial, helvetica, sans-serif;
+  font-weight: bold;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  line-height: 1.33;
+  letter-spacing: 0.08em;
+}
+
+.sdds-detail-05 {
+  font-family: 'Scania Sans Semi Condensed', 'Scania Sans Condensed', arial, helvetica, sans-serif;
+  font-size: 0.75rem;
+  line-height: 1.33;
+  letter-spacing: 0;
+}
+
+.sdds-detail-06 {
+  font-family: 'Scania Sans', arial, helvetica, sans-serif;
+  font-weight: bold;
+  text-transform: uppercase;
+  font-size: 0.625rem;
+  line-height: 1.6;
+  letter-spacing: 0.08em;
+}
+
+.sdds-detail-07 {
+  font-family: 'Scania Sans Semi Condensed', 'Scania Sans Condensed', arial, helvetica, sans-serif;
+  font-size: 0.625rem;
+  line-height: 0.8;
+  letter-spacing: 0;
+}
+
+.sdds-expressive-headline-01 {
+  font-family: 'Scania Sans Headline', arial, helvetica, sans-serif;
+  font-weight: bold;
+  font-size: 5rem;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.sdds-expressive-headline-02 {
+  font-family: 'Scania Sans Headline', arial, helvetica, sans-serif;
+  font-weight: bold;
+  font-size: 3.5rem;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+h1 {
+  font-family: 'Scania Sans Headline', arial, helvetica, sans-serif;
+  font-weight: bold;
+  font-size: 2.5rem;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+h2 {
+  font-family: 'Scania Sans', arial, helvetica, sans-serif;
+  font-weight: bold;
+  font-size: 2rem;
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+h3 {
+  font-family: 'Scania Sans', arial, helvetica, sans-serif;
+  font-weight: bold;
+  font-size: 1.5rem;
+  line-height: 1;
+  letter-spacing: -0.03em;
+}
+
+h4 {
+  font-family: 'Scania Sans', arial, helvetica, sans-serif;
+  font-weight: bold;
+  font-size: 1.25rem;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+}
+
+h5 {
+  font-family: 'Scania Sans', arial, helvetica, sans-serif;
+  font-weight: bold;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  letter-spacing: -0.02em;
+}
+
+h6 {
+  font-family: 'Scania Sans', arial, helvetica, sans-serif;
+  font-weight: bold;
+  font-size: 0.875rem;
+  line-height: 1.14;
+  letter-spacing: -0.02em;
+}
+
+.h7 {
+  font-family: 'Scania Sans Semi Condensed', arial, helvetica, sans-serif;
+  font-weight: bold;
+  font-size: 0.875rem;
+  line-height: 1.14;
+  letter-spacing: -0.01em;
+}


### PR DESCRIPTION
**Describe pull-request**  
Removed tegel dependancy on scania/typography package.

This is an alternative to https://github.com/scania-digital-design-system/sdds/pull/710

**Solving issue**  
Fixes: [AB#2830](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2830)

**How to test**  
1. Go to storybook link below
2. Check in typography
3. Check that the font are correct and that they are using rem for font-size and no unit for line-height.

**Screenshots**  
-

**Additional context**  
-
