### PR TITLE
docs(event): documentation of event naming convention

### DIFF
--- a/tegel/readme.md
+++ b/tegel/readme.md
@@ -155,7 +155,7 @@ See all available components in the [Tegel Design System](https://tegel.scania.c
 ## Events
 
 The tegel components emit custom events to allow the users to repond to changes/updates in the components. These are all named using the 
-sdds-prefix. This is done in order to not have conflicting events and to make it clear to the user the the specified event is something that is emitted
+sdds-prefix. This is done in order to not have conflicting events and to make it clear to the user the specified event is something that is emitted
 from a tegel component.
 
 The events are named according to our naming convention: 'sdds' + event.
@@ -163,7 +163,7 @@ For a click event this would result in the event being called `sddsClick`. To li
 should be passed to the `addEventListener` function as the first argument:
 ```javascript
 document.addEventListener('sddsClick', (event) => {
-  // do something with/based on the event.
+  // Do something with/based on the event.
 })
 ```
 

--- a/tegel/readme.md
+++ b/tegel/readme.md
@@ -152,6 +152,30 @@ export class AppModule { }
 
 See all available components in the [Tegel Design System](https://tegel.scania.com/components/overview).
 
+## Events
+
+The tegel components emit custom events to allow the users to repond to changes/updates in the components. These are all named using the 
+sdds-prefix. This not to have conflicting events and to make it clear to the user the the specified event is something that is emitted
+from a tegel component.
+
+The events are named according to our naming convention: 'sdds' + event.
+For a click event this would result in the event being called `sddsClick`. To listen for these events in vanilla JS the event name
+should be passed to the `addEventListener` function as the first argument:
+```javascript
+document.addEventListener('sddsClick', (event) => {
+  // do something with/based on the event.
+})
+```
+
+In JSX these events can be listened to by prefixing them with an `on` directly on the component:
+```jsx
+<sdds-textfield
+  onSddsChange={(event) => {/* To something with/based on the event. */}}
+  >
+
+</sdds-textfield>
+```
+
 ## Browser support
 
 See the browser support section on [the Tegel website](https://tegel.scania.com/development/getting-started-development/introduction#browser-support).

--- a/tegel/readme.md
+++ b/tegel/readme.md
@@ -170,7 +170,7 @@ document.addEventListener('sddsClick', (event) => {
 In JSX these events can be listened to by prefixing them with an `on` directly on the component:
 ```jsx
 <sdds-textfield
-  onSddsChange={(event) => {/* To something with/based on the event. */}}
+  onSddsChange={(event) => {/* Do something with/based on the event. */}}
   >
 
 </sdds-textfield>

--- a/tegel/readme.md
+++ b/tegel/readme.md
@@ -181,7 +181,7 @@ inluding what data is passed with the event to the user.
 
 ### Internal events
 
-Some of the component are using event to communicate with its parent/child. These events are not recommended to in any way use since
+Some of the component are using event to communicate with its parent/child. These events are not recommended to use in any way since
 they might change without notice. Their payload might also be changed based on refactoring of components. These events are prefixed
 with 'internal'. This is to make it as clear as possible to a user that this is an internal event that the components are using,
 but the user should not interact with it. E.g. `internalSddsPropsChange`.

--- a/tegel/readme.md
+++ b/tegel/readme.md
@@ -176,6 +176,16 @@ In JSX these events can be listened to by prefixing them with an `on` directly o
 </sdds-textfield>
 ```
 
+What is attached to the event object is highlighted in our storybook. Under the docs tab of each component the events are outlined,
+inluding what data is passed with the event to the user.
+
+### Internal events
+
+Some of the component are using event to communicate with its parent/child. These events are not recommended to in any way use since
+they might change without notice. Their payload might also be changed based on refactoring of components. These events are prefixed
+with 'internal'. This is to make it as clear as possible to a user that this is an internal event that the components are using,
+but the user should not interact with it. E.g. `internalSddsPropsChange`.
+
 ## Browser support
 
 See the browser support section on [the Tegel website](https://tegel.scania.com/development/getting-started-development/introduction#browser-support).

--- a/tegel/readme.md
+++ b/tegel/readme.md
@@ -155,7 +155,7 @@ See all available components in the [Tegel Design System](https://tegel.scania.c
 ## Events
 
 The tegel components emit custom events to allow the users to repond to changes/updates in the components. These are all named using the 
-sdds-prefix. This not to have conflicting events and to make it clear to the user the the specified event is something that is emitted
+sdds-prefix. This is done in order to not have conflicting events and to make it clear to the user the the specified event is something that is emitted
 from a tegel component.
 
 The events are named according to our naming convention: 'sdds' + event.

--- a/tegel/src/stories/Events/Events.stories.mdx
+++ b/tegel/src/stories/Events/Events.stories.mdx
@@ -4,7 +4,7 @@
 ## Events
 
 The tegel components emit custom events to allow the users to repond to changes/updates in the components. These are all named using the 
-sdds-prefix. This is done in order to not have and to make it clear to the user the specified event is something that is emitted
+sdds-prefix. This is done in order to not have conflicting events and to make it clear to the user the specified event is something that is emitted
 from a tegel component.
 
 The events are named according to our naming convention: **sdds** + event.
@@ -12,7 +12,7 @@ For a click event this would result in the event being called `sddsClick`. To li
 should be passed to the `addEventListener` function as the first argument:
 ```javascript
 document.addEventListener('sddsClick', (event) => {
-  // do something with/based on the event.
+  // Do something with/based on the event.
 })
 ```
 

--- a/tegel/src/stories/Events/Events.stories.mdx
+++ b/tegel/src/stories/Events/Events.stories.mdx
@@ -1,0 +1,36 @@
+<Meta title="Intro/Tegel - Events" />
+
+
+## Events
+
+The tegel components emit custom events to allow the users to repond to changes/updates in the components. These are all named using the 
+sdds-prefix. This not to have conflicting events and to make it clear to the user the the specified event is something that is emitted
+from a tegel component.
+
+The events are named according to our naming convention: **sdds** + event.
+For a click event this would result in the event being called `sddsClick`. To listen for these events in vanilla JS the event name
+should be passed to the `addEventListener` function as the first argument:
+```javascript
+document.addEventListener('sddsClick', (event) => {
+  // do something with/based on the event.
+})
+```
+
+In JSX these events can be listened to by prefixing them with an `on` directly on the component:
+```jsx
+<sdds-textfield
+  onSddsChange={(event) => {/* To something with/based on the event. */}}
+  >
+
+</sdds-textfield>
+```
+
+What is attached to the event object is highlighted in our storybook. Under the docs tab of each component the events are outlined,
+inluding what data is passed with the event to the user.
+
+### Internal events
+
+Some of the component are using event to communicate with its parent/child. These events are not recommended to in any way use since
+they might change without notice. Their payload might also be changed based on refactoring of components. These events are prefixed
+with **internal**. This is to make it as clear as possible to a user that this is an internal event that the components are using,
+but the user should not interact with it. E.g. `internalSddsPropsChange`.

--- a/tegel/src/stories/Events/Events.stories.mdx
+++ b/tegel/src/stories/Events/Events.stories.mdx
@@ -4,7 +4,7 @@
 ## Events
 
 The tegel components emit custom events to allow the users to repond to changes/updates in the components. These are all named using the 
-sdds-prefix. This not to have conflicting events and to make it clear to the user the the specified event is something that is emitted
+sdds-prefix. This is done in order to not have and to make it clear to the user the specified event is something that is emitted
 from a tegel component.
 
 The events are named according to our naming convention: **sdds** + event.
@@ -19,7 +19,7 @@ document.addEventListener('sddsClick', (event) => {
 In JSX these events can be listened to by prefixing them with an `on` directly on the component:
 ```jsx
 <sdds-textfield
-  onSddsChange={(event) => {/* To something with/based on the event. */}}
+  onSddsChange={(event) => {/* Do something with/based on the event. */}}
   >
 
 </sdds-textfield>
@@ -30,7 +30,7 @@ inluding what data is passed with the event to the user.
 
 ### Internal events
 
-Some of the component are using event to communicate with its parent/child. These events are not recommended to in any way use since
+Some of the component are using event to communicate with its parent/child. These events are not recommended to use in any way since
 they might change without notice. Their payload might also be changed based on refactoring of components. These events are prefixed
 with **internal**. This is to make it as clear as possible to a user that this is an internal event that the components are using,
 but the user should not interact with it. E.g. `internalSddsPropsChange`.


### PR DESCRIPTION
**Describe pull-request**  
Documentation on event naming convention - both internal and external.

**Solving issue**  
Fixes: [AB#3299](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3299)

**How to test**  
1. Go to storybook
2. Check in Tegel - events
3. Check the readme of this PR: https://github.com/scania-digital-design-system/sdds/tree/docs/event-documentation/tegel

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

**Screenshots**  


**Additional context**  

