### PR TITLE
fix(date-time): align props date time and introduce default-value

### DIFF
--- a/tegel/src/components/datetime/datetime.scss
+++ b/tegel/src/components/datetime/datetime.scss
@@ -279,10 +279,15 @@ slot[name='sdds-label']::slotted(*) {
 .sdds-datetime-helper {
   font: var(--sdds-detail-05);
   letter-spacing: var(--sdds-detail-05-ls);
-  display: block;
+  display: flex;
   flex-basis: 100%;
   padding-top: var(--sdds-spacing-element-4);
   color: var(--sdds-datetime-helper);
+
+  .sdds-helper {
+    display: inline-flex;
+    gap: 8px;
+  }
 }
 
 //Disabled state

--- a/tegel/src/components/datetime/datetime.scss
+++ b/tegel/src/components/datetime/datetime.scss
@@ -279,7 +279,7 @@ slot[name='sdds-label']::slotted(*) {
 .sdds-datetime-helper {
   font: var(--sdds-detail-05);
   letter-spacing: var(--sdds-detail-05-ls);
-  display: flex;
+  display: block;
   flex-basis: 100%;
   padding-top: var(--sdds-spacing-element-4);
   color: var(--sdds-datetime-helper);

--- a/tegel/src/components/datetime/datetime.stories.ts
+++ b/tegel/src/components/datetime/datetime.stories.ts
@@ -34,7 +34,7 @@ export default {
       control: {
         type: 'radio',
       },
-      options: ['None', 'Custom', 'Now'],
+      options: ['None', 'Custom'],
     },
     size: {
       name: 'Size',
@@ -152,8 +152,6 @@ const datetimeTemplate = ({
         default:
           return 'Invalid type';
       }
-    } else if (value === 'Now') {
-      return 'now';
     }
   };
 

--- a/tegel/src/components/datetime/datetime.stories.ts
+++ b/tegel/src/components/datetime/datetime.stories.ts
@@ -30,7 +30,8 @@ export default {
     },
     defaultValue: {
       name: 'Default value',
-      description: 'Default value of the component.',
+      description:
+        'Default value of the component. Format for time: HH-MM. Format for date: YY-MM-DD. Format for date-time: YY-MM-DDTHH-MM ',
       control: {
         type: 'radio',
       },

--- a/tegel/src/components/datetime/datetime.stories.ts
+++ b/tegel/src/components/datetime/datetime.stories.ts
@@ -28,6 +28,14 @@ export default {
       },
       options: ['Datetime', 'Date', 'Time'],
     },
+    defaultValue: {
+      name: 'Default value',
+      description: 'Default value of the component.',
+      control: {
+        type: 'radio',
+      },
+      options: ['None', 'Custom', 'Now'],
+    },
     size: {
       name: 'Size',
       description: 'Switch between different sizes',
@@ -52,19 +60,34 @@ export default {
       },
     },
     label: {
+      name: 'Label',
+      description: 'Add/remove a label text for the component',
+      control: {
+        type: 'boolean',
+      },
+    },
+    labelText: {
       description: 'Label text for specific textfield',
       name: 'Label text',
       control: {
         type: 'text',
       },
+      if: { arg: 'label', eq: true },
     },
-
     helper: {
+      name: 'Helper',
+      description: 'Add/remove a helper text for the component',
+      control: {
+        type: 'boolean',
+      },
+    },
+    helperText: {
       name: 'Helper text',
       description: 'Add helper text for the textfield',
       control: {
         type: 'text',
       },
+      if: { arg: 'helper', eq: true },
     },
     state: {
       name: 'State',
@@ -78,15 +101,29 @@ export default {
   args: {
     type: 'Datetime',
     size: 'Large',
+    defaultValue: 'None',
     minWidth: 'Default',
     disabled: false,
     state: 'None',
-    label: 'Label text',
-    helper: 'Helper text',
+    label: true,
+    labelText: 'Label text',
+    helper: true,
+    helperText: 'Helper text',
   },
 };
 
-const datetimeTemplate = ({ type, size, minWidth, disabled, label, state, helper }) => {
+const datetimeTemplate = ({
+  type,
+  size,
+  minWidth,
+  disabled,
+  label,
+  labelText,
+  state,
+  helper,
+  helperText,
+  defaultValue,
+}) => {
   const typeLookup = {
     Datetime: 'datetime-local',
     Date: 'date',
@@ -103,6 +140,23 @@ const datetimeTemplate = ({ type, size, minWidth, disabled, label, state, helper
     Error: 'error',
   };
 
+  const getDefaultValue = (value: string, componentType: string) => {
+    if (value === 'Custom') {
+      switch (componentType) {
+        case 'Datetime':
+          return '1891-01-01T12:30';
+        case 'Date':
+          return '1891-01-01';
+        case 'Time':
+          return '12:30';
+        default:
+          return 'Invalid type';
+      }
+    } else if (value === 'Now') {
+      return 'now';
+    }
+  };
+
   return formatHtmlPreview(
     `
 
@@ -116,23 +170,29 @@ const datetimeTemplate = ({ type, size, minWidth, disabled, label, state, helper
   <div class="demo-wrapper">
 
     <sdds-datetime
-    id="datetime"
+      id="datetime"
+      ${defaultValue !== 'None' ? `default-value="${getDefaultValue(defaultValue, type)}"` : ''}
       type="${typeLookup[type]}"
       size="${sizeLookup[size]}"
       state="${stateLookup[state]}"
       ${disabled ? 'disabled' : ''}
-      ${minWidth ? 'no-min-width' : ''}>
-      ${label ? `<label slot='sdds-label'>${label}</label>` : ''}
-      ${helper ? `<span slot='sdds-helper'>${helper}</span>` : ''}
+      ${minWidth ? 'no-min-width' : ''}
+      ${label ? `label="${labelText}" ` : ''}
+      ${helper ? `helper="${helperText}" ` : ''}
+      >
     </sdds-datetime>
 
 
     <script>
+
+
     /* You can listen for the 'customChange' event to get value updates. */
       const datetimeEl = document.getElementById('datetime');
       datetimeEl.addEventListener('customChange', (event) => {
         console.log(event.target.value);
       });
+
+
     </script>
   </div>`,
   );
@@ -146,8 +206,6 @@ export const ErrorState = datetimeTemplate.bind({});
 
 ErrorState.args = {
   state: 'Error',
-  helper: 'Helper text',
-  label: 'Label text',
 };
 
 export const Time = datetimeTemplate.bind({});

--- a/tegel/src/components/datetime/datetime.tsx
+++ b/tegel/src/components/datetime/datetime.tsx
@@ -15,10 +15,8 @@ export class Datetime {
   /** Value of the input text */
   @Prop({ reflect: true }) value = '';
 
-  /** Default value of the component. Needs to match the format of the type.
-    Use 'now' to get the current date/time.
-   */
-  @Prop() defaultValue: string | 'now' | 'none' = 'none';
+  /** Default value of the component. Needs to match the format of the type. */
+  @Prop() defaultValue: string | 'none' = 'none';
 
   /** Set input in disabled state */
   @Prop() disabled: boolean = false;
@@ -57,31 +55,13 @@ export class Datetime {
   customChange: EventEmitter;
 
   getDefaultValue = () => {
-    let dateTimeObj: {
-      year: string | number;
-      month: string | number;
-      day: string | number;
-      hours: string | number;
-      minutes: string | number;
+    const dateTimeObj = {
+      year: this.defaultValue.slice(0, 4),
+      month: this.defaultValue.slice(5, 7),
+      day: this.defaultValue.slice(8, 10),
+      hours: this.defaultValue.slice(11, 13),
+      minutes: this.defaultValue.slice(14, 16),
     };
-    if (this.defaultValue === 'now') {
-      const date = new Date();
-      dateTimeObj = {
-        year: date.getFullYear(),
-        month: date.getMonth() + 1,
-        day: date.getDate(),
-        hours: date.getHours(),
-        minutes: date.getMinutes(),
-      };
-    } else {
-      dateTimeObj = {
-        year: this.defaultValue.slice(0, 4),
-        month: this.defaultValue.slice(5, 7),
-        day: this.defaultValue.slice(8, 10),
-        hours: this.defaultValue.slice(11, 13),
-        minutes: this.defaultValue.slice(14, 16),
-      };
-    }
     switch (this.type) {
       case 'datetime-local':
         return `${dateTimeObj.year}-${dateTimeObj.month}-${dateTimeObj.day}T${dateTimeObj.hours}:${dateTimeObj.minutes}`;

--- a/tegel/src/components/datetime/datetime.tsx
+++ b/tegel/src/components/datetime/datetime.tsx
@@ -78,11 +78,18 @@ export class Datetime {
   };
 
   getDefaultValue = () => {
+    const [year, month, day, hours, minutes] = [
+      this.defaultValue.slice(0, 4),
+      this.defaultValue.slice(5, 7),
+      this.defaultValue.slice(8, 10),
+      this.defaultValue.slice(11, 13),
+      this.defaultValue.slice(14, 16),
+    ];
     switch (this.type) {
       case 'datetime-local':
-        return new Date(this.defaultValue).toJSON().slice(0, 16);
+        return `${year}-${month}-${day}T${hours}:${minutes}`;
       case 'date':
-        return new Date(this.defaultValue).toJSON().slice(0, 10);
+        return `${year}-${month}-${day}`;
       case 'time':
         return this.defaultValue;
       default:

--- a/tegel/src/components/datetime/datetime.tsx
+++ b/tegel/src/components/datetime/datetime.tsx
@@ -203,7 +203,7 @@ export class Datetime {
         </div>
 
         <div class="sdds-datetime-helper">
-          {this.label && (
+          {this.helper && (
             <div class="sdds-helper">
               {this.state === 'error' && <sdds-icon name="error" size="16px"></sdds-icon>}
               {this.helper}

--- a/tegel/src/components/datetime/datetime.tsx
+++ b/tegel/src/components/datetime/datetime.tsx
@@ -15,6 +15,8 @@ export class Datetime {
   /** Value of the input text */
   @Prop({ reflect: true }) value = '';
 
+  @Prop() format: '' | 'none';
+
   /** Default value of the component. Needs to match the format of the type. */
   @Prop() defaultValue: string | 'none' = 'none';
 
@@ -68,7 +70,7 @@ export class Datetime {
       case 'date':
         return `${dateTimeObj.year}-${dateTimeObj.month}-${dateTimeObj.day}`;
       case 'time':
-        return `${dateTimeObj.hours}:${dateTimeObj.minutes}`;
+        return `${this.defaultValue.slice(0, 2)}:${this.defaultValue.slice(3, 5)}`;
       default:
         throw new Error('Invalid type.');
     }
@@ -76,6 +78,8 @@ export class Datetime {
 
   componentWillLoad() {
     if (this.defaultValue !== 'none') {
+      console.log(this.getDefaultValue());
+      console.log(this.defaultValue);
       this.value = this.getDefaultValue();
     }
   }

--- a/tegel/src/components/datetime/datetime.tsx
+++ b/tegel/src/components/datetime/datetime.tsx
@@ -46,7 +46,7 @@ export class Datetime {
   @Prop() helper: string = '';
 
   /** Listen to the focus state of the input */
-  @State() focusInput;
+  @State() focusInput: boolean;
 
   /** Change event for the datetime */
   @Event({
@@ -56,42 +56,39 @@ export class Datetime {
   })
   customChange: EventEmitter;
 
-  getCurrentValue = () => {
-    const date = new Date();
-    const [year, month, day, hours, minutes] = [
-      date.getFullYear(),
-      date.getMonth() + 1,
-      date.getDate(),
-      date.getHours(),
-      date.getMinutes(),
-    ];
-    switch (this.type) {
-      case 'datetime-local':
-        return `${year}-${month}-${day}T${hours}:${minutes}`;
-      case 'date':
-        return `${year}-${month}-${day}`;
-      case 'time':
-        return `${hours}:${minutes}`;
-      default:
-        throw new Error('Invalid type.');
-    }
-  };
-
   getDefaultValue = () => {
-    const [year, month, day, hours, minutes] = [
-      this.defaultValue.slice(0, 4),
-      this.defaultValue.slice(5, 7),
-      this.defaultValue.slice(8, 10),
-      this.defaultValue.slice(11, 13),
-      this.defaultValue.slice(14, 16),
-    ];
+    let dateTimeObj: {
+      year: string | number;
+      month: string | number;
+      day: string | number;
+      hours: string | number;
+      minutes: string | number;
+    };
+    if (this.defaultValue === 'now') {
+      const date = new Date();
+      dateTimeObj = {
+        year: date.getFullYear(),
+        month: date.getMonth() + 1,
+        day: date.getDate(),
+        hours: date.getHours(),
+        minutes: date.getMinutes(),
+      };
+    } else {
+      dateTimeObj = {
+        year: this.defaultValue.slice(0, 4),
+        month: this.defaultValue.slice(5, 7),
+        day: this.defaultValue.slice(8, 10),
+        hours: this.defaultValue.slice(11, 13),
+        minutes: this.defaultValue.slice(14, 16),
+      };
+    }
     switch (this.type) {
       case 'datetime-local':
-        return `${year}-${month}-${day}T${hours}:${minutes}`;
+        return `${dateTimeObj.year}-${dateTimeObj.month}-${dateTimeObj.day}T${dateTimeObj.hours}:${dateTimeObj.minutes}`;
       case 'date':
-        return `${year}-${month}-${day}`;
+        return `${dateTimeObj.year}-${dateTimeObj.month}-${dateTimeObj.day}`;
       case 'time':
-        return this.defaultValue;
+        return `${dateTimeObj.hours}:${dateTimeObj.minutes}`;
       default:
         throw new Error('Invalid type.');
     }
@@ -99,15 +96,7 @@ export class Datetime {
 
   componentWillLoad() {
     if (this.defaultValue !== 'none') {
-      if (this.defaultValue === 'now') {
-        this.value = this.getCurrentValue();
-      } else {
-        try {
-          this.value = this.getDefaultValue();
-        } catch (error) {
-          throw new Error(error);
-        }
-      }
+      this.value = this.getDefaultValue();
     }
   }
 
@@ -129,7 +118,7 @@ export class Datetime {
   }
 
   // Change event isn't a composed:true by default in for input
-  handleChange(e): void {
+  handleChange(e: Event): void {
     this.customChange.emit(e);
   }
 

--- a/tegel/src/components/datetime/datetime.tsx
+++ b/tegel/src/components/datetime/datetime.tsx
@@ -71,7 +71,7 @@ export class Datetime {
       case 'date':
         return `${year}-${month}-${day}`;
       case 'time':
-        return new Date().toTimeString().slice(0, 5);
+        return `${hours}:${minutes}`;
       default:
         throw new Error('Invalid type.');
     }
@@ -84,15 +84,7 @@ export class Datetime {
       case 'date':
         return new Date(this.defaultValue).toJSON().slice(0, 10);
       case 'time':
-        return new Date(
-          2000,
-          1,
-          1,
-          parseInt(this.defaultValue.slice(0, 2)),
-          parseInt(this.defaultValue.slice(3, 5)),
-        )
-          .toTimeString()
-          .slice(0, 5);
+        return this.defaultValue;
       default:
         throw new Error('Invalid type.');
     }
@@ -102,7 +94,6 @@ export class Datetime {
     if (this.defaultValue !== 'none') {
       if (this.defaultValue === 'now') {
         this.value = this.getCurrentValue();
-        console.log(this.value);
       } else {
         try {
           this.value = this.getDefaultValue();

--- a/tegel/src/components/datetime/datetime.tsx
+++ b/tegel/src/components/datetime/datetime.tsx
@@ -133,7 +133,6 @@ export class Datetime {
   // Change event isn't a composed:true by default in for input
   handleChange(e): void {
     this.customChange.emit(e);
-    console.log(this.value);
   }
 
   /** Set the input as focus when clicking the whole datetime with suffix/prefix */

--- a/tegel/src/components/datetime/datetime.tsx
+++ b/tegel/src/components/datetime/datetime.tsx
@@ -15,9 +15,7 @@ export class Datetime {
   /** Value of the input text */
   @Prop({ reflect: true }) value = '';
 
-  @Prop() format: '' | 'none';
-
-  /** Default value of the component. Needs to match the format of the type. */
+  /** Default value of the component. Format for time: HH-MM. Format for date: YY-MM-DD. Format for date-time: YY-MM-DDTHH-MM */
   @Prop() defaultValue: string | 'none' = 'none';
 
   /** Set input in disabled state */
@@ -32,7 +30,6 @@ export class Datetime {
   /** Name property */
   @Prop() name = '';
 
-  // TODO: This one needs better naming
   /** Error state of input */
   @Prop() state: string;
 
@@ -78,8 +75,6 @@ export class Datetime {
 
   componentWillLoad() {
     if (this.defaultValue !== 'none') {
-      console.log(this.getDefaultValue());
-      console.log(this.defaultValue);
       this.value = this.getDefaultValue();
     }
   }

--- a/tegel/src/components/datetime/readme.md
+++ b/tegel/src/components/datetime/readme.md
@@ -5,19 +5,20 @@
 
 ## Properties
 
-| Property       | Attribute       | Description                                                                                                    | Type                                   | Default            |
-| -------------- | --------------- | -------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ------------------ |
-| `autofocus`    | `autofocus`     | Autofocus for input                                                                                            | `boolean`                              | `false`            |
-| `defaultValue` | `default-value` | Default value of the component. Needs to match the format of the type. Use 'now' to get the current date/time. | `string`                               | `'none'`           |
-| `disabled`     | `disabled`      | Set input in disabled state                                                                                    | `boolean`                              | `false`            |
-| `helper`       | `helper`        | Helper text for the component                                                                                  | `string`                               | `''`               |
-| `label`        | `label`         | Label text for the component                                                                                   | `string`                               | `''`               |
-| `name`         | `name`          | Name property                                                                                                  | `string`                               | `''`               |
-| `noMinWidth`   | `no-min-width`  | With setting                                                                                                   | `boolean`                              | `false`            |
-| `size`         | `size`          | Size of the input                                                                                              | `"" \| "md" \| "sm"`                   | `''`               |
-| `state`        | `state`         | Error state of input                                                                                           | `string`                               | `undefined`        |
-| `type`         | `type`          | Which input type, text, password or similar                                                                    | `"date" \| "datetime-local" \| "time"` | `'datetime-local'` |
-| `value`        | `value`         | Value of the input text                                                                                        | `string`                               | `''`               |
+| Property       | Attribute       | Description                                                            | Type                                   | Default            |
+| -------------- | --------------- | ---------------------------------------------------------------------- | -------------------------------------- | ------------------ |
+| `autofocus`    | `autofocus`     | Autofocus for input                                                    | `boolean`                              | `false`            |
+| `defaultValue` | `default-value` | Default value of the component. Needs to match the format of the type. | `string`                               | `'none'`           |
+| `disabled`     | `disabled`      | Set input in disabled state                                            | `boolean`                              | `false`            |
+| `format`       | `format`        |                                                                        | `"" \| "none"`                         | `undefined`        |
+| `helper`       | `helper`        | Helper text for the component                                          | `string`                               | `''`               |
+| `label`        | `label`         | Label text for the component                                           | `string`                               | `''`               |
+| `name`         | `name`          | Name property                                                          | `string`                               | `''`               |
+| `noMinWidth`   | `no-min-width`  | With setting                                                           | `boolean`                              | `false`            |
+| `size`         | `size`          | Size of the input                                                      | `"" \| "md" \| "sm"`                   | `''`               |
+| `state`        | `state`         | Error state of input                                                   | `string`                               | `undefined`        |
+| `type`         | `type`          | Which input type, text, password or similar                            | `"date" \| "datetime-local" \| "time"` | `'datetime-local'` |
+| `value`        | `value`         | Value of the input text                                                | `string`                               | `''`               |
 
 
 ## Events

--- a/tegel/src/components/datetime/readme.md
+++ b/tegel/src/components/datetime/readme.md
@@ -5,20 +5,19 @@
 
 ## Properties
 
-| Property       | Attribute       | Description                                                            | Type                                   | Default            |
-| -------------- | --------------- | ---------------------------------------------------------------------- | -------------------------------------- | ------------------ |
-| `autofocus`    | `autofocus`     | Autofocus for input                                                    | `boolean`                              | `false`            |
-| `defaultValue` | `default-value` | Default value of the component. Needs to match the format of the type. | `string`                               | `'none'`           |
-| `disabled`     | `disabled`      | Set input in disabled state                                            | `boolean`                              | `false`            |
-| `format`       | `format`        |                                                                        | `"" \| "none"`                         | `undefined`        |
-| `helper`       | `helper`        | Helper text for the component                                          | `string`                               | `''`               |
-| `label`        | `label`         | Label text for the component                                           | `string`                               | `''`               |
-| `name`         | `name`          | Name property                                                          | `string`                               | `''`               |
-| `noMinWidth`   | `no-min-width`  | With setting                                                           | `boolean`                              | `false`            |
-| `size`         | `size`          | Size of the input                                                      | `"" \| "md" \| "sm"`                   | `''`               |
-| `state`        | `state`         | Error state of input                                                   | `string`                               | `undefined`        |
-| `type`         | `type`          | Which input type, text, password or similar                            | `"date" \| "datetime-local" \| "time"` | `'datetime-local'` |
-| `value`        | `value`         | Value of the input text                                                | `string`                               | `''`               |
+| Property       | Attribute       | Description                                                                                                             | Type                                   | Default            |
+| -------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ------------------ |
+| `autofocus`    | `autofocus`     | Autofocus for input                                                                                                     | `boolean`                              | `false`            |
+| `defaultValue` | `default-value` | Default value of the component. Format for time: HH-MM. Format for date: YY-MM-DD. Format for date-time: YY-MM-DDTHH-MM | `string`                               | `'none'`           |
+| `disabled`     | `disabled`      | Set input in disabled state                                                                                             | `boolean`                              | `false`            |
+| `helper`       | `helper`        | Helper text for the component                                                                                           | `string`                               | `''`               |
+| `label`        | `label`         | Label text for the component                                                                                            | `string`                               | `''`               |
+| `name`         | `name`          | Name property                                                                                                           | `string`                               | `''`               |
+| `noMinWidth`   | `no-min-width`  | With setting                                                                                                            | `boolean`                              | `false`            |
+| `size`         | `size`          | Size of the input                                                                                                       | `"" \| "md" \| "sm"`                   | `''`               |
+| `state`        | `state`         | Error state of input                                                                                                    | `string`                               | `undefined`        |
+| `type`         | `type`          | Which input type, text, password or similar                                                                             | `"date" \| "datetime-local" \| "time"` | `'datetime-local'` |
+| `value`        | `value`         | Value of the input text                                                                                                 | `string`                               | `''`               |
 
 
 ## Events

--- a/tegel/src/components/datetime/readme.md
+++ b/tegel/src/components/datetime/readme.md
@@ -5,16 +5,19 @@
 
 ## Properties
 
-| Property     | Attribute      | Description                                 | Type                 | Default     |
-| ------------ | -------------- | ------------------------------------------- | -------------------- | ----------- |
-| `autofocus`  | `autofocus`    | Autofocus for input                         | `boolean`            | `false`     |
-| `disabled`   | `disabled`     | Set input in disabled state                 | `boolean`            | `false`     |
-| `name`       | `name`         | Name property                               | `string`             | `''`        |
-| `noMinWidth` | `no-min-width` | With setting                                | `boolean`            | `false`     |
-| `size`       | `size`         | Size of the input                           | `"" \| "md" \| "sm"` | `''`        |
-| `state`      | `state`        | Error state of input                        | `string`             | `undefined` |
-| `type`       | `type`         | Which input type, text, password or similar | `string`             | `'text'`    |
-| `value`      | `value`        | Value of the input text                     | `string`             | `''`        |
+| Property       | Attribute       | Description                                                                                                    | Type                                   | Default            |
+| -------------- | --------------- | -------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ------------------ |
+| `autofocus`    | `autofocus`     | Autofocus for input                                                                                            | `boolean`                              | `false`            |
+| `defaultValue` | `default-value` | Default value of the component. Needs to match the format of the type. Use 'now' to get the current date/time. | `string`                               | `'none'`           |
+| `disabled`     | `disabled`      | Set input in disabled state                                                                                    | `boolean`                              | `false`            |
+| `helper`       | `helper`        | Helper text for the component                                                                                  | `string`                               | `''`               |
+| `label`        | `label`         | Label text for the component                                                                                   | `string`                               | `''`               |
+| `name`         | `name`          | Name property                                                                                                  | `string`                               | `''`               |
+| `noMinWidth`   | `no-min-width`  | With setting                                                                                                   | `boolean`                              | `false`            |
+| `size`         | `size`          | Size of the input                                                                                              | `"" \| "md" \| "sm"`                   | `''`               |
+| `state`        | `state`         | Error state of input                                                                                           | `string`                               | `undefined`        |
+| `type`         | `type`          | Which input type, text, password or similar                                                                    | `"date" \| "datetime-local" \| "time"` | `'datetime-local'` |
+| `value`        | `value`         | Value of the input text                                                                                        | `string`                               | `''`               |
 
 
 ## Events
@@ -23,6 +26,19 @@
 | -------------- | ----------------------------- | ------------------ |
 | `customChange` | Change event for the datetime | `CustomEvent<any>` |
 
+
+## Dependencies
+
+### Depends on
+
+- [sdds-icon](../icon)
+
+### Graph
+```mermaid
+graph TD;
+  sdds-datetime --> sdds-icon
+  style sdds-datetime fill:#f9f,stroke:#333,stroke-width:4px
+```
 
 ----------------------------------------------
 

--- a/tegel/src/components/icon/readme.md
+++ b/tegel/src/components/icon/readme.md
@@ -16,11 +16,13 @@
 ### Used by
 
  - [sdds-accordion-item](../accordion/accordion-item)
+ - [sdds-datetime](../datetime)
 
 ### Graph
 ```mermaid
 graph TD;
   sdds-accordion-item --> sdds-icon
+  sdds-datetime --> sdds-icon
   style sdds-icon fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/tegel/src/stories/Migration/Migration.stories.mdx
+++ b/tegel/src/stories/Migration/Migration.stories.mdx
@@ -199,6 +199,38 @@ If the child of the native `sdds-btn` is a text it will need a class of `sdds-bt
 </button>
 ```
 
+## Datepicker
+
+[Web Component](/docs/components-datetime--default)
+
+#### Aligned props for ´label´ and 'helper'
+Previously `<sdds-datetime>` component components has used slots for label and helper. This has now been
+aligned with other components and this component now accepts two props `label` and `helper` to display
+these texts. 
+
+##### What action is required?
+Change all `<sdds-datetime>` that are using slots to use the prop instead.
+
+
+```jsx
+// Old ❌
+<sdds-datetime id="datetime" type="datetime-local" size="lg" state="none" no-min-width>
+  <label slot="sdds-label">Label text</label>
+  <span slot="sdds-helper">Helper text</span>
+</sdds-datetime>
+
+// New ✅
+<sdds-datetime
+  id="datetime"
+  type="datetime-local"
+  size="lg"
+  state="none"
+  no-min-width
+  label="Label text"
+  helper="Helper text"
+></sdds-datetime>
+```
+
 #### Added class 'sdds-btn-only-icon'
 
 We added a class for only icon buttons on native button in order to style it correctly.

--- a/tegel/src/stories/Migration/Migration.stories.mdx
+++ b/tegel/src/stories/Migration/Migration.stories.mdx
@@ -199,7 +199,7 @@ If the child of the native `sdds-btn` is a text it will need a class of `sdds-bt
 </button>
 ```
 
-## Datepicker
+## Datetime
 
 [Web Component](/docs/components-datetime--default)
 
@@ -210,7 +210,6 @@ these texts.
 
 ##### What action is required?
 Change all `<sdds-datetime>` that are using slots to use the prop instead.
-
 
 ```jsx
 // Old ❌


### PR DESCRIPTION
**Describe pull-request**  
Removed the slots for label/helper and created props for them instead, also introduces the prop
default-value to allow the user to select a default time to be displayed.

**Solving issue**  
Fixes: [AB#2837](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2837)

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Date-time
3. Check that the controls regarding label/helper works as inteded.
4. Try out the new custom/now value for default-value.

**Screenshots**  
-

**Additional context**  
-
