### PR TITLE
fix(inline-tabs): width of buttons

### DIFF
--- a/components/src/components/tabs/inline-tabs/inline-tabs.stories.js
+++ b/components/src/components/tabs/inline-tabs/inline-tabs.stories.js
@@ -52,7 +52,7 @@ const Template = ({ autoHeight = false, modeVariant }) => `
       This tab is disabled, so you should not be able to see this content.
     </div>
 
-    <div data-name="Tab 4">
+    <div data-name="Tab 4 with a very long name">
       Content for tab 4<br>
       here is some content...
     </div>

--- a/components/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/components/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -130,8 +130,7 @@ export class InlineTabs {
       navButton.style.width = '';
       const width = navButton.clientWidth;
       navButton.style.width = oldStyle;
-
-      if (navButton.clientWidth > best) {
+      if (width > best) {
         best = width;
       }
     });

--- a/components/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/components/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -154,6 +154,10 @@ export class InlineTabs {
     });
 
     this.tabHeight = best;
+
+    if (this.useAutoHeight) {
+      this.heightStyle = `${this.tabHeight}px`;
+    }
   }
 
   componentDidRender() {
@@ -281,10 +285,6 @@ export class InlineTabs {
   }
 
   render() {
-    if (this.useAutoHeight) {
-      this.heightStyle = `${this.tabHeight}px`;
-    }
-
     return (
       <Host>
         <div class={`sdds-inline-tabs sdds-inline-tabs-${this.modeVariant}`}>

--- a/components/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/components/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -34,6 +34,8 @@ export class InlineTabs {
   /** current calculated tab height (calculated from the one with the most height) */
   @State() tabHeight: number = 0;
 
+  @State() heightStyle: string;
+
   @State() showLeftScroll: boolean = false;
 
   @State() showRightScroll: boolean = false;
@@ -279,9 +281,8 @@ export class InlineTabs {
   }
 
   render() {
-    const heightStyle = {};
     if (this.useAutoHeight) {
-      heightStyle['height'] = `${this.tabHeight}px`;
+      this.heightStyle = `${this.tabHeight}px`;
     }
 
     return (
@@ -353,7 +354,7 @@ export class InlineTabs {
           <div
             ref={(el) => (this.tabWrapperElement = el as HTMLElement)}
             class="sdds-inline-tabs-main"
-            style={heightStyle}
+            style={{ height: `${this.heightStyle}`}}
           >
             <slot />
           </div>


### PR DESCRIPTION
**Describe pull-request**  
Fixed bug with buttons not being based on the widest one.

**Solving issue**  
Fixes: [AB#3291](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3291)

**How to test**  
1. Checkout branch
2. Run storybook for component package
3. Check that the button width for the inline tabs are based on the widest one.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

**Screenshots**  


**Additional context**  

