### PR TITLE
fix(sdds-icon): removed all selfclosures

### DIFF
--- a/tegel/src/components/banner/banner.stories.ts
+++ b/tegel/src/components/banner/banner.stories.ts
@@ -78,17 +78,17 @@ const Template = ({ state, prefix, header, subheader, link }) =>
     <div class="sdds-banner sdds-banner-${state.toLowerCase()}">
       ${
         prefix && state === 'error'
-          ? '<span class="sdds-banner-prefix"><sdds-icon name="error" size="20px" /></span>'
+          ? '<span class="sdds-banner-prefix"><sdds-icon name="error" size="20px"></sdds-icon></span>'
           : ''
       }
       ${
         prefix && state === 'info'
-          ? '<span class="sdds-banner-prefix"><sdds-icon name="info" size="20px" /></span>'
+          ? '<span class="sdds-banner-prefix"><sdds-icon name="info" size="20px"></sdds-icon></span>'
           : ''
       }
       ${
         prefix && !(state === 'info' || state === 'error')
-          ? '<span class="sdds-banner-prefix"><sdds-icon name="truck" size="20px" /></span>'
+          ? '<span class="sdds-banner-prefix"><sdds-icon name="truck" size="20px"></sdds-icon></span>'
           : ''
       }
       <div class="sdds-banner-body">

--- a/tegel/src/components/data-table/table-body/table-body.tsx
+++ b/tegel/src/components/data-table/table-body/table-body.tsx
@@ -341,7 +341,7 @@ export class TableBody {
         {this.bodyDataManipulated.map((row) => (
           <sdds-table-body-row>
             {Object.keys(row).map((cellData) => (
-              <sdds-body-cell cell-key={cellData} cell-value={row[cellData]} />
+              <sdds-body-cell cell-key={cellData} cell-value={row[cellData]}></sdds-body-cell>
             ))}
           </sdds-table-body-row>
         ))}

--- a/tegel/src/components/data-table/table-component-batch-actions.stories.ts
+++ b/tegel/src/components/data-table/table-component-batch-actions.stories.ts
@@ -104,7 +104,7 @@ export default {
     verticalDivider: false,
     responsiveDesign: false,
     batchArea: formatHtmlPreview(
-      '<button slot="sdds-table__actionbar" class="sdds-table__actionbar-btn"><sdds-icon class="sdds-table__actionbar-btn-icon" name="settings" size="20px" /> </button><sdds-button slot="sdds-table__actionbar" type="primary" size="sm" text="Download"></sdds-button>',
+      '<button slot="sdds-table__actionbar" class="sdds-table__actionbar-btn"><sdds-icon class="sdds-table__actionbar-btn-icon" name="settings" size="20px"></sdds-icon> </button><sdds-button slot="sdds-table__actionbar" type="primary" size="sm" text="Download"></sdds-button>',
     ),
     noMinWidth: false,
   },

--- a/tegel/src/components/footer/footer.stories.ts
+++ b/tegel/src/components/footer/footer.stories.ts
@@ -43,7 +43,7 @@ const Template = ({ topPart }) =>
             <div class="sdds-footer-title opened">
               <span>Title 1</span>
               <span class="sdds-footer-top-icon">
-                <sdds-icon name="chevron_down" size="16px" /> 
+                <sdds-icon name="chevron_down" size="16px"></sdds-icon> 
               </span>
             </div>
             <ul class="sdds-footer-main-links opened">
@@ -58,7 +58,7 @@ const Template = ({ topPart }) =>
             <div class="sdds-footer-title">
               <span>Title 2</span>
               <span class="sdds-footer-top-icon">
-              <sdds-icon name="chevron_down" size="16px" /> 
+              <sdds-icon name="chevron_down" size="16px"></sdds-icon> 
               </span>
             </div>
             <ul class="sdds-footer-main-links">

--- a/tegel/src/components/header/header-all.stories.ts
+++ b/tegel/src/components/header/header-all.stories.ts
@@ -78,7 +78,7 @@ const AllMenusTemplate = ({ siteName }) =>
               <button class='sdds-nav__item-core' onclick='toggleInlineDropdown()'>
                   <span class='sdds-nav__item-core-text'>Item 3</span>
                   <span class='sdds-nav__dropdown-icon'>
-                        <sdds-icon class="sdds-nav__dropdown-icon-svg" name="chevron_down" size="16px" />
+                        <sdds-icon class="sdds-nav__dropdown-icon-svg" name="chevron_down" size="16px"></sdds-icon> 
                     </span>
               </button>
               <ul class='sdds-nav__dropdown-menu'>
@@ -126,7 +126,7 @@ const AllMenusTemplate = ({ siteName }) =>
         <div class='sdds-nav__right'>
           <div class='sdds-nav__item sdds-nav__app-launcher'>
               <button class='sdds-nav__app-launcher-btn' onclick='toggleAppLauncher()'>
-                  <sdds-icon class="sdds-nav__app-launcher-btn-svg" name="bento" size="20px" />
+                  <sdds-icon class="sdds-nav__app-launcher-btn-svg" name="bento" size="20px" ></sdds-icon> 
               </button>
               <ul class='sdds-nav__app-launcher-menu'>
                   <li class='sdds-nav__app-launcher-item sdds-nav__app-launcher-item--category'>

--- a/tegel/src/components/header/header-inline.stories.ts
+++ b/tegel/src/components/header/header-inline.stories.ts
@@ -78,7 +78,7 @@ const InlineMenuTemplate = ({ siteName }) =>
               <button class='sdds-nav__item-core' onclick='toggleInlineDropdown()'>
                   <span class='sdds-nav__item-core-text'>Item 3</span>
                   <span class='sdds-nav__dropdown-icon'>
-                    <sdds-icon class="sdds-nav__dropdown-icon-svg" name="chevron_down" size="16px" />
+                    <sdds-icon class="sdds-nav__dropdown-icon-svg" name="chevron_down" size="16px"></sdds-icon> 
                   </span>
               </button>
               <ul class='sdds-nav__dropdown-menu'>

--- a/tegel/src/components/header/header-search.stories.ts
+++ b/tegel/src/components/header/header-search.stories.ts
@@ -83,7 +83,7 @@ const SearchbarMenuTemplate = ({ siteName }) =>
         <button class='sdds-nav__item-core' onclick='toggleInlineDropdown()'>
             <span class='sdds-nav__item-core-text'>Item 3</span>
             <span class='sdds-nav__dropdown-icon'>
-              <sdds-icon class="sdds-nav__dropdown-icon-svg" name="chevron_down" size="16px" />
+              <sdds-icon class="sdds-nav__dropdown-icon-svg" name="chevron_down" size="16px"></sdds-icon> 
             </span>
         </button>
         <ul class='sdds-nav__dropdown-menu'>
@@ -109,7 +109,7 @@ const SearchbarMenuTemplate = ({ siteName }) =>
               <a href='' class='sdds-nav__searchbar-results-item-core'>User – Eric Mattsson – IXCD Visual designer </a>
               <button class="sdds-nav__app-searchbar-results-x-btn">
                 <div>
-                  <sdds-icon class="sdds-nav__app-searchbar-results-x-btn" name="cross" size="16px" />
+                  <sdds-icon class="sdds-nav__app-searchbar-results-x-btn" name="cross" size="16px"></sdds-icon> 
                 </div>
               </button>
             </li>
@@ -117,7 +117,7 @@ const SearchbarMenuTemplate = ({ siteName }) =>
               <a href='' class='sdds-nav__searchbar-results-item-core'>User– Eric Mattsson – IXCD Visual designer </a>
               <button class="sdds-nav__app-searchbar-results-x-btn">
               <div>
-              <sdds-icon class="sdds-nav__app-searchbar-results-x-btn" name="cross" size="16px" />
+              <sdds-icon class="sdds-nav__app-searchbar-results-x-btn" name="cross" size="16px"></sdds-icon> 
             </div>              </button>
               </li>
             </ul>
@@ -128,19 +128,19 @@ const SearchbarMenuTemplate = ({ siteName }) =>
               <a href='' class='sdds-nav__searchbar-results-item-core'>Team– Eric Mattsson – IXCD Visual designer </a>
               <button class="sdds-nav__app-searchbar-results-x-btn">
               <div>
-              <sdds-icon class="sdds-nav__app-searchbar-results-x-btn" name="cross" size="16px" />
+              <sdds-icon class="sdds-nav__app-searchbar-results-x-btn" name="cross" size="16px"></sdds-icon> 
             </div>             </button>
               </li>
           </ul>
         </ul>
         <input class="sdds-nav__searchbar-input" type="text" placeholder="Search">
           <button class="sdds-nav__app-searchbar-btn sdds-nav__app-searchbar-x-btn" onclick="toggleSearchbar()">
-            <sdds-icon class="sdds-nav__app-searchbar-btn-svg" name="cross" size="20px" />
+            <sdds-icon class="sdds-nav__app-searchbar-btn-svg" name="cross" size="20px"></sdds-icon> 
           </button>
 
       </div>
        <button class="sdds-nav__app-searchbar-btn sdds-nav__app-searchbar-mgl-btn" onclick="toggleSearchbar()">
-          <sdds-icon class="sdds-nav__app-searchbar-btn-svg" name="search" size="20px" />
+          <sdds-icon class="sdds-nav__app-searchbar-btn-svg" name="search" size="20px"></sdds-icon> 
       </button>
     </div>
   </div>
@@ -175,7 +175,7 @@ const SearchbarMenuTemplate = ({ siteName }) =>
         <div class='sdds-nav__right'>
           <div class='sdds-nav__item sdds-nav__app-launcher'>
               <button class='sdds-nav__app-launcher-btn' onclick='toggleAppLauncher()'>
-                <sdds-icon class="sdds-nav__app-launcher-btn-svg" name="bento" size="20px" />
+                <sdds-icon class="sdds-nav__app-launcher-btn-svg" name="bento" size="20px"></sdds-icon> 
               </button>
               <ul class='sdds-nav__app-launcher-menu'>
                   <li class='sdds-nav__app-launcher-item sdds-nav__app-launcher-item--category'>

--- a/tegel/src/components/header/header-toolbar.stories.ts
+++ b/tegel/src/components/header/header-toolbar.stories.ts
@@ -78,7 +78,7 @@ const ToolbarMenuTemplate = ({ siteName }) =>
               <button class='sdds-nav__item-core' onclick='toggleInlineDropdown()'>
                   <span class='sdds-nav__item-core-text'>Item 3</span>
                   <span class='sdds-nav__dropdown-icon'>
-                    <sdds-icon class="sdds-nav__dropdown-icon-svg" name="chevron_down" size="16px" />
+                    <sdds-icon class="sdds-nav__dropdown-icon-svg" name="chevron_down" size="16px"></sdds-icon> 
                   </span>
               </button>
               <ul class='sdds-nav__dropdown-menu'>
@@ -121,7 +121,7 @@ const ToolbarMenuTemplate = ({ siteName }) =>
         <div class='sdds-nav__right'>
           <div class='sdds-nav__item sdds-nav__app-launcher'>
               <button class='sdds-nav__app-launcher-btn' onclick='toggleAppLauncher()'>
-                <sdds-icon class="sdds-nav__app-launcher-btn-svg" name="bento" size="20px" />
+                <sdds-icon class="sdds-nav__app-launcher-btn-svg" name="bento" size="20px"></sdds-icon> 
               </button>
               <ul class='sdds-nav__app-launcher-menu'>
                   <li class='sdds-nav__app-launcher-item sdds-nav__app-launcher-item--category'>

--- a/tegel/src/components/icon/icon-web-component.stories.ts
+++ b/tegel/src/components/icon/icon-web-component.stories.ts
@@ -48,7 +48,7 @@ export default {
 
 const IconTemplate = (args) =>
   formatHtmlPreview(`
-  <sdds-icon name="${args.icon}" size="${`${args.size.toString()}px`}" />
+  <sdds-icon name="${args.icon}" size="${`${args.size.toString()}px`}"></sdds-icon> 
   `);
 
 export const WebComponent = IconTemplate.bind({});

--- a/tegel/src/components/message/message.stories.ts
+++ b/tegel/src/components/message/message.stories.ts
@@ -87,7 +87,7 @@ const Template = ({ messageType, icon, iconType, showExtendedMessage, variant })
   const iconHtml =
     iconType === 'Native'
       ? `<i class="sdds-message-icon sdds-icon ${iconClass} ${nativeIconNameLookup[messageType]}"></i>`
-      : `<div><sdds-icon class="sdds-message-icon ${iconClass}" name="${nativeIconNameLookup[messageType]}" size="20" /></div>`;
+      : `<div><sdds-icon class="sdds-message-icon ${iconClass}" name="${nativeIconNameLookup[messageType]}" size="20"></sdds-icon></div>`;
 
   return formatHtmlPreview(
     `

--- a/tegel/src/components/popover-canvas/popover-canvas.stories.ts
+++ b/tegel/src/components/popover-canvas/popover-canvas.stories.ts
@@ -80,7 +80,7 @@ const ComponentPopoverCanvas = ({ canvasPosition }) => {
       </sdds-popover-canvas>
       <div class="demo-wrapper">
         <span style="user-select: none;margin-right: 16px;">Click icon for popover canvas</span>
-        <sdds-icon id="trigger" name="kebab" size="16px" />
+        <sdds-icon id="trigger" name="kebab" size="16px"></sdds-icon> 
       </div>
     `,
   );

--- a/tegel/src/components/popover-menu/popover-menu-icons.stories.ts
+++ b/tegel/src/components/popover-menu/popover-menu-icons.stories.ts
@@ -82,7 +82,7 @@ const Template = ({ menuPosition }) => {
           <li>
             <a target="_blank" href="https://digitaldesign.scania.com">
             <i>
-              <sdds-icon name="save" size="16px" />
+              <sdds-icon name="save" size="16px"></sdds-icon> 
             </i>
                 Menu item 1            
             </a>
@@ -90,7 +90,7 @@ const Template = ({ menuPosition }) => {
           <li>            
             <a target="_blank" href="https://digitaldesign.scania.com">
             <i>
-              <sdds-icon name="save" size="16px" />
+              <sdds-icon name="save" size="16px"></sdds-icon> 
             </i>   
               Menu item 2
             </a>
@@ -98,7 +98,7 @@ const Template = ({ menuPosition }) => {
           <li>            
             <a target="_blank" href="https://digitaldesign.scania.com">
             <i>
-              <sdds-icon name="save" size="16px" />
+              <sdds-icon name="save" size="16px"></sdds-icon> 
             </i>
               Menu item 3
             </a>
@@ -107,7 +107,7 @@ const Template = ({ menuPosition }) => {
           <li>            
             <a target="_blank" href="https://digitaldesign.scania.com">
             <i>
-              <sdds-icon name="save" size="16px" />
+              <sdds-icon name="save" size="16px"></sdds-icon> 
             </i>
               Menu item 4
             </a>
@@ -115,7 +115,7 @@ const Template = ({ menuPosition }) => {
           <li>            
             <a target="_blank" href="https://digitaldesign.scania.com">
             <i>
-              <sdds-icon name="save" size="16px" />
+              <sdds-icon name="save" size="16px"></sdds-icon> 
             </i>
               Menu item 5
             </a>
@@ -125,7 +125,7 @@ const Template = ({ menuPosition }) => {
     
       <div class="demo-wrapper">
         <span style="user-select: none;margin-right: 16px;">Click icon for popover menu</span>
-        <sdds-icon id="trigger" name="kebab" size="16px" />
+        <sdds-icon id="trigger" name="kebab" size="16px"></sdds-icon> 
       </div>
       `,
   );

--- a/tegel/src/components/popover-menu/popover-menu.stories.ts
+++ b/tegel/src/components/popover-menu/popover-menu.stories.ts
@@ -103,7 +103,7 @@ const Template = ({ menuPosition }) => {
 
       <div class="demo-wrapper">
         <span style="user-select: none;margin-right: 16px;">Click icon for popover menu</span>
-        <sdds-icon id="trigger" name="kebab" size="16px" />
+        <sdds-icon id="trigger" name="kebab" size="16px"></sdds-icon> 
       </div>
   `,
   );

--- a/tegel/src/components/side-menu/side-menu.stories.ts
+++ b/tegel/src/components/side-menu/side-menu.stories.ts
@@ -63,7 +63,7 @@ const Template = ({ showIcons, collapsed }) => {
 <nav class="sdds-nav">
   <div class="sdds-nav__left">
     <button class="sdds-nav__mob-menu-btn">
-      <sdds-icon name="burger" size="20px" />
+      <sdds-icon name="burger" size="20px"></sdds-icon> 
     </button>
     <div class="sdds-nav__app-name">My application</div>
   </div>
@@ -75,18 +75,18 @@ const Template = ({ showIcons, collapsed }) => {
   <div class="sdds-sidebar side-menu ${collapsed ? 'collapsed' : ''}">
     <div class="sdds-sidebar-mheader">
     <button class="sdds-sidebar-mheader__close">
-      <sdds-icon name="cross" size="20px" />
+      <sdds-icon name="cross" size="20px"></sdds-icon> 
     </button>
     </div>
     <ul class="sdds-sidebar-nav sdds-sidebar-nav--main ${icons}">
       <li class="sdds-sidebar-nav__item sdds-sidebar-nav__extended">
         <button class="sdds-sidebar-nav__item-link">
           <div>
-            <sdds-icon class="sdds-sidebar-nav__icon" name="truck" size="20px"/>
+            <sdds-icon class="sdds-sidebar-nav__icon" name="truck" size="20px"></sdds-icon> 
           </div>
           <span class="sdds-sidebar-nav__item-text">Sub-menu</span>
           <div>
-            <sdds-icon class="sdds-sidebar-nav__chevron" name="chevron_down" size="16px"/>
+            <sdds-icon class="sdds-sidebar-nav__chevron" name="chevron_down" size="16px></sdds-icon> 
           </div>
         </button>
         <ul class="sdds-sidebar-nav-subnav">
@@ -113,11 +113,11 @@ const Template = ({ showIcons, collapsed }) => {
       <li class="sdds-sidebar-nav__item sdds-sidebar-nav__extended">
       <button class="sdds-sidebar-nav__item-link">
       <div>
-        <sdds-icon class="sdds-sidebar-nav__icon" name="truck" size="20px"/>
+        <sdds-icon class="sdds-sidebar-nav__icon" name="truck" size="20px></sdds-icon> 
       </div>
       <span class="sdds-sidebar-nav__item-text">Sub-menu</span>
       <div>
-        <sdds-icon class="sdds-sidebar-nav__chevron" name="chevron_down" size="16px"/>
+        <sdds-icon class="sdds-sidebar-nav__chevron" name="chevron_down" size="16px></sdds-icon> 
       </div>
       </button>
         <ul class="sdds-sidebar-nav-subnav">
@@ -144,7 +144,7 @@ const Template = ({ showIcons, collapsed }) => {
       <li class="sdds-sidebar-nav__item">
         <a class="sdds-sidebar-nav__item-link" href="#">
         <div>
-        <sdds-icon class="sdds-sidebar-nav__icon" name="truck" size="20px"/>
+        <sdds-icon class="sdds-sidebar-nav__icon" name="truck" size="20px"></sdds-icon> 
       </div>
           <span class="sdds-sidebar-nav__item-text">Page link</span>
         </a>
@@ -152,7 +152,7 @@ const Template = ({ showIcons, collapsed }) => {
       <li class="sdds-sidebar-nav__item">
         <a class="sdds-sidebar-nav__item-link" href="#">
         <div>
-        <sdds-icon class="sdds-sidebar-nav__icon" name="truck" size="20px"/>
+        <sdds-icon class="sdds-sidebar-nav__icon" name="truck" size="20px"></sdds-icon> 
       </div>
           <span class="sdds-sidebar-nav__item-text">Page link</span>
         </a>

--- a/tegel/src/components/stepper/stepper.stories.ts
+++ b/tegel/src/components/stepper/stepper.stories.ts
@@ -117,7 +117,7 @@ const Template = ({ size, style, showLabel, iconType }) => {
           iconType === 'Native'
             ? `<i class="sdds-icon warning"></i>
         `
-            : `<sdds-icon name="warning" size="${size === 'Small' ? '16px' : '18px'}" />`
+            : `<sdds-icon name="warning" size="${size === 'Small' ? '16px' : '18px'}"></sdds-icon> `
         }
         </div>
         ${showLabel ? '<label class="sdds-stepper__step_label">Step warning</label>' : ''}
@@ -137,7 +137,7 @@ const Template = ({ size, style, showLabel, iconType }) => {
             ? `<i class="sdds-icon tick"></i>
         `
             : `<div>
-        <sdds-icon name="tick" size="${size === 'Small' ? '16px' : '20px'}" />
+        <sdds-icon name="tick" size="${size === 'Small' ? '16px' : '20px'}"></sdds-icon> 
         </div>`
         }
         </div>

--- a/tegel/src/components/textfield/textfield.stories.ts
+++ b/tegel/src/components/textfield/textfield.stories.ts
@@ -224,7 +224,7 @@ const Template = ({
           prefix
             ? `
         <span slot="sdds-prefix">
-          ${prefixType === 'Text' ? '$' : '<sdds-icon name="truck" size="20px"/>'}
+          ${prefixType === 'Text' ? '$' : '<sdds-icon name="truck" size="20px"></sdds-icon> '}
         </span>`
             : ''
         }
@@ -233,7 +233,7 @@ const Template = ({
           suffix
             ? `
         <span slot="sdds-suffix">
-          ${suffixType === 'Text' ? '$' : '<sdds-icon name="truck" size="20px"/>'}
+          ${suffixType === 'Text' ? '$' : '<sdds-icon name="truck" size="20px"></sdds-icon> '}
         </span>`
             : ''
         }


### PR DESCRIPTION
**Describe pull-request**  
Removed all instances of solfclosures on our custom elements. See: https://stackoverflow.com/questions/23961178/do-custom-elements-require-a-close-tag

**Solving issue**  
Fixes: [AB#2750](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2750)

**How to test**  
1. Go to storybook link below
2. Check in Foundations -> Icon
3. Check that the component still renders as intended

**Screenshots**  
-

**Additional context**  
-
