### PR TITLE
fix(toggle): darkmode fixes

### DIFF
--- a/tegel/src/components/toggle/sdds-toggle.scss
+++ b/tegel/src/components/toggle/sdds-toggle.scss
@@ -4,6 +4,10 @@
     letter-spacing: var(--sdds-detail-02-ls);
     color: var(--sdds-toggle-headline);
     margin-bottom: 12px;
+
+    &.disabled {
+      color: var(--sdds-toggle-headline-disabled);
+    }
   }
 
   input[type='checkbox'] {
@@ -72,6 +76,17 @@
       }
     }
 
+    &:disabled:checked {
+      &::before {
+        background-color: var(--sdds-toggle-on-slider-disabled);
+        border: 1px solid var(--sdds-toggle-on-slider-disabled);
+      }
+
+      &::after {
+        background-color: var(--sdds-toggle-switch-disabled);
+      }
+    }
+
     &.sm {
       width: 28px;
       height: 16px;
@@ -116,5 +131,9 @@
     letter-spacing: var(--sdds-detail-01-ls);
     color: var(--sdds-toggle-label-color);
     padding-left: 8px;
+
+    &.disabled {
+      color: var(--sdds-toggle-label-color-disabled);
+    }
   }
 }

--- a/tegel/src/components/toggle/sdds-toggle.tsx
+++ b/tegel/src/components/toggle/sdds-toggle.tsx
@@ -62,7 +62,9 @@ export class SddsToggle {
   render() {
     return (
       <div class="sdds-toggle-webcomponent">
-        {this.headline && <div class={`toggle-headline`}>{this.headline}</div>}
+        {this.headline && (
+          <div class={`toggle-headline ${this.disabled ? 'disabled' : ''}`}>{this.headline}</div>
+        )}
         <input
           aria-labelledby={this.ariaLabelledby}
           aria-describedby={this.ariaDescribedby}
@@ -82,7 +84,7 @@ export class SddsToggle {
           id={this.toggleId}
           role="switch"
         />
-        <label htmlFor={this.toggleId}>
+        <label class={`${this.disabled ? 'disabled' : ''}`} htmlFor={this.toggleId}>
           <slot></slot>
         </label>
       </div>

--- a/tegel/src/components/toggle/toggle-theme-vars.scss
+++ b/tegel/src/components/toggle/toggle-theme-vars.scss
@@ -1,15 +1,14 @@
-:root,
-html,
 .sdds-theme-light {
   --sdds-toggle-switch: var(--sdds-white);
   --sdds-toggle-switch-disabled: var(--sdds-grey-200);
   --sdds-toggle-headline: var(--sdds-grey-700);
-  --sdds-toggle-headline-disabled: var(--sdds-grey-400);
+  --sdds-toggle-headline-disabled: var(--sdds-grey-600);
   --sdds-toggle-on-slider: var(--sdds-positive);
   --sdds-toggle-on-slider-hover: var(--sdds-positive);
   --sdds-toggle-on-slider-focus: var(--sdds-positive);
   --sdds-toggle-on-slider-pressed: var(--sdds-positive);
   --sdds-toggle-on-border-focus: var(--sdds-positive);
+  --sdds-toggle-on-slider-disabled: var(--sdds-grey-400);
   --sdds-toggle-slider-disabled: var(--sdds-grey-400);
   --sdds-toggle-label-color: var(--sdds-grey-900);
   --sdds-toggle-label-color-disabled: var(--sdds-grey-600);
@@ -21,18 +20,19 @@ html,
 }
 
 .sdds-theme-dark {
-  --sdds-toggle-switch: var(--sdds-black);
+  --sdds-toggle-switch: var(--sdds-white);
   --sdds-toggle-switch-disabled: var(--sdds-grey-200);
-  --sdds-toggle-headline: var(--sdds-grey-700);
-  --sdds-toggle-headline-disabled: var(--sdds-grey-400);
+  --sdds-toggle-headline: var(--sdds-grey-100);
+  --sdds-toggle-headline-disabled: var(--sdds-grey-700);
   --sdds-toggle-on-slider: var(--sdds-positive);
   --sdds-toggle-on-slider-hover: var(--sdds-positive);
   --sdds-toggle-on-slider-focus: var(--sdds-positive);
   --sdds-toggle-on-slider-pressed: var(--sdds-positive);
   --sdds-toggle-on-border-focus: var(--sdds-positive);
+  --sdds-toggle-on-slider-disabled: var(--sdds-grey-800);
   --sdds-toggle-slider-disabled: var(--sdds-grey-400);
-  --sdds-toggle-label-color: var(--sdds-grey-900);
-  --sdds-toggle-label-color-disabled: var(--sdds-grey-600);
+  --sdds-toggle-label-color: var(--sdds-white);
+  --sdds-toggle-label-color-disabled: var(--sdds-grey-400);
   --sdds-toggle-off-slider: var(--sdds-grey-500);
   --sdds-toggle-off-slider-hover: var(--sdds-grey-600);
   --sdds-toggle-off-slider-focus: var(--sdds-grey-600);

--- a/tegel/src/components/toggle/toggle.scss
+++ b/tegel/src/components/toggle/toggle.scss
@@ -182,34 +182,25 @@
     .sdds-toggle-input {
       @include activeState;
     }
-
-    // .sdds-toggle-switch{
-    //   &:before{
-    //     background-color: var(--sdds-toggle-off-slider-pressed);
-    //   }
-    // }
-    // .sdds-toggle-input:checked {
-    //   + .sdds-toggle-switch{
-    //     &:before{
-    //       background-color: var(--sdds-toggle-on-slider-pressed);
-    //     }
-    //   }
-    // }
   }
 
   &.disabled {
     cursor: not-allowed;
 
+    &::before {
+      background-color: var(--sdds-toggle-slider-disabled);
+      border: 0;
+    }
+
     .sdds-toggle-input {
       pointer-events: none;
 
-      &,
       &:checked,
       &:checked:focus,
       &:focus {
         + .sdds-toggle-switch {
           &::before {
-            background-color: var(--sdds-toggle-slider-disabled);
+            background-color: var(--sdds-toggle-on-slider-disabled);
             border: 0;
           }
         }

--- a/tegel/src/components/toggle/toggle.stories.tsx
+++ b/tegel/src/components/toggle/toggle.stories.tsx
@@ -40,15 +40,26 @@ export default {
         type: 'boolean',
       },
     },
+    checked: {
+      name: 'Checked',
+      description: 'Sets the toggle as checked',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: 'false' },
+      },
+    },
   },
   args: {
     size: 'Default',
-    headline: '',
+    headline: 'Headline',
     disabled: false,
+    checked: false,
   },
 };
 
-const Template = ({ size, disabled = false, headline = '' }) => {
+const Template = ({ size, disabled, headline, checked }) => {
   const sizeValue = size === 'Small' ? 'sdds-toggle-sm' : '';
   const headlineDiv =
     headline.length > 0 ? `<div class="sdds-toggle-headline">${headline}</div>` : '';
@@ -58,7 +69,7 @@ const Template = ({ size, disabled = false, headline = '' }) => {
         ${headlineDiv}
         <input type="checkbox" class="sdds-toggle-input" id="customSwitch1" ${
           disabled ? 'disabled' : ''
-        }>
+        } ${checked ? 'checked' : ''}>
         <span class="sdds-toggle-switch"></span>
         <label class="sdds-toggle-label" for="customSwitch1">Toggle this switch element</label>
       </div>


### PR DESCRIPTION
**Describe pull-request**  
Toggle in darkmode seemed to be having some faulty color values:

<img width="285" alt="Screenshot 2023-02-16 at 10 55 44" src="https://user-images.githubusercontent.com/62651103/219353176-59b8ddea-8e5a-4d3d-8990-eda0d7c944c0.png">

**Solving issue**  
Fixes: -

**How to test**  
1. Go to storybook link below
2. Check in Components -> Toggle -> Web Component / Native
3. Check that the design for dark mode is correct.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

