### PR TITLE
feat(chip): renamed classes to align with convention

### DIFF
--- a/tegel/src/components/chips/chips.scss
+++ b/tegel/src/components/chips/chips.scss
@@ -42,7 +42,7 @@ button.sdds-chip {
     }
   }
 
-  &__active {
+  &-active {
     color: var(--sdds-chips-color-active);
     background-color: var(--sdds-chips-background-active);
 
@@ -58,11 +58,11 @@ button.sdds-chip {
   }
 
   &-sm,
-  &__small {
+  &-small {
     padding: 4px 16px;
   }
 
-  &__icon-left {
+  &-icon-left {
     padding-left: 32px;
 
     .sdds-chip-icon {
@@ -70,7 +70,7 @@ button.sdds-chip {
     }
   }
 
-  &__icon-right {
+  &-icon-right {
     padding-right: 32px;
     flex-flow: row-reverse;
 

--- a/tegel/src/components/chips/chips.stories.tsx
+++ b/tegel/src/components/chips/chips.stories.tsx
@@ -78,11 +78,11 @@ export default {
 };
 
 const Template = ({ icon, iconPosition, iconType, state, placeholderText, size }) => {
-  const stateValue = state === 'Active' ? 'sdds-chip__active' : '';
+  const stateValue = state === 'Active' ? 'sdds-chip-active' : '';
   const sizeValue = size === 'Small' ? 'sdds-chip-sm' : '';
   const iconPositionLookup = {
-    'Icon left': 'sdds-chip__icon-left',
-    'Icon right': 'sdds-chip__icon-right',
+    'Icon left': 'sdds-chip-icon-left',
+    'Icon right': 'sdds-chip-icon-right',
   };
 
   // TODO - Add dark theme to story
@@ -114,27 +114,4 @@ const Template = ({ icon, iconPosition, iconType, state, placeholderText, size }
     `);
 };
 
-export const Default = Template.bind({});
-Default.args = {};
-
-export const IconRight = Template.bind({});
-IconRight.args = {
-  icon: true,
-  iconPosition: 'Icon right',
-};
-
-export const IconLeft = Template.bind({});
-IconLeft.args = {
-  icon: true,
-  iconPosition: 'Icon left',
-};
-
-export const Active = Template.bind({});
-Active.args = {
-  state: 'Active',
-};
-
-export const Small = Template.bind({});
-Small.args = {
-  size: 'Small',
-};
+export const Native = Template.bind({});

--- a/tegel/src/stories/Migration/Migration.stories.mdx
+++ b/tegel/src/stories/Migration/Migration.stories.mdx
@@ -325,6 +325,46 @@ Rename all instances of `sdds-chip__small` to `sdds-chip-sm`.
 </div>
 ```
 
+#### Renamed class to `sdds-chip-active`
+
+The class `sdds-chip__active` was changed to `sdds-chip-active` to conform with other class names.
+
+##### What action is required?
+
+Rename all instances of `sdds-chip__active` to `sdds-chip-active`.
+
+```jsx
+// Old ❌
+<div class="sdds-chip sdds-chip__small">
+  <span class="sdds-chip-text">Chip text</span>
+</div>
+
+// New ✅
+<div class="sdds-chip sdds-chip-active">
+  <span class="sdds-chip-text">Chip text</span>
+</div>
+```
+
+#### Renamed classes to `sdds-chip-icon-right`/`sdds-chip-icon-left`
+
+The classes `sdds-chip__icon-right`/`sdds-chip__icon-left` was changed to `sdds-chip-icon-right`/`sdds-chip-icon-left` to conform with other class names.
+
+##### What action is required?
+
+Rename all instances of `sdds-chip__icon-right`/`sdds-chip__icon-left` to `sdds-chip-icon-right`/`sdds-chip-icon-left`.
+
+```jsx
+// Old ❌
+<div class="sdds-chip sdds-chip__icon-right">
+  <span class="sdds-chip-text">Chip text</span>
+</div>
+
+// New ✅
+<div class="sdds-chip sdds-chip-icon-right">
+  <span class="sdds-chip-text">Chip text</span>
+</div>
+```
+
 ## Divider
 
 [Native](/docs/components-divider--default)


### PR DESCRIPTION
BREAKING CHANGE: The classes __small, __active and __icon-right/left was renamed to conform with our convention of classnames

**Describe pull-request**  
The classes __small, __active and __icon-right/left was renamed to conform with our convention of classnames

**Solving issue**  
Fixes: -

**How to test**  
1. Go to storybook link below
2. Check in Components -> Chips -> Native
3. Check that the styling is correct and that the controls function as before.
4. Have a look at the Chip section in the migration docs.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

**Screenshots**  
-

**Additional context**  
-
