### PR TITLE
feat(link): webcomponent

### DIFF
--- a/tegel/src/components/dropdown/dropdown-theme-vars.scss
+++ b/tegel/src/components/dropdown/dropdown-theme-vars.scss
@@ -4,7 +4,9 @@
 :host,
 ::slotted(*),
 .sdds-theme-light {
-  --sdds-link: var(--sdds-grey-958);
+  /* This one is overriding the --sdds-link css for the link component. */
+
+  /* --sdds-link: var(--sdds-grey-958); */
   --sdds-link-text-decoration: none;
   --sdds-dropdown-bg: var(--sdds-white);
   --sdds-dropdown-bg-hover: var(--sdds-grey-50);

--- a/tegel/src/components/link/link-theme-vars.scss
+++ b/tegel/src/components/link/link-theme-vars.scss
@@ -3,7 +3,7 @@
   --sdds-link: var(--sdds-blue-500);
   --sdds-link-hover: var(--sdds-blue-400);
   --sdds-link-focus: var(--sdds-blue-400);
-  --sdds-link-visited: var(--sdds-blue-400);
+  --sdds-link-visited: var(--sdds-grey-900);
   --sdds-link-disabled: var(--sdds-grey-400);
 }
 

--- a/tegel/src/components/link/link.stories.tsx
+++ b/tegel/src/components/link/link.stories.tsx
@@ -49,4 +49,4 @@ const Template = ({ disabled, noUnderline }) =>
       </a>
   `,
   );
-export const Default = Template.bind({});
+export const Native = Template.bind({});

--- a/tegel/src/components/link/readme.md
+++ b/tegel/src/components/link/readme.md
@@ -1,0 +1,30 @@
+# sdds-link
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property         | Attribute        | Description                                                       | Type                                                                                                                                                                               | Default               |
+| ---------------- | ---------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `disabled`       | `disabled`       | Disables the link                                                 | `boolean`                                                                                                                                                                          | `false`               |
+| `href`           | `href`           | URL for the link                                                  | `string`                                                                                                                                                                           | `undefined`           |
+| `linkId`         | `link-id`        | ID for the link. Randomly generated if not specified.             | `string`                                                                                                                                                                           | `crypto.randomUUID()` |
+| `referrerpolicy` | `referrerpolicy` | How much of the referrer to send when following the link.         | `"no-referrer" \| "no-referrer-when-downgrade" \| "origin" \| "origin-when-cross-origin" \| "same-origin" \| "strict-origin" \| "strict-origin-when-cross-origin" \| "unsafe-url"` | `undefined`           |
+| `rel`            | `rel`            | The relationship of the linked URL as space-separated link types. | `string`                                                                                                                                                                           | `'noopener'`          |
+| `target`         | `target`         | Where to open the linked URL                                      | `"_blank" \| "_parent" \| "_self" \| "_top"`                                                                                                                                       | `'_self'`             |
+| `underline`      | `underline`      | Displays the link without an underline.                           | `boolean`                                                                                                                                                                          | `true`                |
+
+
+## Events
+
+| Event                  | Description                                              | Type                                         |
+| ---------------------- | -------------------------------------------------------- | -------------------------------------------- |
+| `sddsLinkClickedEvent` | Sends unique link identifier and href when it is clicked | `CustomEvent<{ href: string; id: string; }>` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/tegel/src/components/link/readme.md
+++ b/tegel/src/components/link/readme.md
@@ -7,15 +7,14 @@
 
 ## Properties
 
-| Property         | Attribute        | Description                                                       | Type                                                                                                                                                                               | Default               |
-| ---------------- | ---------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
-| `disabled`       | `disabled`       | Disables the link                                                 | `boolean`                                                                                                                                                                          | `false`               |
-| `href`           | `href`           | URL for the link                                                  | `string`                                                                                                                                                                           | `undefined`           |
-| `linkId`         | `link-id`        | ID for the link. Randomly generated if not specified.             | `string`                                                                                                                                                                           | `crypto.randomUUID()` |
-| `referrerpolicy` | `referrerpolicy` | How much of the referrer to send when following the link.         | `"no-referrer" \| "no-referrer-when-downgrade" \| "origin" \| "origin-when-cross-origin" \| "same-origin" \| "strict-origin" \| "strict-origin-when-cross-origin" \| "unsafe-url"` | `undefined`           |
-| `rel`            | `rel`            | The relationship of the linked URL as space-separated link types. | `string`                                                                                                                                                                           | `'noopener'`          |
-| `target`         | `target`         | Where to open the linked URL                                      | `"_blank" \| "_parent" \| "_self" \| "_top"`                                                                                                                                       | `'_self'`             |
-| `underline`      | `underline`      | Displays the link without an underline.                           | `boolean`                                                                                                                                                                          | `true`                |
+| Property    | Attribute   | Description                                                       | Type                                         | Default               |
+| ----------- | ----------- | ----------------------------------------------------------------- | -------------------------------------------- | --------------------- |
+| `disabled`  | `disabled`  | Disables the link                                                 | `boolean`                                    | `false`               |
+| `href`      | `href`      | URL for the link                                                  | `string`                                     | `undefined`           |
+| `linkId`    | `link-id`   | ID for the link. Randomly generated if not specified.             | `string`                                     | `crypto.randomUUID()` |
+| `rel`       | `rel`       | The relationship of the linked URL as space-separated link types. | `string`                                     | `'noopener'`          |
+| `target`    | `target`    | Where to open the linked URL                                      | `"_blank" \| "_parent" \| "_self" \| "_top"` | `'_self'`             |
+| `underline` | `underline` | Displays the link without an underline.                           | `boolean`                                    | `true`                |
 
 
 ## Events

--- a/tegel/src/components/link/readme.md
+++ b/tegel/src/components/link/readme.md
@@ -7,21 +7,13 @@
 
 ## Properties
 
-| Property    | Attribute   | Description                                                       | Type                                         | Default               |
-| ----------- | ----------- | ----------------------------------------------------------------- | -------------------------------------------- | --------------------- |
-| `disabled`  | `disabled`  | Disables the link                                                 | `boolean`                                    | `false`               |
-| `href`      | `href`      | URL for the link                                                  | `string`                                     | `undefined`           |
-| `linkId`    | `link-id`   | ID for the link. Randomly generated if not specified.             | `string`                                     | `crypto.randomUUID()` |
-| `rel`       | `rel`       | The relationship of the linked URL as space-separated link types. | `string`                                     | `'noopener'`          |
-| `target`    | `target`    | Where to open the linked URL                                      | `"_blank" \| "_parent" \| "_self" \| "_top"` | `'_self'`             |
-| `underline` | `underline` | Displays the link without an underline.                           | `boolean`                                    | `true`                |
-
-
-## Events
-
-| Event                  | Description                                              | Type                                         |
-| ---------------------- | -------------------------------------------------------- | -------------------------------------------- |
-| `sddsLinkClickedEvent` | Sends unique link identifier and href when it is clicked | `CustomEvent<{ href: string; id: string; }>` |
+| Property    | Attribute   | Description                                                                                                                                            | Type                                         | Default      |
+| ----------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------- | ------------ |
+| `disabled`  | `disabled`  | Disables the link                                                                                                                                      | `boolean`                                    | `false`      |
+| `linkHref`  | `link-href` | URL for the link                                                                                                                                       | `string`                                     | `undefined`  |
+| `rel`       | `rel`       | 'noopener' is a security measure for legacy browsers that preventsthe opened page from getting access to the original page when using target='_blank'. | `string`                                     | `'noopener'` |
+| `target`    | `target`    | Where to open the linked URL                                                                                                                           | `"_blank" \| "_parent" \| "_self" \| "_top"` | `'_self'`    |
+| `underline` | `underline` | Displays the link without an underline.                                                                                                                | `boolean`                                    | `true`       |
 
 
 ----------------------------------------------

--- a/tegel/src/components/link/sdds-link.scss
+++ b/tegel/src/components/link/sdds-link.scss
@@ -1,0 +1,43 @@
+a {
+  cursor: pointer;
+  outline: none;
+  color: var(--sdds-link);
+
+  &:active {
+    color: var(--sdds-link);
+    text-decoration: underline;
+    text-decoration-color: var(--sdds-link);
+  }
+
+  &:hover {
+    color: var(--sdds-link-hover);
+    text-decoration: underline;
+    text-decoration-color: var(--sdds-link-hover);
+  }
+
+  &:visited {
+    color: var(--sdds-link-visited);
+    text-decoration-color: var(--sdds-link-visited);
+  }
+
+  &:focus {
+    color: var(--sdds-link-focus);
+    text-decoration: none;
+    outline: 2px solid var(--sdds-link-focus);
+    outline-offset: -2px;
+  }
+
+  &.disabled {
+    color: var(--sdds-link-disabled);
+    text-decoration-color: var(--sdds-link-disabled);
+    pointer-events: none;
+  }
+
+  &.no-underline {
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+}

--- a/tegel/src/components/link/sdds-link.stories.tsx
+++ b/tegel/src/components/link/sdds-link.stories.tsx
@@ -26,12 +26,18 @@ export default {
       controls: {
         type: 'boolean',
       },
+      table: {
+        defaultValue: { summary: 'false' },
+      },
     },
     underline: {
       name: 'Underline',
       description: 'Underline under link text.',
       controls: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: 'true' },
       },
     },
     target: {
@@ -41,6 +47,9 @@ export default {
         type: 'radio',
       },
       options: ['_self', '_blank', '_parent', '_top'],
+      table: {
+        defaultValue: { summary: '_self' },
+      },
     },
   },
   args: {
@@ -52,7 +61,8 @@ export default {
 
 const Template = ({ disabled, underline, target }) =>
   formatHtmlPreview(
-    `<sdds-link
+    `
+    <sdds-link
         ${disabled ? 'disabled' : ''}
         ${underline ? '' : 'underline="false"'}
         link-href="#"
@@ -60,11 +70,6 @@ const Template = ({ disabled, underline, target }) =>
         >
         This is a link.
     </sdds-link>
-    <script>
-        document.addEventListener('sddsLinkClickedEvent', (e) => {
-            console.log('Link with id: ', event.detail.linkId, ' and href:', event.detail.href, 'was clicked.')
-        })
-    </script>
   `,
   );
 export const WebComponent = Template.bind({});

--- a/tegel/src/components/link/sdds-link.stories.tsx
+++ b/tegel/src/components/link/sdds-link.stories.tsx
@@ -55,7 +55,7 @@ const Template = ({ disabled, underline, target }) =>
     `<sdds-link
         ${disabled ? 'disabled' : ''}
         ${underline ? '' : 'underline="false"'}
-        href="#"
+        link-href="#"
         target="${target}"
         >
         This is a link.

--- a/tegel/src/components/link/sdds-link.stories.tsx
+++ b/tegel/src/components/link/sdds-link.stories.tsx
@@ -55,10 +55,10 @@ const Template = ({ disabled, underline, target }) =>
     `<sdds-link
         ${disabled ? 'disabled' : ''}
         ${underline ? '' : 'underline="false"'}
-        href="https://tegel.scania.com"
+        href="#"
         target="${target}"
         >
-        Link
+        This is a link.
     </sdds-link>
     <script>
         document.addEventListener('sddsLinkClickedEvent', (e) => {

--- a/tegel/src/components/link/sdds-link.stories.tsx
+++ b/tegel/src/components/link/sdds-link.stories.tsx
@@ -1,0 +1,70 @@
+import { formatHtmlPreview } from '../../utils/utils';
+import readme from './readme.md';
+
+export default {
+  title: 'Components/Link',
+  parameters: {
+    notes: readme,
+    layout: 'centered',
+    design: [
+      {
+        name: 'Figma',
+        type: 'figma',
+        url: 'https://www.figma.com/file/d8bTgEx7h694MSesi2CTLF/Tegel-UI-Library?node-id=2147%3A99321&t=Ne6myqwca5m00de7-1',
+      },
+      {
+        name: 'Link',
+        type: 'link',
+        url: 'https://www.figma.com/file/d8bTgEx7h694MSesi2CTLF/Tegel-UI-Library?node-id=2147%3A99321&t=Ne6myqwca5m00de7-1',
+      },
+    ],
+  },
+  argTypes: {
+    disabled: {
+      name: 'Disabled',
+      description: 'Display link in disabled state',
+      controls: {
+        type: 'boolean',
+      },
+    },
+    underline: {
+      name: 'Underline',
+      description: 'Underline under link text.',
+      controls: {
+        type: 'boolean',
+      },
+    },
+    target: {
+      name: 'Target',
+      description: 'Where to open the linked URL.',
+      control: {
+        type: 'radio',
+      },
+      options: ['_self', '_blank', '_parent', '_top'],
+    },
+  },
+  args: {
+    disabled: false,
+    underline: true,
+    target: '_self',
+  },
+};
+
+const Template = ({ disabled, underline, target }) =>
+  formatHtmlPreview(
+    `<sdds-link
+        ${disabled ? 'disabled' : ''}
+        ${underline ? '' : 'underline="false"'}
+        href="https://tegel.scania.com"
+        target="${target}"
+        >
+        Link
+    </sdds-link>
+    <script>
+        document.addEventListener('sddsLinkClickedEvent', (e) => {
+            console.log('Link with id: ', event.detail.linkId, ' and href:', event.detail.href, 'was clicked.')
+        })
+    </script>
+  `,
+  );
+export const WebComponent = Template.bind({});

--- a/tegel/src/components/link/sdds-link.tsx
+++ b/tegel/src/components/link/sdds-link.tsx
@@ -1,16 +1,13 @@
-import { Component, h, Prop, Event, EventEmitter } from '@stencil/core';
+import { Component, h, Prop } from '@stencil/core';
 
 @Component({
   tag: 'sdds-link',
   styleUrl: 'sdds-link.scss',
-  shadow: true,
+  shadow: false,
 })
 export class SddsLink {
   /** URL for the link */
   @Prop() linkHref: string;
-
-  /** ID for the link. Randomly generated if not specified. */
-  @Prop() linkId: string = crypto.randomUUID();
 
   /** Where to open the linked URL */
   @Prop() target: '_self' | '_blank' | '_parent' | '_top' = '_self';
@@ -24,27 +21,9 @@ export class SddsLink {
   /** 'noopener' is a security measure for legacy browsers that preventsthe opened page from getting access to the original page when using target='_blank'. */
   @Prop() rel: string = 'noopener';
 
-  /** Sends unique link identifier and href when it is clicked */
-  @Event({
-    eventName: 'sddsLinkClickedEvent',
-    composed: true,
-    cancelable: true,
-    bubbles: true,
-  })
-  sddsLinkClickedEvent: EventEmitter<{
-    href: string;
-    id: string;
-  }>;
-
   render() {
     return (
       <a
-        onClick={() => {
-          this.sddsLinkClickedEvent.emit({
-            href: this.linkHref,
-            id: this.linkId,
-          });
-        }}
         class={`
         ${this.disabled ? 'disabled' : ''}
         ${this.underline ? '' : 'no-underline'}

--- a/tegel/src/components/link/sdds-link.tsx
+++ b/tegel/src/components/link/sdds-link.tsx
@@ -24,17 +24,6 @@ export class SddsLink {
   /** The relationship of the linked URL as space-separated link types. */
   @Prop() rel: string = 'noopener';
 
-  /** How much of the referrer to send when following the link. */
-  @Prop() referrerpolicy:
-    | 'no-referrer'
-    | 'no-referrer-when-downgrade'
-    | 'origin'
-    | 'origin-when-cross-origin'
-    | 'same-origin'
-    | 'strict-origin'
-    | 'strict-origin-when-cross-origin'
-    | 'unsafe-url';
-
   /** Sends unique link identifier and href when it is clicked */
   @Event({
     eventName: 'sddsLinkClickedEvent',
@@ -64,7 +53,6 @@ export class SddsLink {
         href={this.href}
         target={this.target}
         rel={this.rel}
-        referrerPolicy={this.referrerpolicy}
       >
         <slot></slot>
       </a>

--- a/tegel/src/components/link/sdds-link.tsx
+++ b/tegel/src/components/link/sdds-link.tsx
@@ -7,7 +7,7 @@ import { Component, h, Prop, Event, EventEmitter } from '@stencil/core';
 })
 export class SddsLink {
   /** URL for the link */
-  @Prop() href: string;
+  @Prop() linkHref: string;
 
   /** ID for the link. Randomly generated if not specified. */
   @Prop() linkId: string = crypto.randomUUID();
@@ -21,7 +21,7 @@ export class SddsLink {
   /** Displays the link without an underline. */
   @Prop() underline: boolean = true;
 
-  /** The relationship of the linked URL as space-separated link types. */
+  /** 'noopener' is a security measure for legacy browsers that preventsthe opened page from getting access to the original page when using target='_blank'. */
   @Prop() rel: string = 'noopener';
 
   /** Sends unique link identifier and href when it is clicked */
@@ -41,7 +41,7 @@ export class SddsLink {
       <a
         onClick={() => {
           this.sddsLinkClickedEvent.emit({
-            href: this.href,
+            href: this.linkHref,
             id: this.linkId,
           });
         }}
@@ -50,7 +50,7 @@ export class SddsLink {
         ${this.underline ? '' : 'no-underline'}
         
         `}
-        href={this.href}
+        href={this.linkHref}
         target={this.target}
         rel={this.rel}
       >

--- a/tegel/src/components/link/sdds-link.tsx
+++ b/tegel/src/components/link/sdds-link.tsx
@@ -1,0 +1,73 @@
+import { Component, h, Prop, Event, EventEmitter } from '@stencil/core';
+
+@Component({
+  tag: 'sdds-link',
+  styleUrl: 'sdds-link.scss',
+  shadow: true,
+})
+export class SddsLink {
+  /** URL for the link */
+  @Prop() href: string;
+
+  /** ID for the link. Randomly generated if not specified. */
+  @Prop() linkId: string = crypto.randomUUID();
+
+  /** Where to open the linked URL */
+  @Prop() target: '_self' | '_blank' | '_parent' | '_top' = '_self';
+
+  /** Disables the link */
+  @Prop() disabled: boolean = false;
+
+  /** Displays the link without an underline. */
+  @Prop() underline: boolean = true;
+
+  /** The relationship of the linked URL as space-separated link types. */
+  @Prop() rel: string = 'noopener';
+
+  /** How much of the referrer to send when following the link. */
+  @Prop() referrerpolicy:
+    | 'no-referrer'
+    | 'no-referrer-when-downgrade'
+    | 'origin'
+    | 'origin-when-cross-origin'
+    | 'same-origin'
+    | 'strict-origin'
+    | 'strict-origin-when-cross-origin'
+    | 'unsafe-url';
+
+  /** Sends unique link identifier and href when it is clicked */
+  @Event({
+    eventName: 'sddsLinkClickedEvent',
+    composed: true,
+    cancelable: true,
+    bubbles: true,
+  })
+  sddsLinkClickedEvent: EventEmitter<{
+    href: string;
+    id: string;
+  }>;
+
+  render() {
+    return (
+      <a
+        onClick={() => {
+          this.sddsLinkClickedEvent.emit({
+            href: this.href,
+            id: this.linkId,
+          });
+        }}
+        class={`
+        ${this.disabled ? 'disabled' : ''}
+        ${this.underline ? '' : 'no-underline'}
+        
+        `}
+        href={this.href}
+        target={this.target}
+        rel={this.rel}
+        referrerPolicy={this.referrerpolicy}
+      >
+        <slot></slot>
+      </a>
+    );
+  }
+}


### PR DESCRIPTION
**Describe pull-request**  
Webcomponent version of link. Also renamed native story.

Removed shadowDOM in order to handle visited state.

**Solving issue**  
Fixes: [AB#3163](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3163)

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Link -> Webcomponents
3. Check that the style is correct.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events



**Screenshots**  


**Additional context**  

