### PR TITLE
docs(button): hide text control in "only icon" stories

### DIFF
--- a/tegel/src/components/button/button-native.stories.tsx
+++ b/tegel/src/components/button/button-native.stories.tsx
@@ -28,6 +28,7 @@ export default {
       control: {
         type: 'text',
       },
+      if: { arg: 'onlyIcon', truthy: false },
     },
     btnType: {
       name: 'Type',
@@ -166,9 +167,9 @@ const NativeTemplate = ({
         ? `@import url('https://cdn.digitaldesign.scania.com/icons/webfont/css/sdds-icons.css');
     i.sdds-btn-icon{
       font-size: ${size === 'Small' ? '16' : '20'}px;
-    }\n `
+    }`
         : ''
-    }\ .demo-wrapper{
+    } .demo-wrapper{
       width: 100%;
     }
   </style>

--- a/tegel/src/components/button/button-webcomponent.stories.tsx
+++ b/tegel/src/components/button/button-webcomponent.stories.tsx
@@ -30,6 +30,7 @@ export default {
       control: {
         type: 'text',
       },
+      if: { arg: 'onlyIcon', truthy: false },
     },
     btnType: {
       name: 'Type',
@@ -164,7 +165,7 @@ const WebComponentTemplate = ({
       font-size: ${size === 'Large' || size === 'Medium' ? '20' : '16'}px;
     }`
         : ''
-    }
+    },
     .demo-wrapper{
       width: 100%;
     }
@@ -183,7 +184,7 @@ const WebComponentTemplate = ({
       iconType === 'Native'
         ? `<i class="sdds-btn-icon sdds-icon ${icon}" slot="icon"></i>`
         : `<sdds-icon slot="icon" class='sdds-btn-icon ' size='${
-            sizeLookUp[size] == 'sm' ? '16px' : '20px'
+            sizeLookUp[size] === 'sm' ? '16px' : '20px'
           }' name='${icon}'></sdds-icon>`
     }
   `


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Removing control for text in "only icon" button stories

**Solving issue**  
Fixes: [AB#2956](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2956)

**How to test**  
1. Go to PR preview link
2. Check Button stories with "Only Icon"
3. Text control should be hidden for these two
