### PR TITLE
fix(accordion): added bottom border to last child

### DIFF
--- a/tegel/src/components/accordion/accordion.scss
+++ b/tegel/src/components/accordion/accordion.scss
@@ -55,3 +55,7 @@
     @include disabledStyle;
   }
 }
+
+:host(:last-child) {
+  border-bottom: 1px solid var(--sdds-accordion-border);
+}


### PR DESCRIPTION
**Describe pull-request**  
In a former PR this seems to have been lost. Adding a bottom border to the last child of the accordion.

**Solving issue**  
Fixes: -

**How to test**  
1. Go to storybook link below
2. Check in Components -> Accordion
3. Check that the accordion has a bottom border of 1px.

**Screenshots**  
-

**Additional context**  
-
