### PR TITLE
feat(dropdown-native): correct styling for disabled dropdown

### DIFF
--- a/components/src/components/dropdown/dropdown-select.scss
+++ b/components/src/components/dropdown/dropdown-select.scss
@@ -1,4 +1,4 @@
-@import "./dropdown-core";
+@import './dropdown-core';
 
 .sdds-dropdown {
   position: relative;
@@ -14,6 +14,14 @@
 
     &:focus {
       border-bottom: 2px solid var(--sdds-blue-400);
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+      border-bottom: none;
+      color: var(--sdds-grey-400);
+      pointer-events: none;
+      background-image: url("data:image/svg+xml,%3Csvg class='sdds-dropdown-arrow' width='12' height='7' viewBox='0 0 12 7' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1L6 6L11 1' stroke='%23cdd1db' stroke-width='1.25' stroke-linecap='round' stroke-linejoin='round' /%3E%3C/svg%3E");
     }
   }
 

--- a/components/src/components/dropdown/dropdown.stories.js
+++ b/components/src/components/dropdown/dropdown.stories.js
@@ -331,13 +331,13 @@ Multiselect.argTypes = {
     },
   },
 };
-const NativeTemplate = ({ size, helper = 'Helper text', label, state, width }) => `
+const NativeTemplate = ({ size, helper = 'Helper text', label, state, width, disabled }) => `
     <div style="width:${width}px">
         <div class="sdds-dropdown ${size !== 'lg' ? `sdds-dropdown-${size}` : ''} ${
   state === 'error' ? 'sdds-dropdown--error' : ''
 }" >
           <span class="sdds-dropdown-label-outside">${label}</span>
-          <select name="nativeDropdown" id="mySelect">
+          <select ${disabled ? 'disabled' : ''} name="nativeDropdown" id="mySelect">
             <option value="truck">Truck</option>
             <option value="bus">Bus</option>
             <option value="car">Car</option>

--- a/tegel/src/components/dropdown/dropdown-select.scss
+++ b/tegel/src/components/dropdown/dropdown-select.scss
@@ -26,10 +26,6 @@
       color: var(--sdds-grey-400);
       pointer-events: none;
       background-image: url("data:image/svg+xml,%3Csvg class='sdds-dropdown-arrow' width='12' height='7' viewBox='0 0 12 7' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1L6 6L11 1' stroke='%23cdd1db' stroke-width='1.25' stroke-linecap='round' stroke-linejoin='round' /%3E%3C/svg%3E");
-
-      .caret {
-        background-color: green;
-      }
     }
   }
 

--- a/tegel/src/components/dropdown/dropdown-select.scss
+++ b/tegel/src/components/dropdown/dropdown-select.scss
@@ -22,6 +22,14 @@
 
     &:disabled {
       cursor: not-allowed;
+      border-bottom: none;
+      color: var(--sdds-grey-400);
+      pointer-events: none;
+      background-image: url("data:image/svg+xml,%3Csvg class='sdds-dropdown-arrow' width='12' height='7' viewBox='0 0 12 7' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1L6 6L11 1' stroke='%23cdd1db' stroke-width='1.25' stroke-linecap='round' stroke-linejoin='round' /%3E%3C/svg%3E");
+
+      .caret {
+        background-color: green;
+      }
     }
   }
 


### PR DESCRIPTION
**Describe pull-request**  
Aligned the styling of the disabled state for native and wc version of dropdown.

**Solving issue**  
Fixes: [AB#3022](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3022)

**How to test - Tegel**  
1. Go to storybook link below
2. Check in Components -> Dropdown -> Native
3. Toggle the disabled state and check that the styling is correct.

**How to test - scania/components**  
1. Checkout branch and run storybook
2. Check in Components -> Dropdown -> Native Select
3. Toggle the disabled state and check that the styling is correct.

**Screenshots**  


**Additional context**  


