### PR TITLE
feat(toggle): webcomponent

### DIFF
--- a/tegel/src/components/toggle/readme.md
+++ b/tegel/src/components/toggle/readme.md
@@ -1,0 +1,23 @@
+# sdds-toggle
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property   | Attribute   | Description                         | Type           | Default               |
+| ---------- | ----------- | ----------------------------------- | -------------- | --------------------- |
+| `checked`  | `checked`   | TODO - Better name for this         | `boolean`      | `false`               |
+| `disabled` | `disabled`  | Sets the toggle in a disabled state | `boolean`      | `false`               |
+| `headline` | `headline`  | Label for the toggle                | `string`       | `undefined`           |
+| `label`    | `label`     | Label for the toggle                | `string`       | `undefined`           |
+| `name`     | `name`      |                                     | `string`       | `undefined`           |
+| `size`     | `size`      | Size of the toggle                  | `"lg" \| "sm"` | `'lg'`                |
+| `toggleId` | `toggle-id` |                                     | `string`       | `crypto.randomUUID()` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/tegel/src/components/toggle/readme.md
+++ b/tegel/src/components/toggle/readme.md
@@ -28,6 +28,19 @@
 | `sddsToggleChangeEvent` | Sends unique toggle identifier and status when it is toggled. | `CustomEvent<{ toggleId: string; checked: boolean; }>` |
 
 
+## Methods
+
+### `toggle() => Promise<{ toggleId: string; checked: boolean; }>`
+
+Toggles the toggle.
+
+#### Returns
+
+Type: `Promise<{ toggleId: string; checked: boolean; }>`
+
+
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/tegel/src/components/toggle/readme.md
+++ b/tegel/src/components/toggle/readme.md
@@ -7,15 +7,22 @@
 
 ## Properties
 
-| Property   | Attribute   | Description                         | Type           | Default               |
-| ---------- | ----------- | ----------------------------------- | -------------- | --------------------- |
-| `checked`  | `checked`   | TODO - Better name for this         | `boolean`      | `false`               |
-| `disabled` | `disabled`  | Sets the toggle in a disabled state | `boolean`      | `false`               |
-| `headline` | `headline`  | Label for the toggle                | `string`       | `undefined`           |
-| `label`    | `label`     | Label for the toggle                | `string`       | `undefined`           |
-| `name`     | `name`      |                                     | `string`       | `undefined`           |
-| `size`     | `size`      | Size of the toggle                  | `"lg" \| "sm"` | `'lg'`                |
-| `toggleId` | `toggle-id` |                                     | `string`       | `crypto.randomUUID()` |
+| Property   | Attribute   | Description                                                              | Type           | Default               |
+| ---------- | ----------- | ------------------------------------------------------------------------ | -------------- | --------------------- |
+| `checked`  | `checked`   | TODO - Better name for this                                              | `boolean`      | `false`               |
+| `disabled` | `disabled`  | Sets the toggle in a disabled state                                      | `boolean`      | `false`               |
+| `headline` | `headline`  | Label for the toggle                                                     | `string`       | `undefined`           |
+| `label`    | `label`     | Label for the toggle                                                     | `string`       | `undefined`           |
+| `name`     | `name`      | Name of the toggles input element                                        | `string`       | `undefined`           |
+| `size`     | `size`      | Size of the toggle                                                       | `"lg" \| "sm"` | `'lg'`                |
+| `toggleId` | `toggle-id` | ID of the toggles input element, if not specifed it's randomly generated | `string`       | `crypto.randomUUID()` |
+
+
+## Events
+
+| Event               | Description                                                   | Type                                                   |
+| ------------------- | ------------------------------------------------------------- | ------------------------------------------------------ |
+| `toggleChangeEvent` | Sends unique toggle identifier and status when it is toggled. | `CustomEvent<{ toggleId: string; checked: boolean; }>` |
 
 
 ----------------------------------------------

--- a/tegel/src/components/toggle/readme.md
+++ b/tegel/src/components/toggle/readme.md
@@ -11,7 +11,7 @@
 | ---------- | ----------- | ------------------------------------------------------------------------ | -------------- | --------------------- |
 | `checked`  | `checked`   | TODO - Better name for this                                              | `boolean`      | `false`               |
 | `disabled` | `disabled`  | Sets the toggle in a disabled state                                      | `boolean`      | `false`               |
-| `headline` | `headline`  | Label for the toggle                                                     | `string`       | `undefined`           |
+| `headline` | `headline`  | Headline for the toggle                                                  | `string`       | `undefined`           |
 | `label`    | `label`     | Label for the toggle                                                     | `string`       | `undefined`           |
 | `name`     | `name`      | Name of the toggles input element                                        | `string`       | `undefined`           |
 | `size`     | `size`      | Size of the toggle                                                       | `"lg" \| "sm"` | `'lg'`                |

--- a/tegel/src/components/toggle/readme.md
+++ b/tegel/src/components/toggle/readme.md
@@ -10,6 +10,7 @@
 | Property          | Attribute          | Description                                                              | Type           | Default               |
 | ----------------- | ------------------ | ------------------------------------------------------------------------ | -------------- | --------------------- |
 | `ariaDescribedby` | `aria-describedby` | Aria-describedby for the toggles input element.                          | `string`       | `undefined`           |
+| `ariaLabelledby`  | `aria-labelledby`  | Aria-labelledby for the toggles input element.                           | `any`          | `undefined`           |
 | `checked`         | `checked`          | Sets the toggle as checked                                               | `boolean`      | `false`               |
 | `disabled`        | `disabled`         | Sets the toggle in a disabled state                                      | `boolean`      | `false`               |
 | `headline`        | `headline`         | Headline for the toggle                                                  | `string`       | `undefined`           |

--- a/tegel/src/components/toggle/readme.md
+++ b/tegel/src/components/toggle/readme.md
@@ -10,7 +10,7 @@
 | Property          | Attribute          | Description                                                              | Type           | Default               |
 | ----------------- | ------------------ | ------------------------------------------------------------------------ | -------------- | --------------------- |
 | `ariaDescribedby` | `aria-describedby` | Aria-describedby for the toggles input element.                          | `string`       | `undefined`           |
-| `ariaLabelledby`  | `aria-labelledby`  | Aria-labelledby for the toggles input element.                           | `any`          | `undefined`           |
+| `ariaLabelledby`  | `aria-labelledby`  | Aria-labelledby for the toggles input element.                           | `string`       | `undefined`           |
 | `checked`         | `checked`          | Sets the toggle as checked                                               | `boolean`      | `false`               |
 | `disabled`        | `disabled`         | Sets the toggle in a disabled state                                      | `boolean`      | `false`               |
 | `headline`        | `headline`         | Headline for the toggle                                                  | `string`       | `undefined`           |

--- a/tegel/src/components/toggle/readme.md
+++ b/tegel/src/components/toggle/readme.md
@@ -7,22 +7,24 @@
 
 ## Properties
 
-| Property   | Attribute   | Description                                                              | Type           | Default               |
-| ---------- | ----------- | ------------------------------------------------------------------------ | -------------- | --------------------- |
-| `checked`  | `checked`   | TODO - Better name for this                                              | `boolean`      | `false`               |
-| `disabled` | `disabled`  | Sets the toggle in a disabled state                                      | `boolean`      | `false`               |
-| `headline` | `headline`  | Headline for the toggle                                                  | `string`       | `undefined`           |
-| `label`    | `label`     | Label for the toggle                                                     | `string`       | `undefined`           |
-| `name`     | `name`      | Name of the toggles input element                                        | `string`       | `undefined`           |
-| `size`     | `size`      | Size of the toggle                                                       | `"lg" \| "sm"` | `'lg'`                |
-| `toggleId` | `toggle-id` | ID of the toggles input element, if not specifed it's randomly generated | `string`       | `crypto.randomUUID()` |
+| Property          | Attribute          | Description                                                              | Type           | Default               |
+| ----------------- | ------------------ | ------------------------------------------------------------------------ | -------------- | --------------------- |
+| `ariaDescribedby` | `aria-describedby` | Aria-describedby for the toggles input element.                          | `string`       | `undefined`           |
+| `checked`         | `checked`          | Sets the toggle as checked                                               | `boolean`      | `false`               |
+| `disabled`        | `disabled`         | Sets the toggle in a disabled state                                      | `boolean`      | `false`               |
+| `headline`        | `headline`         | Headline for the toggle                                                  | `string`       | `undefined`           |
+| `label`           | `label`            | Label for the toggle                                                     | `string`       | `undefined`           |
+| `name`            | `name`             | Name of the toggles input element                                        | `string`       | `undefined`           |
+| `required`        | `required`         | Make the toggle required                                                 | `boolean`      | `false`               |
+| `size`            | `size`             | Size of the toggle                                                       | `"lg" \| "sm"` | `'lg'`                |
+| `toggleId`        | `toggle-id`        | ID of the toggles input element, if not specifed it's randomly generated | `string`       | `crypto.randomUUID()` |
 
 
 ## Events
 
-| Event               | Description                                                   | Type                                                   |
-| ------------------- | ------------------------------------------------------------- | ------------------------------------------------------ |
-| `toggleChangeEvent` | Sends unique toggle identifier and status when it is toggled. | `CustomEvent<{ toggleId: string; checked: boolean; }>` |
+| Event                   | Description                                                   | Type                                                   |
+| ----------------------- | ------------------------------------------------------------- | ------------------------------------------------------ |
+| `sddsToggleChangeEvent` | Sends unique toggle identifier and status when it is toggled. | `CustomEvent<{ toggleId: string; checked: boolean; }>` |
 
 
 ----------------------------------------------

--- a/tegel/src/components/toggle/sdds-toggle.scss
+++ b/tegel/src/components/toggle/sdds-toggle.scss
@@ -1,6 +1,4 @@
-:host {
-  display: block;
-
+.sdds-toggle-webcomponent {
   .toggle-headline {
     font: var(--sdds-detail-02);
     letter-spacing: var(--sdds-detail-02-ls);

--- a/tegel/src/components/toggle/sdds-toggle.scss
+++ b/tegel/src/components/toggle/sdds-toggle.scss
@@ -1,0 +1,122 @@
+:host {
+  display: block;
+
+  .toggle-headline {
+    font: var(--sdds-detail-02);
+    letter-spacing: var(--sdds-detail-02-ls);
+    color: var(--sdds-toggle-headline);
+    margin-bottom: 12px;
+  }
+
+  input[type='checkbox'] {
+    margin: 0;
+    width: 44px;
+    height: 24px;
+    position: relative;
+    display: inline-block;
+    vertical-align: middle;
+
+    &::after,
+    &::before {
+      content: '';
+      position: absolute;
+      box-sizing: border-box;
+      transition: all 0.5s cubic-bezier(0.075, 0.82, 0.165, 1);
+    }
+
+    &::before {
+      /* Slider */
+      width: 44px;
+      height: 24px;
+      border-radius: 16px;
+      background-color: var(--sdds-toggle-off-slider);
+      left: 0;
+    }
+
+    /* Switch */
+    &::after {
+      width: 16px;
+      height: 16px;
+      background-color: var(--sdds-toggle-switch);
+      border-radius: 50%;
+      left: 4px;
+      top: 4px;
+    }
+
+    &:focus {
+      outline: none;
+
+      &::before {
+        background-color: var(--sdds-toggle-off-slider-focus);
+        border: 1px solid var(--sdds-toggle-off-border-focus);
+      }
+    }
+
+    &:checked {
+      &::before {
+        background-color: var(--sdds-toggle-on-slider);
+        border: 1px solid var(--sdds-toggle-on-border-focus);
+      }
+
+      &::after {
+        left: calc(44px - 20px);
+      }
+    }
+
+    &:disabled {
+      &::before {
+        background-color: var(--sdds-toggle-slider-disabled);
+        border: 1px solid var(--sdds-toggle-slider-disabled);
+      }
+
+      &::after {
+        background-color: var(--sdds-toggle-switch-disabled);
+      }
+    }
+
+    &.sm {
+      width: 28px;
+      height: 16px;
+
+      &::before {
+        width: 28px;
+        height: 16px;
+      }
+
+      &::after {
+        width: 8px;
+        height: 8px;
+      }
+
+      &:checked {
+        &::before {
+          background-color: var(--sdds-toggle-on-slider);
+        }
+
+        &::after {
+          left: calc(44px - 28px); // slider width - switch width - padding
+        }
+      }
+
+      &:disabled {
+        &::before {
+          background-color: var(--sdds-toggle-slider-disabled);
+          border: 1px solid var(--sdds-toggle-slider-disabled);
+        }
+
+        &::after {
+          background-color: var(--sdds-toggle-switch-disabled);
+        }
+      }
+    }
+  }
+
+  label {
+    display: inline-block;
+    vertical-align: middle;
+    font: var(--sdds-detail-01);
+    letter-spacing: var(--sdds-detail-01-ls);
+    color: var(--sdds-toggle-label-color);
+    padding-left: 8px;
+  }
+}

--- a/tegel/src/components/toggle/sdds-toggle.stories.tsx
+++ b/tegel/src/components/toggle/sdds-toggle.stories.tsx
@@ -84,6 +84,8 @@ const Template = ({ label, size, disabled, headline, checked }) =>
         size="${size === 'Large' ? 'lg' : 'sm'}">
         ${label}
     </sdds-toggle>
+
+    <!-- Script tag with eventlistener for demo purposes. -->
     <script>
       document.addEventListener('sddsToggleChangeEvent', ()=>{
         console.log('Toggle with id: ', event.detail.toggleId, ' is ', event.detail.checked)

--- a/tegel/src/components/toggle/sdds-toggle.stories.tsx
+++ b/tegel/src/components/toggle/sdds-toggle.stories.tsx
@@ -27,6 +27,9 @@ export default {
       },
       options: ['Large', 'Small'],
       description: 'Size of the toggle',
+      table: {
+        defaultValue: { summary: 'lg' },
+      },
     },
     label: {
       name: 'Label',
@@ -48,12 +51,18 @@ export default {
       control: {
         type: 'boolean',
       },
+      table: {
+        defaultValue: { summary: 'false' },
+      },
     },
     checked: {
       name: 'Checked',
       description: 'Sets the toggle as checked',
       control: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: 'false' },
       },
     },
   },
@@ -71,12 +80,12 @@ const Template = ({ label, size, disabled, headline, checked }) =>
       <sdds-toggle
         ${checked ? 'checked' : ''}
         ${disabled ? 'disabled' : ''}
-        ${label ? `label="${label}"` : ''}
         ${headline ? `headline="${headline}"` : ''}
         size="${size === 'Large' ? 'lg' : 'sm'}">
+        ${label}
     </sdds-toggle>
     <script>
-      document.addEventListener('toggleChangeEvent', ()=>{
+      document.addEventListener('sddsToggleChangeEvent', ()=>{
         console.log('Toggle with id: ', event.detail.toggleId, ' is ', event.detail.checked)
       })
     </script>

--- a/tegel/src/components/toggle/sdds-toggle.stories.tsx
+++ b/tegel/src/components/toggle/sdds-toggle.stories.tsx
@@ -75,5 +75,10 @@ const Template = ({ label, size, disabled, headline, checked }) =>
         ${headline ? `headline="${headline}"` : ''}
         size="${size === 'Large' ? 'lg' : 'sm'}">
     </sdds-toggle>
+    <script>
+      document.addEventListener('toggleChangeEvent', ()=>{
+        console.log('Toggle with id: ', event.detail.toggleId, ' is ', event.detail.checked)
+      })
+    </script>
   `);
 export const WebComponent = Template.bind({});

--- a/tegel/src/components/toggle/sdds-toggle.stories.tsx
+++ b/tegel/src/components/toggle/sdds-toggle.stories.tsx
@@ -33,14 +33,14 @@ export default {
     },
     label: {
       name: 'Label',
-      description: 'Optional value to be used to clarify what the toggle is switching on / off',
+      description: 'Label for the toggles input element.',
       control: {
         type: 'text',
       },
     },
     headline: {
       name: 'Headline',
-      description: 'Optional value to be used to clarify what the toggle is switching on / off',
+      description: 'Headline, displayed above the toggle.',
       control: {
         type: 'text',
       },

--- a/tegel/src/components/toggle/sdds-toggle.stories.tsx
+++ b/tegel/src/components/toggle/sdds-toggle.stories.tsx
@@ -59,7 +59,7 @@ export default {
   },
   args: {
     size: 'Large',
-    label: 'Labe',
+    label: 'Label',
     headline: 'Headline',
     disabled: false,
     checked: false,

--- a/tegel/src/components/toggle/sdds-toggle.stories.tsx
+++ b/tegel/src/components/toggle/sdds-toggle.stories.tsx
@@ -1,0 +1,79 @@
+import { formatHtmlPreview } from '../../utils/utils';
+import readme from './readme.md';
+
+export default {
+  title: 'Components/Toggle',
+  parameters: {
+    notes: readme,
+    layout: 'centered',
+    design: [
+      {
+        name: 'Figma',
+        type: 'figma',
+        url: 'https://www.figma.com/file/d8bTgEx7h694MSesi2CTLF/Tegel-UI-Library?node-id=2479%3A108951&t=Ne6myqwca5m00de7-1',
+      },
+      {
+        name: 'Link',
+        type: 'link',
+        url: 'https://www.figma.com/file/d8bTgEx7h694MSesi2CTLF/Tegel-UI-Library?node-id=2479%3A108951&t=Ne6myqwca5m00de7-1',
+      },
+    ],
+  },
+  argTypes: {
+    size: {
+      name: 'Size',
+      control: {
+        type: 'radio',
+      },
+      options: ['Large', 'Small'],
+      description: 'Size of the toggle',
+    },
+    label: {
+      name: 'Label',
+      description: 'Optional value to be used to clarify what the toggle is switching on / off',
+      control: {
+        type: 'text',
+      },
+    },
+    headline: {
+      name: 'Headline',
+      description: 'Optional value to be used to clarify what the toggle is switching on / off',
+      control: {
+        type: 'text',
+      },
+    },
+    disabled: {
+      name: 'Disabled',
+      description: 'Sets the toggle as disabled',
+      control: {
+        type: 'boolean',
+      },
+    },
+    checked: {
+      name: 'Checked',
+      description: 'Sets the toggle as checked',
+      control: {
+        type: 'boolean',
+      },
+    },
+  },
+  args: {
+    size: 'Large',
+    label: 'Labe',
+    headline: 'Headline',
+    disabled: false,
+    checked: false,
+  },
+};
+
+const Template = ({ label, size, disabled, headline, checked }) =>
+  formatHtmlPreview(`
+      <sdds-toggle
+        ${checked ? 'checked' : ''}
+        ${disabled ? 'disabled' : ''}
+        ${label ? `label="${label}"` : ''}
+        ${headline ? `headline="${headline}"` : ''}
+        size="${size === 'Large' ? 'lg' : 'sm'}">
+    </sdds-toggle>
+  `);
+export const WebComponent = Template.bind({});

--- a/tegel/src/components/toggle/sdds-toggle.tsx
+++ b/tegel/src/components/toggle/sdds-toggle.tsx
@@ -1,5 +1,4 @@
-import { Component, h, Prop, Element, Event, EventEmitter } from '@stencil/core';
-import { HostElement } from '@stencil/core/internal';
+import { Component, h, Prop, Event, EventEmitter, Method } from '@stencil/core';
 
 @Component({
   tag: 'sdds-toggle',
@@ -9,7 +8,7 @@ import { HostElement } from '@stencil/core/internal';
 })
 export class SddsToggle {
   /** Sets the toggle as checked */
-  @Prop() checked: boolean = false;
+  @Prop({ reflect: true }) checked: boolean = false;
 
   /** Make the toggle required */
   @Prop() required: boolean = false;
@@ -38,7 +37,15 @@ export class SddsToggle {
   /** ID of the toggles input element, if not specifed it's randomly generated */
   @Prop() toggleId: string = crypto.randomUUID();
 
-  @Element() host: HostElement;
+  /** Toggles the toggle. */
+  @Method()
+  async toggle() {
+    this.checked = !this.checked;
+    return {
+      toggleId: this.toggleId,
+      checked: this.checked,
+    };
+  }
 
   /** Sends unique toggle identifier and status when it is toggled. */
   @Event({

--- a/tegel/src/components/toggle/sdds-toggle.tsx
+++ b/tegel/src/components/toggle/sdds-toggle.tsx
@@ -14,6 +14,9 @@ export class SddsToggle {
   /** Make the toggle required */
   @Prop() required: boolean = false;
 
+  /** Aria-labelledby for the toggles input element. */
+  @Prop() ariaLabelledby;
+
   /** Aria-describedby for the toggles input element. */
   @Prop() ariaDescribedby: string;
 
@@ -54,6 +57,7 @@ export class SddsToggle {
       <div class="sdds-toggle-webcomponent">
         {this.headline && <div class={`toggle-headline`}>{this.headline}</div>}
         <input
+          aria-labelledby={this.ariaLabelledby}
           aria-describedby={this.ariaDescribedby}
           onChange={() => {
             this.checked = !this.checked;
@@ -69,6 +73,7 @@ export class SddsToggle {
           type="checkbox"
           name={this.name}
           id={this.toggleId}
+          role="switch"
         />
         <label htmlFor={this.toggleId}>
           <slot></slot>

--- a/tegel/src/components/toggle/sdds-toggle.tsx
+++ b/tegel/src/components/toggle/sdds-toggle.tsx
@@ -19,7 +19,7 @@ export class SddsToggle {
   /** Label for the toggle */
   @Prop() label: string;
 
-  /** Label for the toggle */
+  /** Headline for the toggle */
   @Prop() headline: string;
 
   /** Sets the toggle in a disabled state */

--- a/tegel/src/components/toggle/sdds-toggle.tsx
+++ b/tegel/src/components/toggle/sdds-toggle.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, Watch, Element } from '@stencil/core';
+import { Component, Host, h, Prop, Watch, Element, Event, EventEmitter } from '@stencil/core';
 import { HostElement } from '@stencil/core/internal';
 
 @Component({
@@ -13,6 +13,7 @@ export class SddsToggle {
   /** Size of the toggle */
   @Prop() size: 'sm' | 'lg' = 'lg';
 
+  /** Name of the toggles input element */
   @Prop() name: string;
 
   /** Label for the toggle */
@@ -24,6 +25,7 @@ export class SddsToggle {
   /** Sets the toggle in a disabled state */
   @Prop() disabled: boolean = false;
 
+  /** ID of the toggles input element, if not specifed it's randomly generated */
   @Prop() toggleId: string = crypto.randomUUID();
 
   @Element() host: HostElement;
@@ -37,6 +39,18 @@ export class SddsToggle {
     }
   }
 
+  /** Sends unique toggle identifier and status when it is toggled. */
+  @Event({
+    eventName: 'toggleChangeEvent',
+    composed: true,
+    cancelable: true,
+    bubbles: true,
+  })
+  toggleChangeEvent: EventEmitter<{
+    toggleId: string;
+    checked: boolean;
+  }>;
+
   render() {
     return (
       <Host>
@@ -44,6 +58,10 @@ export class SddsToggle {
         <input
           onChange={() => {
             this.checked = !this.checked;
+            this.toggleChangeEvent.emit({
+              toggleId: this.toggleId,
+              checked: this.checked,
+            });
           }}
           class={`${this.size}`}
           checked={this.checked}

--- a/tegel/src/components/toggle/sdds-toggle.tsx
+++ b/tegel/src/components/toggle/sdds-toggle.tsx
@@ -14,7 +14,7 @@ export class SddsToggle {
   @Prop() required: boolean = false;
 
   /** Aria-labelledby for the toggles input element. */
-  @Prop() ariaLabelledby;
+  @Prop() ariaLabelledby: string;
 
   /** Aria-describedby for the toggles input element. */
   @Prop() ariaDescribedby: string;

--- a/tegel/src/components/toggle/sdds-toggle.tsx
+++ b/tegel/src/components/toggle/sdds-toggle.tsx
@@ -1,10 +1,10 @@
-import { Component, Host, h, Prop, Watch, Element, Event, EventEmitter } from '@stencil/core';
+import { Component, h, Prop, Watch, Element, Event, EventEmitter } from '@stencil/core';
 import { HostElement } from '@stencil/core/internal';
 
 @Component({
   tag: 'sdds-toggle',
   styleUrl: 'sdds-toggle.scss',
-  shadow: true,
+  shadow: false,
 })
 export class SddsToggle {
   /** TODO - Better name for this */
@@ -53,7 +53,7 @@ export class SddsToggle {
 
   render() {
     return (
-      <Host>
+      <div class="sdds-toggle-webcomponent">
         {this.headline && <div class={`toggle-headline`}>{this.headline}</div>}
         <input
           onChange={() => {
@@ -71,7 +71,7 @@ export class SddsToggle {
           id={this.toggleId}
         />
         {this.label && <label htmlFor={this.toggleId}>{this.label}</label>}
-      </Host>
+      </div>
     );
   }
 }

--- a/tegel/src/components/toggle/sdds-toggle.tsx
+++ b/tegel/src/components/toggle/sdds-toggle.tsx
@@ -1,14 +1,21 @@
-import { Component, h, Prop, Watch, Element, Event, EventEmitter } from '@stencil/core';
+import { Component, h, Prop, Element, Event, EventEmitter } from '@stencil/core';
 import { HostElement } from '@stencil/core/internal';
 
 @Component({
   tag: 'sdds-toggle',
   styleUrl: 'sdds-toggle.scss',
   shadow: false,
+  scoped: true,
 })
 export class SddsToggle {
-  /** TODO - Better name for this */
-  @Prop({ reflect: true }) checked: boolean = false;
+  /** Sets the toggle as checked */
+  @Prop() checked: boolean = false;
+
+  /** Make the toggle required */
+  @Prop() required: boolean = false;
+
+  /** Aria-describedby for the toggles input element. */
+  @Prop() ariaDescribedby: string;
 
   /** Size of the toggle */
   @Prop() size: 'sm' | 'lg' = 'lg';
@@ -30,23 +37,14 @@ export class SddsToggle {
 
   @Element() host: HostElement;
 
-  @Watch('checked')
-  updatedCheckedState() {
-    if (this.checked) {
-      this.host.setAttribute('checked', `${this.checked}`);
-    } else {
-      this.host.removeAttribute('checked');
-    }
-  }
-
   /** Sends unique toggle identifier and status when it is toggled. */
   @Event({
-    eventName: 'toggleChangeEvent',
+    eventName: 'sddsToggleChangeEvent',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  toggleChangeEvent: EventEmitter<{
+  sddsToggleChangeEvent: EventEmitter<{
     toggleId: string;
     checked: boolean;
   }>;
@@ -56,9 +54,10 @@ export class SddsToggle {
       <div class="sdds-toggle-webcomponent">
         {this.headline && <div class={`toggle-headline`}>{this.headline}</div>}
         <input
+          aria-describedby={this.ariaDescribedby}
           onChange={() => {
             this.checked = !this.checked;
-            this.toggleChangeEvent.emit({
+            this.sddsToggleChangeEvent.emit({
               toggleId: this.toggleId,
               checked: this.checked,
             });
@@ -66,11 +65,14 @@ export class SddsToggle {
           class={`${this.size}`}
           checked={this.checked}
           disabled={this.disabled}
+          required={this.required}
           type="checkbox"
           name={this.name}
           id={this.toggleId}
         />
-        {this.label && <label htmlFor={this.toggleId}>{this.label}</label>}
+        <label htmlFor={this.toggleId}>
+          <slot></slot>
+        </label>
       </div>
     );
   }

--- a/tegel/src/components/toggle/sdds-toggle.tsx
+++ b/tegel/src/components/toggle/sdds-toggle.tsx
@@ -1,0 +1,59 @@
+import { Component, Host, h, Prop, Watch, Element } from '@stencil/core';
+import { HostElement } from '@stencil/core/internal';
+
+@Component({
+  tag: 'sdds-toggle',
+  styleUrl: 'sdds-toggle.scss',
+  shadow: true,
+})
+export class SddsToggle {
+  /** TODO - Better name for this */
+  @Prop({ reflect: true }) checked: boolean = false;
+
+  /** Size of the toggle */
+  @Prop() size: 'sm' | 'lg' = 'lg';
+
+  @Prop() name: string;
+
+  /** Label for the toggle */
+  @Prop() label: string;
+
+  /** Label for the toggle */
+  @Prop() headline: string;
+
+  /** Sets the toggle in a disabled state */
+  @Prop() disabled: boolean = false;
+
+  @Prop() toggleId: string = crypto.randomUUID();
+
+  @Element() host: HostElement;
+
+  @Watch('checked')
+  updatedCheckedState() {
+    if (this.checked) {
+      this.host.setAttribute('checked', `${this.checked}`);
+    } else {
+      this.host.removeAttribute('checked');
+    }
+  }
+
+  render() {
+    return (
+      <Host>
+        {this.headline && <div class={`toggle-headline`}>{this.headline}</div>}
+        <input
+          onChange={() => {
+            this.checked = !this.checked;
+          }}
+          class={`${this.size}`}
+          checked={this.checked}
+          disabled={this.disabled}
+          type="checkbox"
+          name={this.name}
+          id={this.toggleId}
+        />
+        {this.label && <label htmlFor={this.toggleId}>{this.label}</label>}
+      </Host>
+    );
+  }
+}

--- a/tegel/src/components/toggle/toggle.stories.tsx
+++ b/tegel/src/components/toggle/toggle.stories.tsx
@@ -44,7 +44,7 @@ export default {
   args: {
     size: 'Default',
     headline: '',
-    disabled: true,
+    disabled: false,
   },
 };
 

--- a/tegel/src/components/toggle/toggle.stories.tsx
+++ b/tegel/src/components/toggle/toggle.stories.tsx
@@ -44,7 +44,7 @@ export default {
   args: {
     size: 'Default',
     headline: '',
-    disabled: false,
+    disabled: true,
   },
 };
 
@@ -65,5 +65,4 @@ const Template = ({ size, disabled = false, headline = '' }) => {
   `);
 };
 
-export const Default = Template.bind({});
-Default.args = {};
+export const Native = Template.bind({});


### PR DESCRIPTION
**Describe pull-request**  
Web component version of the toggle. Also renamed toggle native story to "Native".

ShadowDOM is removed in order for the component to work within a form.


**Solving issue**  
Fixes: [AB#3144](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3144)

**How to test**  
1. Go to story book link below
2. Check in Component -> Toggle -> Web Component
3. Check that styling and functionality is correct

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events


**Screenshots**  


**Additional context**  

