### PR TITLE
fix(modal): fix body text spacing

### DIFF
--- a/tegel/src/components/modal/modal-native.stories.tsx
+++ b/tegel/src/components/modal/modal-native.stories.tsx
@@ -104,7 +104,7 @@ const Template = ({ headline, bodyText, size, actions, showModal }) =>
           </button>
         </div>
           <div class="sdds-modal-body">
-            ${bodyText}
+            <p>${bodyText}</p>
           </div>
           <div class="sdds-modal-actions">
               <button class="sdds-btn sdds-btn-primary sdds-btn-md">Save</button>

--- a/tegel/src/components/modal/modal-native.stories.tsx
+++ b/tegel/src/components/modal/modal-native.stories.tsx
@@ -72,7 +72,7 @@ const Template = ({ headline, size, actions, showModal }) =>
     position: relative;
     top: 0;
     left: 0;
-    height: 500px;
+    height: 100vh;
   }
   .demo-styles {
     position: absolute;

--- a/tegel/src/components/modal/modal-native.stories.tsx
+++ b/tegel/src/components/modal/modal-native.stories.tsx
@@ -104,7 +104,7 @@ const Template = ({ headline, bodyText, size, actions, showModal }) =>
           </button>
         </div>
           <div class="sdds-modal-body">
-            <p>${bodyText}</p>
+            <p class="sdds-u-mb0 sdds-u-mt0">${bodyText}</p>
           </div>
           <div class="sdds-modal-actions">
               <button class="sdds-btn sdds-btn-primary sdds-btn-md">Save</button>

--- a/tegel/src/components/modal/modal-native.stories.tsx
+++ b/tegel/src/components/modal/modal-native.stories.tsx
@@ -48,9 +48,18 @@ export default {
         type: 'text',
       },
     },
+    bodyText: {
+      name: 'Modal body text',
+      description: 'Customize body text',
+      control: {
+        type: 'text',
+      },
+    },
   },
   args: {
     headline: 'The buttons for the modal only works in the canvas tab',
+    bodyText:
+      'The steps fell lightly and oddly, with a certain swing, for all they went so slowly; it was different indeed from the heavy creaking tread of Henry Jekyll. Utterson sighed. “Is there never anything else?” he asked.',
     actions: 'Static',
     size: 'Large',
     showModal: true,
@@ -64,7 +73,7 @@ const sizeLookUp = {
   'Extra small': 'xs',
 };
 
-const Template = ({ headline, size, actions, showModal }) =>
+const Template = ({ headline, bodyText, size, actions, showModal }) =>
   formatHtmlPreview(
     `    <style>
   /* demo-wrapper and demo-styles is for demonstration purposes only*/
@@ -95,9 +104,7 @@ const Template = ({ headline, size, actions, showModal }) =>
           </button>
         </div>
           <div class="sdds-modal-body">
-            <p>
-              Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Maecenas tempus, tellus eget condimentum rhoncus.
-            </p>
+            ${bodyText}
           </div>
           <div class="sdds-modal-actions">
               <button class="sdds-btn sdds-btn-primary sdds-btn-md">Save</button>

--- a/tegel/src/components/modal/modal-webcomponent.stories.tsx
+++ b/tegel/src/components/modal/modal-webcomponent.stories.tsx
@@ -74,9 +74,9 @@ const ModalTemplate = ({ size, headline, bodyText, actions }) =>
 
   <sdds-modal open id="my-modal" size="${sizeLookUp[size]}" actions="${actions.toLowerCase()}">
       <h5 class="sdds-modal-headline" slot="sdds-modal-headline">${headline}</h5>
-      <div class="sdds-modal-body" slot="sdds-modal-body">
+      <span slot="sdds-modal-body">
           ${bodyText}
-      </div>
+      </span>
       <button slot="sdds-modal-actions" data-dismiss-modal onclick="console.log('delete')" class="sdds-btn sdds-btn-danger sdds-btn-md">Delete</button>
       <button slot="sdds-modal-actions" data-dismiss-modal onclick="console.log('cancel')" class="sdds-btn sdds-btn-secondary sdds-btn-md">Cancel</button>
   </sdds-modal>

--- a/tegel/src/components/modal/modal-webcomponent.stories.tsx
+++ b/tegel/src/components/modal/modal-webcomponent.stories.tsx
@@ -43,9 +43,18 @@ export default {
         type: 'text',
       },
     },
+    bodyText: {
+      name: 'Modal body text',
+      description: 'Customize body text',
+      control: {
+        type: 'text',
+      },
+    },
   },
   args: {
     headline: 'The buttons for the modal only works in the canvas tab',
+    bodyText:
+      'The steps fell lightly and oddly, with a certain swing, for all they went so slowly; it was different indeed from the heavy creaking tread of Henry Jekyll. Utterson sighed. “Is there never anything else?” he asked.',
     actions: 'Static',
     size: 'Large',
   },
@@ -58,15 +67,15 @@ const sizeLookUp = {
   'Extra small': 'xs',
 };
 
-const ModalTemplate = ({ size, headline, actions }) =>
+const ModalTemplate = ({ size, headline, bodyText, actions }) =>
   formatHtmlPreview(
     `
-  <button id="my-modal-button" class="sdds-btn sdds-btn-primary">Open modal</button>  
+  <button id="my-modal-button" class="sdds-btn sdds-btn-primary">Open modal</button>
 
   <sdds-modal open id="my-modal" size="${sizeLookUp[size]}" actions="${actions.toLowerCase()}">
       <h5 class="sdds-modal-headline" slot="sdds-modal-headline">${headline}</h5>
       <div class="sdds-modal-body" slot="sdds-modal-body">
-        Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Maecenas tempus, tellus eget condimentum rhoncus.
+          ${bodyText}
       </div>
       <button slot="sdds-modal-actions" data-dismiss-modal onclick="console.log('delete')" class="sdds-btn sdds-btn-danger sdds-btn-md">Delete</button>
       <button slot="sdds-modal-actions" data-dismiss-modal onclick="console.log('cancel')" class="sdds-btn sdds-btn-secondary sdds-btn-md">Cancel</button>
@@ -77,7 +86,7 @@ const ModalTemplate = ({ size, headline, actions }) =>
       document.getElementById('my-modal').open = true;
     })
   </script>
-  
+
   `,
   );
 

--- a/tegel/src/components/modal/modal.scss
+++ b/tegel/src/components/modal/modal.scss
@@ -181,7 +181,7 @@ $modals: (
 
     .sdds-modal-actions {
       position: absolute;
-      bottom: 0;
+      bottom: -1px;
       left: 0;
       right: 0;
       background-color: var(--sdds-modal-background);

--- a/tegel/src/components/modal/modal.scss
+++ b/tegel/src/components/modal/modal.scss
@@ -145,6 +145,7 @@ $modals: (
   letter-spacing: var(--sdds-body-01-ls);
   padding-bottom: 40px;
   overflow-y: visible;
+  padding-right: 16px;
   @include modal-scroll-inner;
 
   @media (min-width: $screen-l) {

--- a/tegel/src/components/modal/modal.scss
+++ b/tegel/src/components/modal/modal.scss
@@ -173,7 +173,7 @@ $modals: (
     .sdds-modal-body {
       font: var(--sdds-body-01);
       letter-spacing: var(--sdds-body-01-ls);
-      padding-bottom: 40px;
+      padding-bottom: 96px;
       margin: 0 -16px 0 0;
       max-height: calc(85vh - 36px);
       overflow-y: auto;


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Fixes for modal:

- body text cut when sticky position of the action bar is set
- padding on right missing on smaller width screen sizes
- enabling control for body text for easier testing
- dropping extra class from story example

**Solving issue**  
Fixes: [AB#2849](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/2849)

**How to test**  
1. Go to the Netlify PR link
2. Add a lot of text to the body and see if text display correctly, no matter sticky/static action bar position
3. Check if padding-right on body-text area looks good on all screens

**Additional context**  
In case you are curios to understand the problem better, try running the current master branch and modal, you will see there is an issue with text being cut off when the sticky action bar is set.
