### PR TITLE
fix(checkbox): remove usused prop - label

### DIFF
--- a/tegel/src/components/checkbox/readme.md
+++ b/tegel/src/components/checkbox/readme.md
@@ -12,7 +12,6 @@
 | `checkboxId` | `checkbox-id` | ID for the checkbox's input element. Randomly generated if not specified. | `string`  | `crypto.randomUUID()` |
 | `checked`    | `checked`     | Sets the checkbox as checked                                              | `boolean` | `false`               |
 | `disabled`   | `disabled`    | Sets the checkbox in a disabled state                                     | `boolean` | `false`               |
-| `label`      | `label`       | Label text for the checkbox                                               | `string`  | `undefined`           |
 | `name`       | `name`        | Name for the checkbox's input element.                                    | `string`  | `undefined`           |
 | `required`   | `required`    | Make the checkbox required                                                | `boolean` | `false`               |
 

--- a/tegel/src/components/checkbox/sdds-checkbox.tsx
+++ b/tegel/src/components/checkbox/sdds-checkbox.tsx
@@ -14,9 +14,6 @@ export class SddsCheckbox {
   /** ID for the checkbox's input element. Randomly generated if not specified. */
   @Prop() checkboxId: string = crypto.randomUUID();
 
-  /** Label text for the checkbox */
-  @Prop() label: string;
-
   /** Sets the checkbox in a disabled state */
   @Prop() disabled: boolean = false;
 


### PR DESCRIPTION
**Describe pull-request**  
Removed a unsused prop - label. The label is populated via the slot.

**Solving issue**  
Fixes: -

**How to test**  
1. Go to storybook link below
2. Check in Components -> Checkbox -> Web Component
3. Check the readme and that all the props are usable.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

**Screenshots**  


**Additional context**  

