### PR TITLE
fix(): dark mode default in divider, footer, header, side-menu and sl…

### DIFF
--- a/tegel/src/components/divider/divider-theme-vars.scss
+++ b/tegel/src/components/divider/divider-theme-vars.scss
@@ -4,11 +4,9 @@ $border-types: top, right, bottom, left;
 .sdds-theme-light {
   --sdds-divider-background: var(--sdds-grey-300);
 }
-:root,
 .sdds-theme-dark {
   --sdds-divider-background: var(--sdds-grey-700);
 }
-:root,
 .sdds-theme-colored {
   --sdds-divider-background: var(--sdds-blue-700);
 }

--- a/tegel/src/components/footer/footer-theme-vars.scss
+++ b/tegel/src/components/footer/footer-theme-vars.scss
@@ -15,7 +15,6 @@
   --sdds-footer-main-copyright: rgb(255 255 255 / 60%);
 }
 
-:root,
 .sdds-theme-dark {
   --sdds-footer-top-background: var(--sdds-grey-868);
   --sdds-footer-top-divider: var(--sdds-grey-300);

--- a/tegel/src/components/header/header-theme-vars.scss
+++ b/tegel/src/components/header/header-theme-vars.scss
@@ -104,7 +104,6 @@
   --sdds-header-mobile-avatar--item-btn-color: var(--sdds-grey-958);
 }
 
-:root,
 .sdds-theme-dark {
   --sdds-header-background: var(--sdds-blue-900);
 

--- a/tegel/src/components/side-menu/side-menu-theme-vars.scss
+++ b/tegel/src/components/side-menu/side-menu-theme-vars.scss
@@ -24,7 +24,6 @@
   --sdds-sidebar-side-menu-subnav-backgrund: var(--sdds-white);
 }
 
-:root,
 .sdds-theme-dark {
   --sdds-sidebar-mobile-menu-btn-hover: var(--sdds-blue-700);
   --sdds-sidebar-mobile-menu-btn-icon: var(--sdds-white);

--- a/tegel/src/components/slider/slider-theme-vars.scss
+++ b/tegel/src/components/slider/slider-theme-vars.scss
@@ -15,7 +15,6 @@
 
 
 }
-:root,
 .sdds-theme-dark {
     --sdds-slider-label-color: var(--sdds-grey-100);
     --sdds-slider-label-color-disabled: var(--sdds-grey-700);


### PR DESCRIPTION
**Describe pull-request**  
Dark mode was accidentally default in divider, footer, header, side-menu and slider. 

**Solving issue**  
Fixes: [AB#3168](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3168)
