### PR TITLE
fix(modal): fix the constant overflow on modal

### DIFF
--- a/components/src/components/modal/_modal-core.scss
+++ b/components/src/components/modal/_modal-core.scss
@@ -1,5 +1,5 @@
-@import "@scania/typography/dist/scss/mixins";
-@import "@scania/typography/dist/scss/tokens";
+@import '@scania/typography/dist/scss/mixins';
+@import '@scania/typography/dist/scss/tokens';
 
 :root,
 html {
@@ -103,7 +103,7 @@ $modals: (
 }
 
 @mixin modal-body {
-  @include type-style("body-01");
+  @include type-style('body-01');
 
   padding-bottom: 40px;
   margin: 0;
@@ -128,7 +128,7 @@ $modals: (
   margin: auto;
   position: relative;
   border-radius: 1rem;
-  padding: 16px;
+  padding: 16px 16px 0;
 }
 
 //Width of modals in different breakpoints
@@ -148,7 +148,7 @@ $modals: (
   .sdds-modal-sm {
     height: 100%;
 
-    slot[name="sdds-modal-actions"]::slotted(*) {
+    slot[name='sdds-modal-actions']::slotted(*) {
       display: flex;
     }
   }
@@ -162,7 +162,7 @@ $modals: (
   background-color: var(--sdds-modal-bg);
 
   &::before {
-    content: " ";
+    content: ' ';
     position: absolute;
     height: 16px;
     top: -16px;
@@ -176,17 +176,7 @@ $modals: (
     position: sticky;
     bottom: 0;
     background-color: var(--sdds-modal-bg);
-    padding-top: var(--sdds-spacing-element-16);
-
-    &::after {
-      content: " ";
-      position: absolute;
-      height: 17px;
-      bottom: -17px;
-      left: 0;
-      width: 100%;
-      background-color: var(--sdds-modal-bg);
-    }
+    padding: var(--sdds-spacing-element-16) 0;
   }
 }
 

--- a/components/src/components/modal/modal.tsx
+++ b/components/src/components/modal/modal.tsx
@@ -25,6 +25,11 @@ export class Modal {
     this.show = true;
   }
 
+  @Method()
+  async closeModal() {
+    this.show = false;
+  }
+
   componentDidLoad() {
     const targets = document.querySelectorAll(this.selector);
     this.dismissModal();


### PR DESCRIPTION


**Describe pull-request**  
Removes the "after" on the modal toolbar and added padding-bottom to prevent constant overflow.

**Solving issue**  
Fixes: -

**How to test**  
1. Checkout and run start for components package.
2. Check in Components -> Modal
3. Check that modal that should not have overflow (little body text) does not have a scrollbar.

**Screenshots**  
-

**Additional context**  
-
