### PR TITLE
fix: mode variant add null and inherit from parent to components

### DIFF
--- a/tegel/src/components/accordion/accordion.tsx
+++ b/tegel/src/components/accordion/accordion.tsx
@@ -10,7 +10,7 @@ export class Accordion {
   @Prop() divider: boolean = true;
 
   /** Set the variant of the the accordion. */
-  @Prop() modeVariant: 'primary' | 'secondary' | null = null;
+  @Prop() modeVariant: 'primary' | 'secondary' = null;
 
   render() {
     return (

--- a/tegel/src/components/button/button-component.tsx
+++ b/tegel/src/components/button/button-component.tsx
@@ -23,7 +23,7 @@ export class SddsButton {
   @Prop() fullbleed: boolean = false;
 
   /** Set the mode variant of the the button. */
-  @Prop() modeVariant: 'primary' | 'secondary' | null = null;
+  @Prop() modeVariant: 'primary' | 'secondary' = null;
 
   @State() onlyIcon: boolean = false;
 

--- a/tegel/src/components/card/card.stories.tsx
+++ b/tegel/src/components/card/card.stories.tsx
@@ -150,9 +150,7 @@ const Template = ({
   }
 </style>
     <div class="demo-wrapper">
-          <div class="sdds-card${clickable ? ' sdds-clickable' : ''} ${
-      modeVariant !== 'Inherit from parent' ? `sdds-mode-variant-${modeVariant}` : ''
-    }">
+          <div class="sdds-card${clickable ? ' sdds-clickable' : ''} ${modeVariant === 'Inherit from parent' ? '' : `sdds-mode-variant-${modeVariant.toLowerCase()}`}">
             ${
               bodyImg === true && headerPlacement === 'Below'
                 ? `<img class="sdds-card-img" src="${CardPlaceholder}" alt="Add description to image"/>`

--- a/tegel/src/components/message/message-theme-vars.scss
+++ b/tegel/src/components/message/message-theme-vars.scss
@@ -8,8 +8,10 @@ html,
 
   .sdds-theme-light {
     --sdds-message-color: var(--sdds-grey-958);
-    --sdds-message-background: var(--sdds-grey-50);
+
+    --sdds-message-background-primary: var(--sdds-grey-50);
     --sdds-message-background-secondary: var(--sdds-white);
+    --sdds-message-background: var(--sdds-message-background-primary);
     --sdds-message-type-error-background: var(--sdds-red-50);
 
     .sdds-mode-variant-primary {

--- a/tegel/src/components/message/message.stories.tsx
+++ b/tegel/src/components/message/message.stories.tsx
@@ -26,13 +26,16 @@ export default {
       },
       options: ['Information', 'Error', 'Warning', 'Success'],
     },
-    variant: {
+    modeVariant: {
       name: 'Mode variant',
       description: 'The mode variant of the component',
       control: {
         type: 'radio',
       },
-      options: ['Primary', 'Secondary'],
+      options: ['Inherit from parent', 'Primary', 'Secondary'],
+      table: {
+        defaultValue: { summary: 'Inherit from parent' },
+      },
     },
     icon: {
       name: 'Icon',
@@ -60,7 +63,7 @@ export default {
   },
   args: {
     messageType: 'Information',
-    variant: 'Primary',
+    modeVariant: 'Inherit from parent',
     icon: false,
     iconType: 'Web Component',
     showExtendedMessage: false,
@@ -74,7 +77,7 @@ const nativeIconNameLookup = {
   Success: 'tick',
 };
 
-const Template = ({ messageType, icon, iconType, showExtendedMessage, variant }) => {
+const Template = ({ messageType, icon, iconType, showExtendedMessage, modeVariant }) => {
   const messageTypeClass =
     messageType === 'Information'
       ? 'sdds-message-type-informative'
@@ -83,7 +86,6 @@ const Template = ({ messageType, icon, iconType, showExtendedMessage, variant })
     messageType === 'Information'
       ? 'sdds-message-icon-informative'
       : `sdds-message-icon-${messageType.toLowerCase()}`;
-  const variantValue = variant === 'Secondary' ? 'sdds-mode-variant-secondary' : '';
   const iconHtml =
     iconType === 'Native'
       ? `<i class="sdds-message-icon sdds-icon ${iconClass} ${nativeIconNameLookup[messageType]}"></i>`
@@ -103,7 +105,8 @@ const Template = ({ messageType, icon, iconType, showExtendedMessage, variant })
 
     <div class="sdds-message ${messageTypeClass} ${icon ? 'sdds-message-icon-active' : ''} ${
       showExtendedMessage ? 'sdds-message-extended-active' : ''
-    } ${variantValue}">
+    } 
+    ${modeVariant === 'Inherit from parent' ? '' : `sdds-mode-variant-${modeVariant.toLowerCase()}`}">
     ${icon ? iconHtml : ''}
     <h4 class="sdds-message-single">
       Single line message goes here.

--- a/tegel/src/components/message/readme.md
+++ b/tegel/src/components/message/readme.md
@@ -11,7 +11,7 @@
 | ------------- | -------------- | ------------------------------------------------ | ---------------------------------------------------- | --------------- |
 | `header`      | `header`       | Header text for the component.                   | `string`                                             | `undefined`     |
 | `minimal`     | `minimal`      | Minimal message styling.                         | `boolean`                                            | `false`         |
-| `modeVariant` | `mode-variant` | Variant of the component, based on current mode. | `"primary" \| "secondary"`                           | `'primary'`     |
+| `modeVariant` | `mode-variant` | Variant of the component, based on current mode. | `"primary" \| "secondary"`                           | `null`          |
 | `noIcon`      | `no-icon`      | Removes the icon in the message.                 | `boolean`                                            | `false`         |
 | `type`        | `type`         | Type of message.                                 | `"error" \| "information" \| "success" \| "warning"` | `'information'` |
 

--- a/tegel/src/components/message/sdds-message.stories.tsx
+++ b/tegel/src/components/message/sdds-message.stories.tsx
@@ -37,9 +37,9 @@ export default {
       control: {
         type: 'radio',
       },
-      options: ['Primary', 'Secondary'],
+      options: ['Inherit from parent', 'Primary', 'Secondary'],
       table: {
-        defaultValue: { summary: 'primary' },
+        defaultValue: { summary: 'Inherit from parent' },
       },
     },
     header: {
@@ -78,7 +78,7 @@ export default {
   },
   args: {
     messageType: 'Information',
-    modeVariant: 'Primary',
+    modeVariant: 'Inherit from parent',
     header: 'Message header',
     noIcon: false,
     extendedMessage:
@@ -102,6 +102,7 @@ const Template = ({ messageType, noIcon, extendedMessage, modeVariant, header, m
           ${noIcon ? 'no-icon' : ''}
           ${minimal ? 'minimal' : ''}
           mode-variant="${modeVariant.toLowerCase()}"
+          ${modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"`: ''}
       >
       ${extendedMessage}
       </sdds-message>

--- a/tegel/src/components/message/sdds-message.tsx
+++ b/tegel/src/components/message/sdds-message.tsx
@@ -10,7 +10,7 @@ export class SddsMessage {
   @Prop() header: string;
 
   /** Variant of the component, based on current mode. */
-  @Prop() modeVariant: 'primary' | 'secondary' = 'primary';
+  @Prop() modeVariant: 'primary' | 'secondary' | null = null;
 
   /** Type of message. */
   @Prop() type: 'information' | 'error' | 'warning' | 'success' = 'information';
@@ -43,7 +43,7 @@ export class SddsMessage {
           class={`
         message-wrapper ${this.type}
         ${this.minimal ? 'message-minimal' : ''}
-        sdds-mode-variant-${this.modeVariant}`}
+        ${this.modeVariant !== null ? `sdds-mode-variant-${this.modeVariant}`: ''}`}
         >
           {!this.noIcon && <sdds-icon name={this.getIconName()} size="20px"></sdds-icon>}
           <div class={`message-content`}>

--- a/tegel/src/components/message/sdds-message.tsx
+++ b/tegel/src/components/message/sdds-message.tsx
@@ -10,7 +10,7 @@ export class SddsMessage {
   @Prop() header: string;
 
   /** Variant of the component, based on current mode. */
-  @Prop() modeVariant: 'primary' | 'secondary' | null = null;
+  @Prop() modeVariant: 'primary' | 'secondary' = null;
 
   /** Type of message. */
   @Prop() type: 'information' | 'error' | 'warning' | 'success' = 'information';

--- a/tegel/src/components/tabs/inline-tabs-default/inline-tabs.tsx
+++ b/tegel/src/components/tabs/inline-tabs-default/inline-tabs.tsx
@@ -22,7 +22,7 @@ export class InlineTabs {
   @Prop() autoHeight: boolean = false;
 
   /** Variant of the tabs, primary= on white, secondary= on grey50 */
-  @Prop() modeVariant: 'primary' | 'secondary' | null = null;
+  @Prop() modeVariant: 'primary' | 'secondary' = null;
 
   /** array with metadata for slotted children */
   @State() tabs: Array<any> = [];

--- a/tegel/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.tsx
+++ b/tegel/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.tsx
@@ -7,7 +7,7 @@ import { Component, Host, State, Element, h, Prop } from '@stencil/core';
 })
 export class InlineTabsFullbleed {
   /** Variant of the tabs, primary= on white, secondary= on grey50 */
-  @Prop() modeVariant: 'primary' | 'secondary' | null = null;
+  @Prop() modeVariant: 'primary' | 'secondary' = null;
 
   @Element() host: HTMLElement;
 

--- a/tegel/src/components/tabs/navigation-tabs/navigation-tabs.tsx
+++ b/tegel/src/components/tabs/navigation-tabs/navigation-tabs.tsx
@@ -15,7 +15,7 @@ export class NavigationTabs {
   @State() showRightScroll: boolean = false;
   
    /** Variant of the tabs, primary= on white, secondary= on grey50 */
-   @Prop() modeVariant: 'primary' | 'secondary' | null = null;
+   @Prop() modeVariant: 'primary' | 'secondary' = null;
 
   navWrapperElement: HTMLElement = null; // reference to container with nav buttons
 

--- a/tegel/src/components/textarea/readme.md
+++ b/tegel/src/components/textarea/readme.md
@@ -5,22 +5,22 @@
 
 ## Properties
 
-| Property        | Attribute        | Description                                                  | Type                                  | Default      |
-| --------------- | ---------------- | ------------------------------------------------------------ | ------------------------------------- | ------------ |
-| `autoFocus`     | `auto-focus`     | Control of autofocus                                         | `boolean`                             | `false`      |
-| `cols`          | `cols`           | Textarea cols attribute                                      | `number`                              | `undefined`  |
-| `disabled`      | `disabled`       | Set input in disabled state                                  | `boolean`                             | `false`      |
-| `helper`        | `helper`         | Helper text                                                  | `string`                              | `undefined`  |
-| `label`         | `label`          | Label text                                                   | `string`                              | `''`         |
-| `labelPosition` | `label-position` | Position of the label for the textfield.                     | `"inside" \| "no-label" \| "outside"` | `'no-label'` |
-| `maxLength`     | `max-length`     | Max length of input                                          | `number`                              | `undefined`  |
-| `modeVariant`   | `mode-variant`   | Variant of the tabs, primary= on white, secondary= on grey50 | `"primary" \| "secondary"`            | `'primary'`  |
-| `name`          | `name`           | Name attribute                                               | `string`                              | `''`         |
-| `placeholder`   | `placeholder`    | Placeholder text                                             | `string`                              | `''`         |
-| `readOnly`      | `read-only`      | Set input in readonly state                                  | `boolean`                             | `false`      |
-| `rows`          | `rows`           | Textarea rows attribute                                      | `number`                              | `undefined`  |
-| `state`         | `state`          | Error state of input                                         | `"default" \| "error" \| "success"`   | `'default'`  |
-| `value`         | `value`          | Value of the input text                                      | `string`                              | `''`         |
+| Property        | Attribute        | Description                              | Type                                  | Default      |
+| --------------- | ---------------- | ---------------------------------------- | ------------------------------------- | ------------ |
+| `autoFocus`     | `auto-focus`     | Control of autofocus                     | `boolean`                             | `false`      |
+| `cols`          | `cols`           | Textarea cols attribute                  | `number`                              | `undefined`  |
+| `disabled`      | `disabled`       | Set input in disabled state              | `boolean`                             | `false`      |
+| `helper`        | `helper`         | Helper text                              | `string`                              | `undefined`  |
+| `label`         | `label`          | Label text                               | `string`                              | `''`         |
+| `labelPosition` | `label-position` | Position of the label for the textfield. | `"inside" \| "no-label" \| "outside"` | `'no-label'` |
+| `maxLength`     | `max-length`     | Max length of input                      | `number`                              | `undefined`  |
+| `modeVariant`   | `mode-variant`   | Mode variant of the textarea             | `"primary" \| "secondary"`            | `null`       |
+| `name`          | `name`           | Name attribute                           | `string`                              | `''`         |
+| `placeholder`   | `placeholder`    | Placeholder text                         | `string`                              | `''`         |
+| `readOnly`      | `read-only`      | Set input in readonly state              | `boolean`                             | `false`      |
+| `rows`          | `rows`           | Textarea rows attribute                  | `number`                              | `undefined`  |
+| `state`         | `state`          | Error state of input                     | `"default" \| "error" \| "success"`   | `'default'`  |
+| `value`         | `value`          | Value of the input text                  | `string`                              | `''`         |
 
 
 ## Events

--- a/tegel/src/components/textarea/textarea.stories.tsx
+++ b/tegel/src/components/textarea/textarea.stories.tsx
@@ -33,9 +33,9 @@ export default {
       control: {
         type: 'radio',
       },
-      options: ['Primary', 'Secondary'],
+      options: ['Inherit from parent','Primary', 'Secondary'],
       table: {
-        defaultValue: { summary: 'primary' },
+        defaultValue: { summary: 'Inherit from parent' },
       },
     },
     disabled: {
@@ -113,7 +113,7 @@ export default {
     maxLength: 0,
     rows: 5,
     state: 'Default',
-    modeVariant: 'Primary',
+    modeVariant: 'Inherit from parent',
   },
 };
 

--- a/tegel/src/components/textarea/textarea.tsx
+++ b/tegel/src/components/textarea/textarea.tsx
@@ -46,7 +46,7 @@ export class Textarea {
   @Prop() maxLength: number;
 
   /** Mode variant of the textarea */
-  @Prop() modeVariant: 'primary' | 'secondary' | null = null;
+  @Prop() modeVariant: 'primary' | 'secondary' = null;
 
   /** Control of autofocus */
   @Prop() autoFocus: boolean = false;

--- a/tegel/src/components/textarea/textarea.tsx
+++ b/tegel/src/components/textarea/textarea.tsx
@@ -46,7 +46,7 @@ export class Textarea {
   @Prop() maxLength: number;
 
   /** Mode variant of the textarea */
-  @Prop() modeVariant: 'primary' | 'secondary' = 'primary';
+  @Prop() modeVariant: 'primary' | 'secondary' | null = null;
 
   /** Control of autofocus */
   @Prop() autoFocus: boolean = false;
@@ -86,7 +86,7 @@ export class Textarea {
         ${this.focusInput ? 'sdds-textarea-focus' : ''}
         ${this.disabled ? 'sdds-textarea-disabled' : ''}
         ${this.readOnly ? 'sdds-textarea-readonly' : ''}
-        sdds-mode-variant-${this.modeVariant}
+        ${this.modeVariant !== null ? `sdds-mode-variant-${this.modeVariant}`: ''}
         ${this.value ? 'sdds-textarea-data' : ''}
         ${this.state === 'error' || this.state === 'success' ? `sdds-textarea-${this.state}` : ''}
         `}

--- a/tegel/src/components/textfield/readme.md
+++ b/tegel/src/components/textfield/readme.md
@@ -5,23 +5,23 @@
 
 ## Properties
 
-| Property        | Attribute        | Description                                                  | Type                                  | Default      |
-| --------------- | ---------------- | ------------------------------------------------------------ | ------------------------------------- | ------------ |
-| `autofocus`     | `autofocus`      | Autofocus for input                                          | `boolean`                             | `false`      |
-| `disabled`      | `disabled`       | Set input in disabled state                                  | `boolean`                             | `false`      |
-| `helper`        | `helper`         | Helper text                                                  | `string`                              | `undefined`  |
-| `label`         | `label`          | Label text                                                   | `string`                              | `''`         |
-| `labelPosition` | `label-position` | Position of the label for the textfield.                     | `"inside" \| "no-label" \| "outside"` | `'no-label'` |
-| `maxLength`     | `max-length`     | Max length of input                                          | `number`                              | `undefined`  |
-| `modeVariant`   | `mode-variant`   | Variant of the tabs, primary= on white, secondary= on grey50 | `"primary" \| "secondary"`            | `null`       |
-| `name`          | `name`           | Name property                                                | `string`                              | `''`         |
-| `noMinWidth`    | `no-min-width`   | With setting                                                 | `boolean`                             | `false`      |
-| `placeholder`   | `placeholder`    | Placeholder text                                             | `string`                              | `''`         |
-| `readonly`      | `readonly`       | Set input in readonly state                                  | `boolean`                             | `false`      |
-| `size`          | `size`           | Size of the input                                            | `"lg" \| "md" \| "sm"`                | `'lg'`       |
-| `state`         | `state`          | Error state of input                                         | `"default" \| "error" \| "success"`   | `'default'`  |
-| `type`          | `type`           | Which input type, text, password or similar                  | `"password" \| "text"`                | `'text'`     |
-| `value`         | `value`          | Value of the input text                                      | `string`                              | `''`         |
+| Property        | Attribute        | Description                                 | Type                                  | Default      |
+| --------------- | ---------------- | ------------------------------------------- | ------------------------------------- | ------------ |
+| `autofocus`     | `autofocus`      | Autofocus for input                         | `boolean`                             | `false`      |
+| `disabled`      | `disabled`       | Set input in disabled state                 | `boolean`                             | `false`      |
+| `helper`        | `helper`         | Helper text                                 | `string`                              | `undefined`  |
+| `label`         | `label`          | Label text                                  | `string`                              | `''`         |
+| `labelPosition` | `label-position` | Position of the label for the textfield.    | `"inside" \| "no-label" \| "outside"` | `'no-label'` |
+| `maxLength`     | `max-length`     | Max length of input                         | `number`                              | `undefined`  |
+| `modeVariant`   | `mode-variant`   | Mode variant of the textarea                | `"primary" \| "secondary"`            | `null`       |
+| `name`          | `name`           | Name property                               | `string`                              | `''`         |
+| `noMinWidth`    | `no-min-width`   | With setting                                | `boolean`                             | `false`      |
+| `placeholder`   | `placeholder`    | Placeholder text                            | `string`                              | `''`         |
+| `readonly`      | `readonly`       | Set input in readonly state                 | `boolean`                             | `false`      |
+| `size`          | `size`           | Size of the input                           | `"lg" \| "md" \| "sm"`                | `'lg'`       |
+| `state`         | `state`          | Error state of input                        | `"default" \| "error" \| "success"`   | `'default'`  |
+| `type`          | `type`           | Which input type, text, password or similar | `"password" \| "text"`                | `'text'`     |
+| `value`         | `value`          | Value of the input text                     | `string`                              | `''`         |
 
 
 ## Events

--- a/tegel/src/components/textfield/textfield.tsx
+++ b/tegel/src/components/textfield/textfield.tsx
@@ -38,7 +38,7 @@ export class Textfield {
 
     /** Mode variant of the textarea */
 
-  @Prop() modeVariant: 'primary' | 'secondary' | null = null;
+  @Prop() modeVariant: 'primary' | 'secondary' = null;
 
   /** With setting */
   @Prop() noMinWidth: boolean = false;


### PR DESCRIPTION
**Describe pull-request**  
Card, message, textfield and textarea was missing null option to mode variant and/or Inherit from parent as option in storybook

**How to test**  
Check the components and that mode variants working in storybook and looks ok in code