### PR TITLE
feat: rewrite native table css to classes are not needed

### DIFF
--- a/tegel/src/components/data-table/native-table.scss
+++ b/tegel/src/components/data-table/native-table.scss
@@ -7,7 +7,7 @@
   border-collapse: collapse;
   display: table;
 
-  .sdds-table__title {
+  & > caption {
     font: var(--sdds-headline-07);
     letter-spacing: var(--sdds-headline-07-ls);
     text-align: left;
@@ -23,12 +23,10 @@
     border-top-right-radius: 4px;
   }
 
-  .sdds-table__header {
+  & > thead {
     display: table-header-group;
-  }
 
-  .sdds-table__header {
-    .sdds-table__header-cell {
+    & > tr > th {
       &:first-of-type {
         border-top-left-radius: 4px;
       }
@@ -39,8 +37,8 @@
     }
   }
 
-  .sdds-table__title + .sdds-table__header {
-    .sdds-table__header-cell {
+  & > caption + thead {
+    & > tr > th {
       &:first-of-type {
         border-top-left-radius: 0;
       }
@@ -51,8 +49,8 @@
     }
   }
 
-  .sdds-table__header {
-    .sdds-table__header-cell {
+  & > thead {
+    & > tr > th {
       font: var(--sdds-headline-07);
       letter-spacing: var(--sdds-headline-07-ls);
       display: table-cell;
@@ -77,107 +75,79 @@
     }
   }
 
-  .sdds-table__body {
+  & > tbody {
     display: table-row-group;
+
+    & > tr > td {
+      font: var(--sdds-detail-02);
+      letter-spacing: var(--sdds-detail-02-ls);
+      display: table-cell;
+      box-sizing: border-box;
+      color: var(--sdds-grey-958);
+      padding: var(--sdds-spacing-element-16);
+      min-width: 192px;
+      vertical-align: top;
+      background-color: transparent;
+      transition: background-color 200ms ease;
+    }
   }
 
-  .sdds-table__row {
-    display: table-row;
-    border-bottom: 1px solid var(--sdds-grey-400);
-    background-color: var(--sdds-white);
-    transition: background-color 200ms ease;
+  & > thead,
+  & > tbody {
+    & > tr {
+      display: table-row;
+      border-bottom: 1px solid var(--sdds-grey-400);
+      background-color: var(--sdds-white);
+      transition: background-color 200ms ease;
+    }
+
+    & > tr:hover {
+      background-color: var(--sdds-grey-100);
+    }
   }
 
-  .sdds-table__row:hover {
-    background-color: var(--sdds-grey-100);
-  }
-
-  .sdds-table__row--selected {
-    background-color: var(--sdds-grey-300);
-  }
-
-  .sdds-table__row--selected:hover {
-    background-color: var(--sdds-grey-400);
-  }
-
-  .sdds-table__row--hidden {
-    display: none;
-  }
-
-  .sdds-table__body-cell {
-    font: var(--sdds-detail-02);
-    letter-spacing: var(--sdds-detail-02-ls);
-    display: table-cell;
-    box-sizing: border-box;
-    color: var(--sdds-grey-958);
-    padding: var(--sdds-spacing-element-16);
-    min-width: 192px;
-    vertical-align: top;
-    background-color: transparent;
-    transition: background-color 200ms ease;
-  }
-
-  .sdds-table__body-cell--hover {
-    background-color: var(--sdds-grey-200);
-  }
-
-  // SDDS GLOBAL STYLES:
   &.sdds-table--compact {
-    .sdds-table__title {
+    & > caption {
       // 24px to account for header component that overlaps
       height: 56px;
     }
 
-    .sdds-table__body-cell,
-    .sdds-table__header-cell {
+    & > thead > tr > th,
+    & > tbody > tr > td {
       padding: var(--sdds-spacing-element-8) var(--sdds-spacing-element-16);
     }
 
-    .sdds-table__body-cell--checkbox {
-      min-width: 32px;
-      width: 32px;
-      padding: 0;
-    }
-
-    .sdds-table__header-cell,
-    .sdds-form-label--data-table {
+    & > thead > tr > th {
       height: 32px;
     }
   }
 
   &.sdds-table--divider {
-    .sdds-table__header-cell,
-    .sdds-table__body-cell {
+    & > thead > tr > th,
+    & > tbody > tr > td {
       border-right: 1px solid var(--sdds-grey-400);
     }
 
-    .sdds-table__header-cell:last-child,
-    .sdds-table__body-cell:last-child {
+    & > thead > tr > th:last-child,
+    & > tbody > tr > td:last-child {
       border-right: none;
     }
   }
 
   &.sdds-table--no-min-width {
-    .sdds-table__header {
-      .sdds-table__header-cell {
-        min-width: unset;
-      }
-    }
-
-    .sdds-table__body {
-      .sdds-table__body-cell {
-        min-width: unset;
-      }
+    & > thead > tr > th,
+    & > tbody > tr > td {
+      min-width: unset;
     }
   }
 
   &.sdds-table--on-white-bg {
-    .sdds-table__row {
+    & > tbody > tr {
       background-color: var(--sdds-grey-50);
-    }
 
-    .sdds-table__row:hover {
-      background-color: var(--sdds-grey-200);
+      &:hover {
+        background-color: var(--sdds-grey-200);
+      }
     }
   }
 

--- a/tegel/src/components/data-table/native-table.stories.ts
+++ b/tegel/src/components/data-table/native-table.stories.ts
@@ -114,18 +114,6 @@ export default {
       },
       if: { arg: 'noMinWidthArg', eq: true },
     },
-    column4Width: {
-      name: 'Column 4 width',
-      description:
-        'Value of width for column 4. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit too next tot the value, eg. 200px.',
-      type: 'string',
-      table: {
-        defaultValue: {
-          summary: '192px',
-        },
-      },
-      if: { arg: 'noMinWidthArg', eq: true },
-    },
   },
   args: {
     tableTitle: 'Native table',
@@ -137,7 +125,6 @@ export default {
     column1Width: '',
     column2Width: '',
     column3Width: '',
-    column4Width: '',
   },
 };
 
@@ -151,47 +138,29 @@ const Template = (args) =>
         ${args.noMinWidthArg ? 'sdds-table--no-min-width' : ''}
         ${args.responsiveTable ? 'sdds-table--responsive' : ''}
     " >
-    ${args.tableTitle && `<caption class="sdds-table__title">${args.tableTitle}</caption>`}
-    <thead class="sdds-table__header">
-      <tr class="sdds-table__row">
-        <th class="sdds-table__header-cell" ${
-          args.column1Width ? `style="width: ${args.column1Width};"` : ''
-        }>Header</th>
-        <th class="sdds-table__header-cell" ${
-          args.column2Width ? `style="width: ${args.column2Width};"` : ''
-        }>Header</th>
-        <th class="sdds-table__header-cell" ${
-          args.column3Width ? `style="width: ${args.column3Width};"` : ''
-        }>Header</th>
-        <th class="sdds-table__header-cell" ${
-          args.column4Width ? `style="width: ${args.column4Width};"` : ''
-        }>Header</th>
+    ${args.tableTitle && `<caption>${args.tableTitle}</caption>`}
+    <thead>
+      <tr>
+        <th ${args.column1Width ? `style="width: ${args.column1Width};"` : ''}>Header</th>
+        <th ${args.column2Width ? `style="width: ${args.column2Width};"` : ''}>Header</th>
+        <th ${args.column3Width ? `style="width: ${args.column3Width};"` : ''}>Header</th>
       </tr>
     </thead>
-     <tbody class="sdds-table__body">
-      <tr class="sdds-table__row">
-        <td class="sdds-table__body-cell">Text</td>
-        <td class="sdds-table__body-cell">Text</td>
-        <td class="sdds-table__body-cell">Text</td>
-       <td class="sdds-table__body-cell">Text</td>
+     <tbody>
+      <tr>
+        <td>Text</td>
+        <td>Text</td>
+        <td>Text</td>
       </tr>
-      <tr class="sdds-table__row">
-        <td class="sdds-table__body-cell">Text</td>
-        <td class="sdds-table__body-cell">Text</td>
-        <td class="sdds-table__body-cell">Text</td>
-       <td class="sdds-table__body-cell">Text</td>
+      <tr>
+        <td>Text</td>
+        <td>Text</td>
+        <td>Text</td>
       </tr>
-      <tr class="sdds-table__row">
-        <td class="sdds-table__body-cell">Text</td>
-        <td class="sdds-table__body-cell">Text</td>
-        <td class="sdds-table__body-cell">Text</td>
-       <td class="sdds-table__body-cell">Text</td>
-      </tr>
-      <tr class="sdds-table__row">
-        <td class="sdds-table__body-cell">Text</td>
-        <td class="sdds-table__body-cell">Text</td>
-        <td class="sdds-table__body-cell">Text</td>
-       <td class="sdds-table__body-cell">Text</td>
+      <tr>
+        <td>Text</td>
+        <td>Text</td>
+        <td>Text</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
**Describe pull-request**  
- Rewrites native table css to classes are not needed
- Removes classes from story
- Removes undocumented left over classes from web component transition
- Makes table a little smaller to minimise the code example

Note: This should not be a breaking change, as it still works with the classes (they just don't do anything), and the other removed classes were undocumented.

**Solving issue**  
Fixes: [AB#2852](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2852)

**How to test**  
Check native table in storybook in the link below.

**Screenshots**
![Screenshot 2022-12-16 at 11 31 51](https://user-images.githubusercontent.com/8556022/208079265-2178d9d9-a329-4e6f-b8ec-fd52b7036ac4.png)
