### PR TITLE
docs: fix radio storybook example

### DIFF
--- a/tegel/src/components/radio-button/radio-button.stories.tsx
+++ b/tegel/src/components/radio-button/radio-button.stories.tsx
@@ -52,7 +52,7 @@ const Template = (args) =>
   <fieldset class="demo-fieldset-reset" ${args.disabled ? 'disabled' : ''}>
     <div class="sdds-radio-button-group">
       <div class="sdds-radio-item">
-        <input class="sdds-form-input" type="radio" name="rb-example" id="rb-option-1">
+        <input class="sdds-form-input" type="radio" name="rb-example" id="rb-option-1" checked>
         <label class="sdds-form-label" for="rb-option-1">
           ${args.label} 1
         </label>

--- a/tegel/src/components/radio-button/radio-button.stories.tsx
+++ b/tegel/src/components/radio-button/radio-button.stories.tsx
@@ -27,14 +27,7 @@ export default {
     },
     disabled: {
       name: 'Disabled',
-      description: 'Disables the radio button',
-      control: {
-        type: 'boolean',
-      },
-    },
-    checked: {
-      name: 'Checked',
-      description: 'Marks the radio button as checked',
+      description: 'Disables the radio buttons',
       control: {
         type: 'boolean',
       },
@@ -43,33 +36,37 @@ export default {
   args: {
     label: 'Label text',
     disabled: false,
-    checked: false,
   },
 };
 
 const Template = (args) =>
   formatHtmlPreview(`
-   <div class="sdds-radio-button-group">
-   <div class="sdds-radio-item">
-     <input class="sdds-form-input" type="radio" name="rb-example" id="rb-option-1" checked="" ${
-       args.disabled ? 'disabled' : ''
-     }>
-     <label class="sdds-form-label" for="rb-option-1">
-       ${args.label} 1
-     </label>
-   </div>
- </div>
- <div class="sdds-radio-button-group">
-   <div class="sdds-radio-item">
-     <input class="sdds-form-input" type="radio" name="rb-example" id="rb-option-1" ${
-       args.checked ? 'checked="checked"' : ''
-     } >
-     <label class="sdds-form-label" for="rb-option-1">
-       ${args.label} 2
-     </label>
-   </div>
-
-   </div>
+  <style>
+    .demo-fieldset-reset { 
+      border: 0;
+      margin: 0;
+      min-width: 0;
+      padding: 0; 
+    }
+  </style>
+  <fieldset class="demo-fieldset-reset" ${args.disabled ? 'disabled' : ''}>
+    <div class="sdds-radio-button-group">
+      <div class="sdds-radio-item">
+        <input class="sdds-form-input" type="radio" name="rb-example" id="rb-option-1">
+        <label class="sdds-form-label" for="rb-option-1">
+          ${args.label} 1
+        </label>
+      </div>
+    </div>
+    <div class="sdds-radio-button-group">
+      <div class="sdds-radio-item">
+        <input class="sdds-form-input" type="radio" name="rb-example" id="rb-option-2">
+        <label class="sdds-form-label" for="rb-option-2">
+          ${args.label} 2
+        </label>
+      </div>
+    </div>
+  </fieldset>
 `);
 
 export const Default = Template.bind({});


### PR DESCRIPTION
Fixes some things in the radio buttons storybook example. See the code changes!

Thought: we might want to include a css reset for the `fieldset` element

**Solving issue**  

Fixes: [AB#3010](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3010)