### PR TITLE
fix(tooltip): moved comment out of element to not break story

### DIFF
--- a/tegel/src/components/tooltip/tooltip.stories.tsx
+++ b/tegel/src/components/tooltip/tooltip.stories.tsx
@@ -120,4 +120,4 @@ const ComponentTooltip = ({ tooltipPosition, mouseOverTooltip, text, slot }) =>
   `,
   );
 
-export const Default = ComponentTooltip.bind({});
+export const WebComponent = ComponentTooltip.bind({});

--- a/tegel/src/components/tooltip/tooltip.stories.tsx
+++ b/tegel/src/components/tooltip/tooltip.stories.tsx
@@ -104,9 +104,10 @@ const ComponentTooltip = ({ tooltipPosition, mouseOverTooltip, text, slot }) =>
     </style>
 
    <div class="demo-wrapper">
+   <!-- The 'referenceEl' prop can be used instead of 'selector',
+    which might be preferable in frameworks like React -->
    <sdds-tooltip
       placement="${positionLookup[tooltipPosition]}"
-      <!-- The 'referenceEl' prop can be used instead, wich might be preferable in frameworks like React -->
       selector="#button-1"
       text="${text}"
       mouse-over-tooltip="${mouseOverTooltip}">


### PR DESCRIPTION
**Describe pull-request**  
The tooltip-story was broken due to a comment in the html-element. Moved it above it.

**Solving issue**  
Fixes: -

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Tooltip
3. Check that the story works.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

**Screenshots**  
-

**Additional context**  
-
