### PR TITLE
fix(slider): refactor event names

### DIFF
--- a/tegel/src/components/icon/readme.md
+++ b/tegel/src/components/icon/readme.md
@@ -22,6 +22,7 @@
  - [sdds-datetime](../datetime)
  - [sdds-message](../message)
  - [sdds-modal](../modal)
+ - [sdds-slider](../slider)
  - [sdds-textarea](../textarea)
  - [sdds-textfield](../textfield)
  - [sdds-toast](../toast)
@@ -34,6 +35,7 @@ graph TD;
   sdds-datetime --> sdds-icon
   sdds-message --> sdds-icon
   sdds-modal --> sdds-icon
+  sdds-slider --> sdds-icon
   sdds-textarea --> sdds-icon
   sdds-textfield --> sdds-icon
   sdds-toast --> sdds-icon

--- a/tegel/src/components/slider/readme.md
+++ b/tegel/src/components/slider/readme.md
@@ -7,30 +7,31 @@
 
 ## Properties
 
-| Property          | Attribute           | Description                                                                      | Type         | Default |
-| ----------------- | ------------------- | -------------------------------------------------------------------------------- | ------------ | ------- |
-| `controls`        | `controls`          | Decide to show the controls or not                                               | `boolean`    | `null`  |
-| `disabled`        | `disabled`          | Sets the disabled state for the whole component                                  | `boolean`    | `null`  |
-| `input`           | `input`             | Decide to show the input field or not                                            | `boolean`    | `null`  |
-| `label`           | `label`             | Text for label                                                                   | `string`     | `''`    |
-| `max`             | `max`               | Maximum value                                                                    | `string`     | `'100'` |
-| `min`             | `min`               | Minimum value                                                                    | `string`     | `'0'`   |
-| `name`            | `name`              | Name property (will be inherited by the native slider component)                 | `string`     | `''`    |
-| `readOnly`        | `read-only`         | Sets the read only state for the whole component                                 | `boolean`    | `null`  |
-| `showTickNumbers` | `show-tick-numbers` | Decide to show numbers above the tick markers or not                             | `boolean`    | `false` |
-| `size`            | `size`              | Sets the size of the scrubber                                                    | `"" \| "sm"` | `''`    |
-| `snap`            | `snap`              | Snap to the ticks grid                                                           | `boolean`    | `null`  |
-| `step`            | `step`              | Defines how much to increment/decrement the value when using controls            | `string`     | `'1'`   |
-| `ticks`           | `ticks`             | Number of tick markers (tick for min- and max-value will be added automatically) | `string`     | `'0'`   |
-| `tooltip`         | `tooltip`           | Decide to show the tooltip or not                                                | `boolean`    | `null`  |
-| `value`           | `value`             | Initial value                                                                    | `string`     | `'0'`   |
+| Property          | Attribute           | Description                                                                      | Type         | Default               |
+| ----------------- | ------------------- | -------------------------------------------------------------------------------- | ------------ | --------------------- |
+| `controls`        | `controls`          | Decide to show the controls or not                                               | `boolean`    | `null`                |
+| `disabled`        | `disabled`          | Sets the disabled state for the whole component                                  | `boolean`    | `null`                |
+| `input`           | `input`             | Decide to show the input field or not                                            | `boolean`    | `null`                |
+| `label`           | `label`             | Text for label                                                                   | `string`     | `''`                  |
+| `max`             | `max`               | Maximum value                                                                    | `string`     | `'100'`               |
+| `min`             | `min`               | Minimum value                                                                    | `string`     | `'0'`                 |
+| `name`            | `name`              | Name property (will be inherited by the native slider component)                 | `string`     | `''`                  |
+| `readOnly`        | `read-only`         | Sets the read only state for the whole component                                 | `boolean`    | `null`                |
+| `showTickNumbers` | `show-tick-numbers` | Decide to show numbers above the tick markers or not                             | `boolean`    | `false`               |
+| `size`            | `size`              | Sets the size of the scrubber                                                    | `"" \| "sm"` | `''`                  |
+| `sliderId`        | `slider-id`         | Id for the sliders input element, randomly generated if not specified.           | `string`     | `crypto.randomUUID()` |
+| `snap`            | `snap`              | Snap to the ticks grid                                                           | `boolean`    | `null`                |
+| `step`            | `step`              | Defines how much to increment/decrement the value when using controls            | `string`     | `'1'`                 |
+| `ticks`           | `ticks`             | Number of tick markers (tick for min- and max-value will be added automatically) | `string`     | `'0'`                 |
+| `tooltip`         | `tooltip`           | Decide to show the tooltip or not                                                | `boolean`    | `null`                |
+| `value`           | `value`             | Initial value                                                                    | `string`     | `'0'`                 |
 
 
 ## Events
 
-| Event          | Description                    | Type               |
-| -------------- | ------------------------------ | ------------------ |
-| `sliderChange` | Change event for the textfield | `CustomEvent<any>` |
+| Event        | Description                                                                       | Type                              |
+| ------------ | --------------------------------------------------------------------------------- | --------------------------------- |
+| `sddsChange` | Sends unique checkbox identifier and value when the slider has a change in value. | `CustomEvent<{ value: string; }>` |
 
 
 ## Methods
@@ -45,6 +46,19 @@ Type: `Promise<void>`
 
 
 
+
+## Dependencies
+
+### Depends on
+
+- [sdds-icon](../icon)
+
+### Graph
+```mermaid
+graph TD;
+  sdds-slider --> sdds-icon
+  style sdds-slider fill:#f9f,stroke:#333,stroke-width:4px
+```
 
 ----------------------------------------------
 

--- a/tegel/src/components/slider/slider.stories.tsx
+++ b/tegel/src/components/slider/slider.stories.tsx
@@ -157,28 +157,24 @@ export default {
     ],
   },
   args: {
-    min: 0,
-    max: 100,
-    value: 50,
+    initialValue: '50',
+    showLabel: false,
+    labelText: 'Label',
+    showTooltip: true,
+    showTicks: false,
+    numTicks: '3',
+    showTickNumbers: false,
+    showControls: false,
+    showInput: false,
+    min: '0',
+    max: '100',
+    step: '1',
+    disabled: false,
+    small: false,
+    snapToTicks: false,
+    readonly: false,
   },
 };
-
-const style = `
-  <style>
-  /* demo-wrapper is for demonstration purposes only*/
-    .demo-wrapper {
-      width: 80%;
-      margin: 0 auto;
-      display: flex;
-      align-items: center;
-      height: 100%;
-      padding-top: 100px;
-      padding-left: 40px;
-      padding-right: 40px;
-    }    
-  </style>
-`;
-
 const Template = ({
   initialValue,
   min,
@@ -198,81 +194,35 @@ const Template = ({
   small,
 }) =>
   formatHtmlPreview(`
-    ${style}
-    <div class="demo-wrapper">
-      <sdds-slider id="sdds-slider"
-        min="${min}" 
-        max="${max}" 
-        ${showControls && step ? `step="${step}"` : ''}
-        value="${initialValue}" 
-        ${showTicks ? `ticks="${numTicks}"` : ''} 
-        ${showTickNumbers ? 'show-tick-numbers' : ''} 
-        ${snapToTicks ? 'snap' : ''} 
-        ${showLabel ? `label="${labelText}"` : ''} 
-        ${showTooltip ? 'tooltip' : ''} 
-        ${showControls ? 'controls' : ''} 
-        ${showInput ? 'input' : ''} 
-        ${disabled ? 'disabled' : ''} 
-        ${small ? 'size="sm"' : ''}
-        ${readonly ? 'read-only' : ''} 
-        >
+    <sdds-slider id="sdds-slider"
+      min="${min}" 
+      max="${max}" 
+      ${showControls && step ? `step="${step}"` : ''}
+      value="${initialValue}" 
+      ${showTicks ? `ticks="${numTicks}"` : ''} 
+      ${showTickNumbers ? 'show-tick-numbers' : ''} 
+      ${snapToTicks ? 'snap' : ''} 
+      ${showLabel ? `label="${labelText}"` : ''} 
+      ${showTooltip ? 'tooltip' : ''} 
+      ${showControls ? 'controls' : ''} 
+      ${showInput ? 'input' : ''} 
+      ${disabled ? 'disabled' : ''} 
+      ${small ? 'size="sm"' : ''}
+      ${readonly ? 'read-only' : ''} 
+      >
 
-      </sdds-slider>
-    </div>
+    </sdds-slider>
+
+    <!-- Script tag for demo purposes -->
+    <script>
+    slider = document.querySelectorAll('sdds-slider')[0]
+
+    slider.removeEventListener('sddsChange', null)
+    slider.addEventListener('sddsChange', (event) => {
+      console.log('Slider changed, value:', event.detail.value);
+    });
+
+    </script>
   `);
 
-let sliderStoryLoaded = false;
-
-function ready(fn) {
-  if (document.readyState !== 'loading') {
-    fn();
-  } else {
-    document.addEventListener('DOMContentLoaded', fn);
-  }
-}
-
-ready(() => {
-  if (sliderStoryLoaded) {
-    return;
-  }
-
-  sliderStoryLoaded = true;
-
-  const slider = document.querySelector('#sdds-slider');
-  if (!slider) {
-    return;
-  }
-
-  /*
-    @ATTENTION
-    Keep in mind that storybook does stuff, so if any story control is changed,
-    the page has to be reloaded for this event listener to work. Also it will only
-    work in the Canvas-tab
-  */
-
-  console.log('adding slider event');
-
-  slider.addEventListener('sliderChange', (event) => {
-    console.log('Got a sliderChange event', (event as any).detail.value);
-  });
-});
-
 export const Default = Template.bind({});
-Default.args = {
-  initialValue: '50',
-  showLabel: false,
-  labelText: 'Label',
-  showTooltip: true,
-  showTicks: false,
-  numTicks: '3',
-  showTickNumbers: false,
-  showControls: false,
-  showInput: false,
-  min: '0',
-  max: '100',
-  step: '1',
-  disabled: false,
-  small: false,
-  snapToTicks: false,
-  readonly: false,
-};

--- a/tegel/src/components/slider/slider.tsx
+++ b/tegel/src/components/slider/slider.tsx
@@ -6,6 +6,54 @@ import { Component, h, Prop, Listen, EventEmitter, Event, Method } from '@stenci
   shadow: false,
 })
 export class Slider {
+  /** Text for label */
+  @Prop() label: string = '';
+
+  /** Initial value */
+  @Prop() value: string = '0';
+
+  /** Minimum value */
+  @Prop() min: string = '0';
+
+  /** Maximum value */
+  @Prop() max: string = '100';
+
+  /** Number of tick markers (tick for min- and max-value will be added automatically) */
+  @Prop() ticks: string = '0';
+
+  /** Decide to show numbers above the tick markers or not  */
+  @Prop() showTickNumbers: boolean = false;
+
+  /** Decide to show the tooltip or not */
+  @Prop() tooltip: boolean = null;
+
+  /** Sets the disabled state for the whole component  */
+  @Prop() disabled: boolean = null;
+
+  /** Sets the read only state for the whole component  */
+  @Prop() readOnly: boolean = null;
+
+  /** Decide to show the controls or not */
+  @Prop() controls: boolean = null;
+
+  /** Decide to show the input field or not */
+  @Prop() input: boolean = null;
+
+  /** Defines how much to increment/decrement the value when using controls */
+  @Prop() step: string = '1';
+
+  /** Name property (will be inherited by the native slider component) */
+  @Prop() name: string = '';
+
+  /** Sets the size of the scrubber */
+  @Prop() size: 'sm' | '' = '';
+
+  /** Snap to the ticks grid */
+  @Prop() snap: boolean = null;
+
+  /** Id for the sliders input element, randomly generated if not specified. */
+  @Prop() sliderId: string = crypto.randomUUID();
+
   wrapperElement: HTMLElement = null;
 
   scrubberElement: HTMLElement = null;
@@ -52,59 +100,16 @@ export class Slider {
 
   resizeObserverAdded: boolean = false;
 
-  /** Change event for the textfield */
+  /** Sends unique checkbox identifier and value when the slider has a change in value. */
   @Event({
-    eventName: 'sliderChange',
+    eventName: 'sddsChange',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  sliderChangeEmitter: EventEmitter<any>;
-
-  /** Text for label */
-  @Prop() label: string = '';
-
-  /** Initial value */
-  @Prop() value: string = '0';
-
-  /** Minimum value */
-  @Prop() min: string = '0';
-
-  /** Maximum value */
-  @Prop() max: string = '100';
-
-  /** Number of tick markers (tick for min- and max-value will be added automatically) */
-  @Prop() ticks: string = '0';
-
-  /** Decide to show numbers above the tick markers or not  */
-  @Prop() showTickNumbers: boolean = false;
-
-  /** Decide to show the tooltip or not */
-  @Prop() tooltip: boolean = null;
-
-  /** Sets the disabled state for the whole component  */
-  @Prop() disabled: boolean = null;
-
-  /** Sets the read only state for the whole component  */
-  @Prop() readOnly: boolean = null;
-
-  /** Decide to show the controls or not */
-  @Prop() controls: boolean = null;
-
-  /** Decide to show the input field or not */
-  @Prop() input: boolean = null;
-
-  /** Defines how much to increment/decrement the value when using controls */
-  @Prop() step: string = '1';
-
-  /** Name property (will be inherited by the native slider component) */
-  @Prop() name: string = '';
-
-  /** Sets the size of the scrubber */
-  @Prop() size: 'sm' | '' = '';
-
-  /** Snap to the ticks grid */
-  @Prop() snap: boolean = null;
+  sddsChange: EventEmitter<{
+    value: string;
+  }>;
 
   /** Public method to re-initialise the slider if some configuration props are changed */
   @Method() async reset() {
@@ -216,7 +221,7 @@ export class Slider {
   }
 
   dispatchChangeEvent() {
-    this.sliderChangeEmitter.emit({ value: this.value });
+    this.sddsChange.emit({ value: this.value });
   }
 
   updateValue() {
@@ -482,6 +487,7 @@ export class Slider {
           min={this.min}
           max={this.max}
           disabled={this.disabled}
+          id={this.sliderId}
         ></input>
 
         <div
@@ -507,14 +513,11 @@ export class Slider {
 
           {this.useControls && (
             <div class="sdds-slider__controls">
-              <div ref={el => (this.minusElement = el as HTMLElement)} class="sdds-slider__control sdds-slider__control-minus">
-                <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    fill-rule="evenodd"
-                    clip-rule="evenodd"
-                    d="M1.98975 8.00005C1.98975 8.27619 2.2136 8.50005 2.48975 8.50005H13.5104C13.7866 8.50005 14.0104 8.27619 14.0104 8.00005C14.0104 7.72391 13.7866 7.50005 13.5104 7.50005L2.48975 7.50005C2.2136 7.50005 1.98975 7.72391 1.98975 8.00005Z"
-                     />
-                </svg>
+              <div
+                ref={(el) => (this.minusElement = el as HTMLElement)}
+                class="sdds-slider__control sdds-slider__control-minus"
+              >
+                <sdds-icon name="minus" size="16px"></sdds-icon>
               </div>
             </div>
           )}
@@ -618,15 +621,11 @@ export class Slider {
 
           {this.useControls && (
             <div class="sdds-slider__controls">
-              <div ref={el => (this.plusElement = el as HTMLElement)} class="sdds-slider__control sdds-slider__control-plus">
-                <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    fill-rule="evenodd"
-                    clip-rule="evenodd"
-                    d="M8.50005 13.5104C8.50005 13.7865 8.27619 14.0104 8.00005 14.0104C7.7239 14.0104 7.50005 13.7865 7.50005 13.5104V8.5H2.48975C2.2136 8.5 1.98975 8.27614 1.98975 8C1.98975 7.72386 2.2136 7.5 2.48975 7.5H7.50005V2.48965C7.50005 2.21351 7.7239 1.98965 8.00005 1.98965C8.27619 1.98965 8.50005 2.21351 8.50005 2.48965V7.5H13.5104C13.7866 7.5 14.0104 7.72386 14.0104 8C14.0104 8.27614 13.7866 8.5 13.5104 8.5H8.50005V13.5104Z"
-                    
-                  />
-                </svg>
+              <div
+                ref={(el) => (this.plusElement = el as HTMLElement)}
+                class="sdds-slider__control sdds-slider__control-plus"
+              >
+                <sdds-icon name="plus" size="16px"></sdds-icon>
               </div>
             </div>
           )}


### PR DESCRIPTION
**Describe pull-request**  
Refactored the event name for the slider. Introduced a slider-id prop and cleaned up the story. Also moved some stuff around in the slider.tsx

**Solving issue**  
Fixes: [AB#3360](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3360)

**How to test**  
1. Go to storybook link below
2. Check in Components -> Slider
3. Check the readme for the event
4. Check the log to make sure the event works as intended.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
