### PR TITLE
fix(button): corrected the margin left for button icon

### DIFF
--- a/tegel/src/components/button/button.scss
+++ b/tegel/src/components/button/button.scss
@@ -210,7 +210,7 @@ $iconProps: (fill, color);
 
     span.sdds-btn-text + .sdds-btn-icon {
       margin: unset;
-      margin-left: 42px;
+      margin-left: 28px;
     }
 
     &.sdds-btn-fullbleed {


### PR DESCRIPTION
**Describe pull-request**  
Corrected the margin left for button icon.

**Solving issue**  
Fixes: [AB#2838](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2838)

**How to test**  
1. Go to Components -> Button -> Native With Icon
2. Check the margin of the icon and make sure its 28px for lg. 

**Screenshots**  
-

**Additional context**  
-
