### PR TITLE
fix: popover canvas color

### DIFF
--- a/tegel/src/components/popover-canvas/popover-canvas-theme-vars.scss
+++ b/tegel/src/components/popover-canvas/popover-canvas-theme-vars.scss
@@ -1,9 +1,9 @@
-:root,--sdds-popover-canvas-color
+:root,
 .sdds-theme-light {
   --sdds-popover-canvas-color: var(--sdds-grey-958);
   --sdds-popover-canvas-background: var(--sdds-white);
 }
-:root,
+
 .sdds-theme-dark {
   --sdds-popover-canvas-color: var(--sdds-grey-50);
   --sdds-popover-canvas-background: var(--sdds-grey-900);


### PR DESCRIPTION
Fixes bug introduced in #748

(Text in popover canvas was white even outside of darkmode)