### PR TITLE
fix(expandable table): safari bug

### DIFF
--- a/tegel/src/components/data-table/table-body-row-expandable/table-body-row-expandable.scss
+++ b/tegel/src/components/data-table/table-body-row-expandable/table-body-row-expandable.scss
@@ -1,4 +1,5 @@
 @import '../../../mixins/box-sizing';
+@import '../../../mixins/focus-state';
 
 :host {
   @include sdds-box-sizing;
@@ -29,11 +30,18 @@
     position: relative;
 
     .sdds-table__expand-input {
-      display: none;
+      all: unset;
+      position: absolute;
+      top: 0;
+      left: 0;
       width: 100%;
       height: 100%;
       position: absolute;
       cursor: pointer;
+
+      &:focus {
+        @include sdds-focus-state;
+      }
     }
 
     .sdds-expendable-row-icon {

--- a/tegel/src/components/data-table/table-body-row-expandable/table-body-row-expandable.scss
+++ b/tegel/src/components/data-table/table-body-row-expandable/table-body-row-expandable.scss
@@ -45,13 +45,12 @@
   }
 
   .sdds-table__row-expand {
-    visibility: collapse;
+    display: none;
     transition: background-color 200ms ease;
 
     .sdds-table__cell-expand {
       padding: 16px 16px 16px 66px;
       color: var(--sdds-data-table-color);
-
     }
   }
 }
@@ -69,7 +68,7 @@
 
   .sdds-table__row-expand {
     background-color: var(--sdds-data-table-body-row-background-selected);
-    visibility: visible;
+    display: table-row;
   }
 }
 

--- a/tegel/src/components/data-table/table-body-row-expandable/table-body-row-expandable.scss
+++ b/tegel/src/components/data-table/table-body-row-expandable/table-body-row-expandable.scss
@@ -29,7 +29,7 @@
     position: relative;
 
     .sdds-table__expand-input {
-      appearance: none;
+      display: none;
       width: 100%;
       height: 100%;
       position: absolute;


### PR DESCRIPTION
**Describe pull-request**  
Switched visibility collapse to display:none. Collapse has bad browser support.

**Solving issue**  
Fixes: [AB#3025](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3025)

**How to test**  
1. Go to storybook link below
2. Check in Components -> Data table -> Expandable rows
3. Check that the row can hide/expand correctly.
4. Make sure to test in safari/firefox.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

**Screenshots**  


**Additional context**  
