### PR TITLE
fix(textarea & textfield) error state and aligned props

### DIFF
--- a/tegel/src/components/icon/readme.md
+++ b/tegel/src/components/icon/readme.md
@@ -20,6 +20,7 @@
  - [sdds-message](../message)
  - [sdds-modal](../modal)
  - [sdds-textarea](../textarea)
+ - [sdds-textfield](../textfield)
 
 ### Graph
 ```mermaid
@@ -29,6 +30,7 @@ graph TD;
   sdds-message --> sdds-icon
   sdds-modal --> sdds-icon
   sdds-textarea --> sdds-icon
+  sdds-textfield --> sdds-icon
   style sdds-icon fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/tegel/src/components/textarea/readme.md
+++ b/tegel/src/components/textarea/readme.md
@@ -10,7 +10,7 @@
 | `autoFocus`     | `auto-focus`     | Control of autofocus                                         | `boolean`                             | `false`      |
 | `cols`          | `cols`           | Textarea cols attribute                                      | `number`                              | `undefined`  |
 | `disabled`      | `disabled`       | Set input in disabled state                                  | `boolean`                             | `false`      |
-| `helper`        | `helper`         | Helper text                                                  | `string`                              | `''`         |
+| `helper`        | `helper`         | Helper text                                                  | `string`                              | `undefined`  |
 | `label`         | `label`          | Label text                                                   | `string`                              | `''`         |
 | `labelPosition` | `label-position` | Position of the label for the textfield.                     | `"inside" \| "no-label" \| "outside"` | `'no-label'` |
 | `maxLength`     | `max-length`     | Max length of input                                          | `number`                              | `undefined`  |

--- a/tegel/src/components/textarea/textarea.scss
+++ b/tegel/src/components/textarea/textarea.scss
@@ -221,7 +221,9 @@
 .sdds-textarea-helper {
   font: var(--sdds-detail-05);
   letter-spacing: var(--sdds-detail-05-ls);
-  display: block;
+  display: flex;
+  gap: 8px;
+  align-items: center;
   padding-top: var(--sdds-spacing-element-4);
   color: var(--sdds-textarea-helper);
   flex-grow: 2;

--- a/tegel/src/components/textarea/textarea.tsx
+++ b/tegel/src/components/textarea/textarea.tsx
@@ -16,7 +16,7 @@ export class Textarea {
   @Prop() name: string = '';
 
   /** Helper text */
-  @Prop() helper: string = '';
+  @Prop() helper: string;
 
   /** Textarea cols attribute */
   @Prop() cols: number;
@@ -134,11 +134,15 @@ export class Textarea {
             </svg>
           </span>
           <span class="sdds-textarea-icon__readonly">
-          <sdds-icon name="edit_inactive"></sdds-icon>
+            <sdds-icon name="edit_inactive"></sdds-icon>
           </span>
           <span class="sdds-textarea-icon__readonly-label">This field is non-editable</span>
         </div>
-        {this.helper.length > 0 && <span class={'sdds-textarea-helper'}>{this.helper}</span>}
+        <span class={'sdds-textarea-helper'}>
+          {this.state === 'error' && <sdds-icon name="error" size="16px"></sdds-icon>}
+          {this.helper}
+        </span>
+
         {this.maxLength > 0 && (
           <div class={'sdds-textarea-textcounter'}>
             {this.value === null ? 0 : this.value?.length}

--- a/tegel/src/components/textfield/readme.md
+++ b/tegel/src/components/textfield/readme.md
@@ -9,6 +9,7 @@
 | --------------- | ---------------- | ------------------------------------------------------------ | ------------------------------------- | ------------ |
 | `autofocus`     | `autofocus`      | Autofocus for input                                          | `boolean`                             | `false`      |
 | `disabled`      | `disabled`       | Set input in disabled state                                  | `boolean`                             | `false`      |
+| `helper`        | `helper`         | Helper text                                                  | `string`                              | `undefined`  |
 | `label`         | `label`          | Label text                                                   | `string`                              | `''`         |
 | `labelPosition` | `label-position` | Position of the label for the textfield.                     | `"inside" \| "no-label" \| "outside"` | `'no-label'` |
 | `maxLength`     | `max-length`     | Max length of input                                          | `number`                              | `undefined`  |
@@ -29,6 +30,19 @@
 | -------------- | ------------------------------ | ------------------ |
 | `customChange` | Change event for the textfield | `CustomEvent<any>` |
 
+
+## Dependencies
+
+### Depends on
+
+- [sdds-icon](../icon)
+
+### Graph
+```mermaid
+graph TD;
+  sdds-textfield --> sdds-icon
+  style sdds-textfield fill:#f9f,stroke:#333,stroke-width:4px
+```
 
 ----------------------------------------------
 

--- a/tegel/src/components/textfield/textfield-theme-vars.scss
+++ b/tegel/src/components/textfield/textfield-theme-vars.scss
@@ -28,10 +28,10 @@
   --sdds-textfield-border-bottom-success: var(--sdds-grey-800);
 
   //error
-  --sdds-textfield-border-bottom-error: var(--sdds-red-500);
-  --sdds-textfield-helper-error: var(--sdds-red-500);
-  --sdds-textfield-bar-error: var(--sdds-red-500);
-  --sdds-textfield-icon-error: var(--sdds-red-500);
+  --sdds-textfield-border-bottom-error: var(--sdds-negative);
+  --sdds-textfield-helper-error: var(--sdds-negative);
+  --sdds-textfield-bar-error: var(--sdds-negative);
+  --sdds-textfield-icon-error: var(--sdds-negative);
 
   //Textcounter
   --sdds-textfield-textcounter: var(--sdds-grey-700);
@@ -51,16 +51,15 @@
   //White background
   --sdds-textfield-on-white-background: var(--sdds-grey-50);
 
-    // Read only
-    --sdds-textfield-icon-read-only-color: var(--sdds-grey-600);
-    --sdds-textfield-icon-read-only-label-color: var(--sdds-grey-800);
+  // Read only
+  --sdds-textfield-icon-read-only-color: var(--sdds-grey-600);
+  --sdds-textfield-icon-read-only-label-color: var(--sdds-grey-800);
 }
 
 .sdds-theme-dark {
   --sdds-textfield-color: var(--sdds-grey-200);
   --sdds-textfield-background: var(--sdds-grey-900);
   --sdds-textfield-placeholder: var(--sdds-grey-600);
-
   --sdds-textfield-border-bottom: var(--sdds-grey-400);
   --sdds-textfield-border-bottom-hover: var(--sdds-grey-600);
 
@@ -71,10 +70,9 @@
   --sdds-textfield-disabled-placeholder: var(--sdds-grey-800);
   --sdds-textfield-disabled-label: var(--sdds-grey-700);
 
-  
   // Label
   --sdds-textfield-label-color: var(--sdds-grey-100);
-  --sdds-textfield-label-inside-color: var(--sdds-grey-400);  
+  --sdds-textfield-label-inside-color: var(--sdds-grey-400);
   --sdds-textfield-placeholder-focus-color: var(--sdds-grey-700);
 
   //Highlight bar
@@ -82,7 +80,6 @@
 
   //helper
   --sdds-textfield-helper: var(--sdds-grey-600);
-
 
   //error
   --sdds-textfield-helper-error: var(--sdds-negative);
@@ -108,7 +105,7 @@
   --sdds-textfield-border-bottom-success: var(--sdds-grey-400);
   --sdds-textfield-border-bottom-error: var(--sdds-negative);
 
-    // Read only
-    --sdds-textfield-icon-read-only-color: var(--sdds-grey-100);
-    --sdds-textfield-icon-read-only-label-color: var(--sdds-grey-50);
+  // Read only
+  --sdds-textfield-icon-read-only-color: var(--sdds-grey-100);
+  --sdds-textfield-icon-read-only-label-color: var(--sdds-grey-50);
 }

--- a/tegel/src/components/textfield/textfield.scss
+++ b/tegel/src/components/textfield/textfield.scss
@@ -268,6 +268,7 @@
   font: var(--sdds-detail-05);
   letter-spacing: var(--sdds-detail-05-ls);
   display: flex;
+  gap: 8px;
   justify-content: space-between;
 
   & .sdds-textfield-textcounter {
@@ -326,8 +327,7 @@
     padding: 8px;
     white-space: nowrap;
     border-radius: 4px 0 4px 4px;
-  background-color: var(--sdds-textfield-icon-read-only-label-background);
-
+    background-color: var(--sdds-textfield-icon-read-only-label-background);
   }
 }
 
@@ -383,11 +383,8 @@
 // .sdds-textfield-textcounter {
 .sdds-textfield-helper-error-state {
   display: flex;
+  gap: 8px;
   flex-wrap: nowrap;
-
-  svg {
-    margin-right: 8px;
-  }
 }
 
 .sdds-textfield-textcounter {

--- a/tegel/src/components/textfield/textfield.stories.tsx
+++ b/tegel/src/components/textfield/textfield.stories.tsx
@@ -141,7 +141,7 @@ export default {
         type: 'radio',
       },
       options: ['Default', 'Success', 'Error'],
-    }
+    },
   },
   args: {
     placeholderText: 'Placeholder',
@@ -204,6 +204,7 @@ const Template = ({
       state="${stateValue}"
       label="${label}"
       label-position="${labelPosition.toLowerCase()}"
+      ${helper ? `helper="${helper}"` : ''}
       ${maxlength}
       ${disabled ? 'disabled' : ''}
       ${readonly ? 'readonly' : ''}
@@ -217,7 +218,6 @@ const Template = ({
         </span>`
             : ''
         }
-        ${helper ? `<span slot='sdds-helper'>${helper}</span>` : ''}
         ${
           suffix
             ? `

--- a/tegel/src/components/textfield/textfield.tsx
+++ b/tegel/src/components/textfield/textfield.tsx
@@ -18,6 +18,9 @@ export class Textfield {
   /** Label text */
   @Prop() label: string = '';
 
+  /** Helper text */
+  @Prop() helper: string;
+
   /** Placeholder text */
   @Prop() placeholder: string = '';
 
@@ -159,60 +162,19 @@ export class Textfield {
             <slot name="sdds-suffix" />
           </div>
           <span class="sdds-textfield-icon__readonly">
-          <svg
-            
-            width="20"
-            height="20"
-            viewBox="0 0 20 20"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              fill-rule="evenodd"
-              clip-rule="evenodd"
-              d="M13.6242 10.7946L17.1365 7.28228C17.6247 6.79412 17.6247 6.00266 17.1365 5.5145L14.485 2.86295C13.9968 2.37479 13.2054 2.37479 12.7172 2.86295L9.20483 6.3753L10.0887 7.25919L11.3914 5.95654L14.0429 8.6081L12.7403 9.91075L13.6242 10.7946ZM13.6011 3.74684L16.2526 6.39839L14.9268 7.72421L12.2753 5.07265L13.6011 3.74684Z"
-              fill="currentColor"
-            />
-            <path
-              d="M7.43707 9.91075L5.00974 12.3381L4.01561 15.9837L7.6613 14.9896L10.0886 12.5623L10.9725 13.4462L8.54519 15.8735C8.39136 16.0274 8.20004 16.1384 7.99014 16.1956L3.28932 17.4774C3.07294 17.5364 2.84154 17.475 2.68295 17.3164C2.52436 17.1578 2.46291 16.9264 2.52191 16.71L3.80377 12.0092C3.861 11.7993 3.97202 11.608 4.12585 11.4542L6.55318 9.02686L7.43707 9.91075Z"
-              fill="currentColor"
-            />
-            <path
-              fill-rule="evenodd"
-              clip-rule="evenodd"
-              d="M1.43306 1.43306C1.67714 1.18898 2.07287 1.18898 2.31695 1.43306L18.5671 17.6832C18.8112 17.9273 18.8112 18.323 18.5671 18.5671C18.323 18.8112 17.9273 18.8112 17.6832 18.5671L1.43306 2.31695C1.18898 2.07287 1.18898 1.67714 1.43306 1.43306Z"
-              fill="currentColor"
-            />
-          </svg>
-</span>
+            <sdds-icon name="edit_inactive" size="20px"></sdds-icon>
+          </span>
           <span class="sdds-textfield-icon__readonly-label">This field is non-editable</span>
         </div>
 
         <div class="sdds-textfield-helper">
           {this.state === 'error' && (
             <div class="sdds-textfield-helper-error-state">
-              <svg
-                width="16"
-                height="16"
-                viewBox="0 0 16 16"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  fill-rule="evenodd"
-                  clip-rule="evenodd"
-                  d="M8 2.00015C4.6853 2.00015 1.9982 4.68725 1.9982 8.00195C1.9982 11.3167 4.6853 14.0038 8 14.0038C11.3147 14.0038 14.0018 11.3167 14.0018 8.00195C14.0018 4.68725 11.3147 2.00015 8 2.00015ZM1 8.00195C1 4.13596 4.13401 1.00195 8 1.00195C11.866 1.00195 15 4.13596 15 8.00195C15 11.8679 11.866 15.002 8 15.002C4.13401 15.002 1 11.8679 1 8.00195Z"
-                  fill="currentColor"
-                />
-                <path
-                  d="M7.4014 7.2352V5H8.5894V7.2352L8.4134 9.3824H7.5774L7.4014 7.2352ZM7.375 10.0512H8.6246V11.248H7.375V10.0512Z"
-                  fill="currentColor"
-                />
-              </svg>
-              <slot name="sdds-helper" />
+              <sdds-icon name="error" size="16px"></sdds-icon>
+              {this.helper}
             </div>
           )}
-          {this.state !== 'error' && <slot name="sdds-helper" />}
+          {this.state !== 'error' && this.helper}
 
           {this.maxLength > 0 && (
             <div class="sdds-textfield-textcounter">

--- a/tegel/src/stories/Migration/Migration.stories.mdx
+++ b/tegel/src/stories/Migration/Migration.stories.mdx
@@ -718,6 +718,30 @@ Rename all instances of `nominwidth` to `no-min-width`.
 ></sdds-textfield>
 ```
 
+
+#### Removed slot for helper and added `helper` prop
+
+Previously the textfield has had its helper text set via a slot. This is now changed
+to be a prop instead, to align with other components.
+
+##### What action is required?
+
+Change all instaces of `<span slot='sdds-helper'>${helper}</span>` to attrubute
+`helper="${helper}"`
+
+```jsx
+// Old ❌
+<sdds-textfield
+>
+  <span slot='sdds-helper'>Helper text!</span>
+</sdds-textfield>
+
+// New ✅
+<sdds-textfield
+    helper="Helper text"
+></sdds-textfield>
+```
+
 ## Toast
 
 #### Changed class name 'sdds-toast-dismiss' to 'sdds-toast-close'


### PR DESCRIPTION
**Describe pull-request**  
This PR adds a error icon to the textarea when it is set to the error state. This PR also removes the slot `sdds-helper` and instead introduces the value as a prop for the **textfield**, like it is in other components. Also changed the error state colors on the textfield-

**Solving issue**  
Fixes: [AB#3169](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3169)

**How to test - 1**  
1. Go to storybook link below.
2. Check in Components -> Textarea
3. Set the component to error state and check that the design is correct.

**How to test - 2**  
1. Go to storybook link below.
2. Check in Components -> Textfield
3. Add an helper text to the component and check that it is rendered correctly.
4. Check out the breaking changes description in the migration docs.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

**Screenshots**  
-

**Additional context**  
-
