### PR TITLE
fix(button): only icon button

### DIFF
--- a/tegel/src/components/button/button-component.tsx
+++ b/tegel/src/components/button/button-component.tsx
@@ -1,4 +1,5 @@
-import { Component, h, Host, Prop, State } from '@stencil/core';
+import { Component, Element, h, Host, Prop, State } from '@stencil/core';
+import { HostElement } from '@stencil/core/internal';
 
 @Component({
   tag: 'sdds-button',
@@ -26,9 +27,12 @@ export class SddsButton {
 
   @State() onlyIcon: boolean = false;
 
+  @Element() host: HostElement;
+
   componentWillLoad() {
     if (this.text === '') {
       this.onlyIcon = true;
+      this.host.setAttribute('only-icon', '');
     }
   }
 

--- a/tegel/src/components/button/button-native.stories.tsx
+++ b/tegel/src/components/button/button-native.stories.tsx
@@ -111,7 +111,7 @@ export default {
         type: 'radio',
       },
       options: ['Native', 'Web Component'],
-      if: { arg: 'icon', neq: 'none' },
+      if: { arg: 'size', neq: 'Extra small' },
     },
   },
   args: {
@@ -154,8 +154,8 @@ const NativeTemplate = ({
   };
 
   const modeVariantLookup = {
-    'Primary': 'primary',
-    'Secondary': 'secondary',
+    Primary: 'primary',
+    Secondary: 'secondary',
   };
 
   return formatHtmlPreview(
@@ -175,9 +175,11 @@ const NativeTemplate = ({
   </style>
 
   <div class="demo-wrapper">
-<button class="sdds-btn sdds-btn-${btnTypeLookUp[btnType]} ${modeVariant !== 'Inherit from parent' ? `sdds-mode-variant-${modeVariantLookup[modeVariant]}`: ''} sdds-btn-${
-      sizeLookUp[size]
-    } ${fbClass} ${disabled ? 'disabled' : ''} ${onlyIconCss} 
+<button class="sdds-btn sdds-btn-${btnTypeLookUp[btnType]} ${
+      modeVariant !== 'Inherit from parent'
+        ? `sdds-mode-variant-${modeVariantLookup[modeVariant]}`
+        : ''
+    } sdds-btn-${sizeLookUp[size]} ${fbClass} ${disabled ? 'disabled' : ''} ${onlyIconCss} 
    ${onlyIcon ? 'sdds-btn-only-icon' : ''}">
   ${!onlyIcon ? `<span class="sdds-btn-text">${text}</span>` : ''}
   ${

--- a/tegel/src/components/button/button-webcomponent.stories.tsx
+++ b/tegel/src/components/button/button-webcomponent.stories.tsx
@@ -172,11 +172,11 @@ const WebComponentTemplate = ({
   </style>
 
   <div class="demo-wrapper">
-  <sdds-button ${modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariantLookup[modeVariant]}"`: ''} ${onlyIcon ? 'onlyIcon' : ''} type="${btnTypeLookUp[btnType]}" size="${
-      sizeLookUp[size]
-    }" ${disabled ? 'disabled' : ''} ${fullbleed ? 'fullbleed' : ''} text="${
-      onlyIcon ? '' : text
-    }" >
+  <sdds-button type="${btnTypeLookUp[btnType]}" size="${sizeLookUp[size]}" ${
+      disabled ? 'disabled' : ''
+    } ${fullbleed ? 'fullbleed' : ''}
+    ${!onlyIcon ? `text="${text}"` : ''}
+    text="${onlyIcon ? '' : text}" variant="${modeVariantLookup[modeVariant]}" >
     ${
       onlyIcon || (icon && icon !== 'none')
         ? `

--- a/tegel/src/components/button/button-webcomponent.stories.tsx
+++ b/tegel/src/components/button/button-webcomponent.stories.tsx
@@ -110,7 +110,7 @@ export default {
         type: 'radio',
       },
       options: ['Native', 'Web Component'],
-      if: { arg: 'icon', neq: 'none' },
+      if: { arg: 'size', neq: 'Extra small' },
     },
   },
   args: {
@@ -151,8 +151,8 @@ const WebComponentTemplate = ({
   };
 
   const modeVariantLookup = {
-    'Primary': 'primary',
-    'Secondary': 'secondary',
+    Primary: 'primary',
+    Secondary: 'secondary',
   };
 
   return formatHtmlPreview(
@@ -176,7 +176,13 @@ const WebComponentTemplate = ({
       disabled ? 'disabled' : ''
     } ${fullbleed ? 'fullbleed' : ''}
     ${!onlyIcon ? `text="${text}"` : ''}
-    text="${onlyIcon ? '' : text}" variant="${modeVariantLookup[modeVariant]}" >
+    text="${onlyIcon ? '' : text}" 
+    ${
+      modeVariant !== 'Inherit from parent'
+        ? `mode-variant="${modeVariantLookup[modeVariant]}"`
+        : ''
+    }
+    >
     ${
       onlyIcon || (icon && icon !== 'none')
         ? `

--- a/tegel/src/components/button/button.scss
+++ b/tegel/src/components/button/button.scss
@@ -328,7 +328,7 @@ i.sdds-btn-icon[slot='icon'] {
   justify-content: center;
 }
 
-:host(sdds-button[onlyIcon]) {
+:host(sdds-button[only-icon]) {
   .sdds-btn-sm {
     padding: $btn-sm-only-icon-padding;
   }
@@ -342,7 +342,7 @@ i.sdds-btn-icon[slot='icon'] {
   }
 }
 
-:host(sdds-button:not([onlyIcon])) {
+:host(sdds-button:not([only-icon])) {
   display: flex;
   align-items: center;
 


### PR DESCRIPTION
**Describe pull-request**  
Corrected the css selector for the only-icon button. Also removed the prop onlyIcon being set in the story, this prop doesn't exist. It is an internal state that is set based on the text value. The old way would lead to the component not being rendered properly.

**Solving issue**  
Fixes: - Found this issue when I was implementing the button in the banner component.

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Button -> Web Component Only Icon
3. Check that no prop is being set if only icon is true and that the component renders as i it should-

**Screenshots**  
-

**Additional context**  
-
