### PR TITLE
fix(modal): removed stopPropogation on modal click

### DIFF
--- a/components/src/components/modal/modal.tsx
+++ b/components/src/components/modal/modal.tsx
@@ -1,14 +1,4 @@
-import {
-  Component,
-  h,
-  Listen,
-  Host,
-  Prop,
-  State,
-  Element,
-  Watch,
-  Method,
-} from '@stencil/core';
+import { Component, h, Listen, Host, Prop, State, Element, Watch, Method } from '@stencil/core';
 
 @Component({
   tag: 'sdds-modal',
@@ -83,15 +73,12 @@ export class Modal {
     ) {
       this.show = false;
     }
-    e.stopPropagation();
   }
 
   render() {
     return (
       <Host class={`sdds-modal-backdrop ${this.show ? 'show' : 'hide'}`}>
-        <div
-          class={`sdds-modal ${this.size ? `sdds-modal-${this.size}` : ''} `}
-        >
+        <div class={`sdds-modal ${this.size ? `sdds-modal-${this.size}` : ''} `}>
           <div class="sdds-modal-header">
             <slot name="sdds-modal-headline"></slot>
             <button class="sdds-modal-btn"></button>


### PR DESCRIPTION
**Describe pull-request**  
Removed stopPropogation on modal to allow clicks within the modal.

**Solving issue**  
Fixes: -

**How to test**  
1. Check out branch and run npm start in components
2. Check in Components -> Modal -> Webcomponent
3. Check that the buttons work as intended within the modal.

**Screenshots**  
-

**Additional context**  
-
