### PR TITLE
feat: rename close btn classes

### DIFF
--- a/tegel/src/components/modal/modal-native.stories.ts
+++ b/tegel/src/components/modal/modal-native.stories.ts
@@ -90,7 +90,7 @@ const Template = ({ headline, size, actions, showModal }) =>
       } sdds-modal__actions-${actions.toLowerCase()}">
         <div class="sdds-modal-header">
             <h5 class="sdds-modal-headline">${headline}</h5>
-          <span class="sdds-modal-btn"></span>
+          <span class="sdds-modal-close"></span>
         </div>
           <div class="sdds-modal-body">
             <p>
@@ -115,7 +115,7 @@ const Template = ({ headline, size, actions, showModal }) =>
     })
   }
 
-  document.getElementsByClassName('sdds-modal-btn')[0].addEventListener('click', () => {
+  document.getElementsByClassName('sdds-modal-close')[0].addEventListener('click', () => {
     modal.classList.replace('show', 'hide');
   })
 

--- a/tegel/src/components/modal/modal.scss
+++ b/tegel/src/components/modal/modal.scss
@@ -238,7 +238,7 @@ $modals: (
   @include modal-host;
 }
 
-.sdds-modal-btn {
+.sdds-modal-close {
   display: inline-block;
   width: 16px;
   height: auto;
@@ -264,7 +264,7 @@ $modals: (
 :host {
   @include modal-host;
 
-  .sdds-modal-btn {
+  .sdds-modal-close {
     border: none;
     background-color: transparent;
 

--- a/tegel/src/components/modal/modal.tsx
+++ b/tegel/src/components/modal/modal.tsx
@@ -39,7 +39,7 @@ export class Modal {
     const targetList = e.composedPath();
     const target = targetList[0];
     if (
-      target.classList[0] === 'sdds-modal-btn' ||
+      target.classList[0] === 'sdds-modal-close' ||
       (target.classList[0] === 'sdds-modal-backdrop' && this.prevent === false)
     ) {
       this.open = false;
@@ -65,7 +65,7 @@ export class Modal {
         >
           <div class="sdds-modal-header">
             <slot name="sdds-modal-headline"></slot>
-            <button class="sdds-modal-btn"></button>
+            <button class="sdds-modal-close"></button>
           </div>
 
           <div class="sdds-modal-body">

--- a/tegel/src/components/toast/toast.scss
+++ b/tegel/src/components/toast/toast.scss
@@ -76,7 +76,7 @@
     float: left;
   }
 
-  &-dismiss {
+  &-close {
     all: unset;
     float: right;
     width: var(--sdds-spacing-element-20);

--- a/tegel/src/components/toast/toast.stories.ts
+++ b/tegel/src/components/toast/toast.stories.ts
@@ -110,7 +110,7 @@ const Template = ({ toastType, subheader, link, iconType, icon }) => {
         <span class="sdds-toast-headline">This is ${
           toastType === 'Success' || toastType === 'Warning' ? 'a' : 'an'
         } ${toastType.toLowerCase()} message</span>
-        <button type="button" aria-label="close" class="sdds-toast-dismiss">
+        <button type="button" aria-label="close" class="sdds-toast-close">
           ${
             iconType === 'Native'
               ? `<i class="sdds-icon cross"></i>`

--- a/tegel/src/stories/Migration/Migration.stories.mdx
+++ b/tegel/src/stories/Migration/Migration.stories.mdx
@@ -11,6 +11,10 @@ https://www.markdownguide.org/cheat-sheet/ -->
 
 ---
 
+# Breaking changes
+
+---
+
 ## Removed base font-size and moved to `px` instead of `rem`.
 
 This change affects all components/typography/spacing/grid.
@@ -549,7 +553,41 @@ Rename all instances of `nominwidth` to `no-min-width`.
 ></sdds-textfield>
 ```
 
-### Not breaing but highly suggested changes
+## Toast
+
+#### Changed class name 'sdds-toast-dismiss' to 'sdds-toast-close'
+
+The class `sdds-toast-dismiss` was renamed to `sdds-toast-close` to conform with other class names.
+
+##### What action is required?
+
+Rename all instances of `sdds-toast-dismiss` to `sdds-toast-close`.
+
+```jsx
+// Old ❌
+<div class="sdds-toast-content">
+  <div class="sdds-toast-header">
+    <span class="sdds-toast-headline">This is a success message</span>
+    <button class="sdds-toast-dismiss">
+    </button>
+  </div>
+</div>
+
+// New ✅
+<div class="sdds-toast-content">
+  <div class="sdds-toast-header">
+    <span class="sdds-toast-headline">This is a success message</span>
+    <button class="sdds-toast-close">
+    </button>
+  </div>
+</div>
+```
+(**NOTE**: there are more highly suggested changes for this component further down 👇)
+
+----- 
+
+# Not breaing but highly suggested changes
+---
 
 ## Side menu
 

--- a/tegel/src/stories/Migration/Migration.stories.mdx
+++ b/tegel/src/stories/Migration/Migration.stories.mdx
@@ -324,6 +324,35 @@ with a single dash (`-`).
 </div>
 ```
 
+## Modal
+
+[Native](/docs/components-modal--native)
+
+#### Changed class name 'sdds-modal-btn' to 'sdds-modal-close'
+
+The class `sdds-modal-btn` was renamed to `sdds-modal-close` to conform with other class names.
+
+##### What action is required?
+
+Rename all instances of `sdds-modal-btn` to `sdds-modal-close` (no action is required if you are using the web component).
+
+```jsx
+// Old ❌
+<div class="sdds-modal">
+  <div class="sdds-modal-header">
+    <span class="sdds-modal-btn"></span>
+  </div>
+</div>
+
+// New ✅
+<div class="sdds-modal">
+  <div class="sdds-modal-header">
+    <span class="sdds-modal-close"></span>
+  </div>
+</div>
+```
+
+
 ## Stepper
 
 [Native](/docs/components-stepper--default)


### PR DESCRIPTION
Unifies close button class naming.

**Solving issue**  
Fixes: [AB#2748](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2748)

**How to test**  
Look at the affected components in the deploy preview.
