### PR TITLE
fix(table): refactor event names

### DIFF
--- a/tegel/src/components/data-table/table-body-cell/table-body-cell.tsx
+++ b/tegel/src/components/data-table/table-body-cell/table-body-cell.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, h, Host, Listen, Prop, State } from '@stencil/core';
-import { InternalSddsPropChange } from '../table/table';
+import { InternalSddsTablePropChange } from '../table/table';
 
-const relevantTableProps: InternalSddsPropChange['changed'] = [
+const relevantTableProps: InternalSddsTablePropChange['changed'] = [
   'verticalDividers',
   'compactDesign',
   'noMinWidth',
@@ -40,7 +40,7 @@ export class TableBodyCell {
   tableEl: HTMLSddsTableElement;
 
   @Listen('internalSddsPropChange', { target: 'body' })
-  internalSddsPropChangeListener(event: CustomEvent<InternalSddsPropChange>) {
+  internalSddsPropChangeListener(event: CustomEvent<InternalSddsTablePropChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))

--- a/tegel/src/components/data-table/table-body-cell/table-body-cell.tsx
+++ b/tegel/src/components/data-table/table-body-cell/table-body-cell.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, h, Host, Listen, Prop, State } from '@stencil/core';
-import { internalSddsChange } from '../table/table';
+import { InternalSddsPropChange } from '../table/table';
 
-const relevantTableProps: internalSddsChange['changed'] = [
+const relevantTableProps: InternalSddsPropChange['changed'] = [
   'verticalDividers',
   'compactDesign',
   'noMinWidth',
@@ -39,8 +39,8 @@ export class TableBodyCell {
 
   tableEl: HTMLSddsTableElement;
 
-  @Listen('internalSddsChange', { target: 'body' })
-  internalSddsChangeListener(event: CustomEvent<internalSddsChange>) {
+  @Listen('internalSddsPropChange', { target: 'body' })
+  internalSddsPropChangeListener(event: CustomEvent<InternalSddsPropChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))

--- a/tegel/src/components/data-table/table-body-cell/table-body-cell.tsx
+++ b/tegel/src/components/data-table/table-body-cell/table-body-cell.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, h, Host, Listen, Prop, State } from '@stencil/core';
-import { TablePropsChangedEvent } from '../table/table';
+import { internalSddsChange } from '../table/table';
 
-const relevantTableProps: TablePropsChangedEvent['changed'] = [
+const relevantTableProps: internalSddsChange['changed'] = [
   'verticalDividers',
   'compactDesign',
   'noMinWidth',
@@ -39,8 +39,8 @@ export class TableBodyCell {
 
   tableEl: HTMLSddsTableElement;
 
-  @Listen('tablePropsChangedEvent', { target: 'body' })
-  tablePropsChangedEventListener(event: CustomEvent<TablePropsChangedEvent>) {
+  @Listen('internalSddsChange', { target: 'body' })
+  internalSddsChangeListener(event: CustomEvent<internalSddsChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))
@@ -54,8 +54,8 @@ export class TableBodyCell {
   }
 
   // Listen to headKey from data-table-header-element
-  @Listen('headCellHoverEvent', { target: 'body' })
-  headCellHoverEventListener(event: CustomEvent<any>) {
+  @Listen('internalSddsHover', { target: 'body' })
+  internalSddsHoverListener(event: CustomEvent<any>) {
     const [receivedID, receivedKeyValue] = event.detail;
 
     if (this.tableId === receivedID) {
@@ -63,9 +63,9 @@ export class TableBodyCell {
     }
   }
 
-  // Listen to textAlignEvent from data-table-header-element
-  @Listen('textAlignEvent', { target: 'body' })
-  textAlignEventListener(event: CustomEvent<any>) {
+  // Listen to internalSddsTextAlign from data-table-header-element
+  @Listen('internalSddsTextAlign', { target: 'body' })
+  internalSddsTextAlignListener(event: CustomEvent<any>) {
     const [receivedID, receivedKey, receivedTextAlign] = event.detail;
 
     if (this.tableId === receivedID) {

--- a/tegel/src/components/data-table/table-body-row-expandable/readme.md
+++ b/tegel/src/components/data-table/table-body-row-expandable/readme.md
@@ -14,10 +14,9 @@
 
 ## Events
 
-| Event                    | Description                                                                                                      | Type                  |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------- | --------------------- |
-| `runPaginationEvent`     | Event that triggers pagination function. Needed as first rows have to be rendered in order for pagination to run | `CustomEvent<string>` |
-| `singleRowExpandedEvent` | Sends out status of itw own expended status feature to table header component                                    | `CustomEvent<any>`    |
+| Event            | Description                                                                                                      | Type                  |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `sddsPagination` | Event that triggers pagination function. Needed as first rows have to be rendered in order for pagination to run | `CustomEvent<string>` |
 
 
 ----------------------------------------------

--- a/tegel/src/components/data-table/table-body-row-expandable/readme.md
+++ b/tegel/src/components/data-table/table-body-row-expandable/readme.md
@@ -12,13 +12,6 @@
 | `colSpan` | `col-span` | In case that automatic count of columns does not work, user can manually set this one. Take in mind that expandable control is column too | `number` | `null`  |
 
 
-## Events
-
-| Event            | Description                                                                                                      | Type                  |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------- | --------------------- |
-| `sddsPagination` | Event that triggers pagination function. Needed as first rows have to be rendered in order for pagination to run | `CustomEvent<string>` |
-
-
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/tegel/src/components/data-table/table-body-row-expandable/table-body-row-expandable.tsx
+++ b/tegel/src/components/data-table/table-body-row-expandable/table-body-row-expandable.tsx
@@ -9,9 +9,9 @@ import {
   Prop,
   State,
 } from '@stencil/core';
-import { InternalSddsPropChange } from '../table/table';
+import { InternalSddsTablePropChange } from '../table/table';
 
-const relevantTableProps: InternalSddsPropChange['changed'] = [
+const relevantTableProps: InternalSddsTablePropChange['changed'] = [
   'verticalDividers',
   'compactDesign',
   'noMinWidth',
@@ -63,7 +63,7 @@ export class TableBodyRowExpandable {
   internalSddsPagination: EventEmitter<string>;
 
   @Listen('internalSddsTablePropChange', { target: 'body' })
-  internalSddsPropChangeListener(event: CustomEvent<InternalSddsPropChange>) {
+  internalSddsPropChangeListener(event: CustomEvent<InternalSddsTablePropChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))

--- a/tegel/src/components/data-table/table-body-row-expandable/table-body-row-expandable.tsx
+++ b/tegel/src/components/data-table/table-body-row-expandable/table-body-row-expandable.tsx
@@ -9,9 +9,9 @@ import {
   Prop,
   State,
 } from '@stencil/core';
-import { TablePropsChangedEvent } from '../table/table';
+import { internalSddsChange } from '../table/table';
 
-const relevantTableProps: TablePropsChangedEvent['changed'] = [
+const relevantTableProps: internalSddsChange['changed'] = [
   'verticalDividers',
   'compactDesign',
   'noMinWidth',
@@ -44,26 +44,26 @@ export class TableBodyRowExpandable {
 
   tableEl: HTMLSddsTableElement;
 
-  /** Sends out status of itw own expended status feature to table header component */
+  /** @internal Sends out status of itw own expended status feature to table header component */
   @Event({
-    eventName: 'singleRowExpandedEvent',
+    eventName: 'internalSddsRowExpanded',
     bubbles: true,
     cancelable: true,
     composed: true,
   })
-  singleRowExpandedEvent: EventEmitter<any>;
+  internalSddsRowExpanded: EventEmitter<any>;
 
   /** Event that triggers pagination function. Needed as first rows have to be rendered in order for pagination to run */
   @Event({
-    eventName: 'runPaginationEvent',
+    eventName: 'sddsPagination',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  runPaginationEvent: EventEmitter<string>;
+  sddsPagination: EventEmitter<string>;
 
-  @Listen('tablePropsChangedEvent', { target: 'body' })
-  tablePropsChangedEventListener(event: CustomEvent<TablePropsChangedEvent>) {
+  @Listen('internalSddsChange', { target: 'body' })
+  internalSddsChangeListener(event: CustomEvent<internalSddsChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))
@@ -88,7 +88,7 @@ export class TableBodyRowExpandable {
   }
 
   componentDidLoad() {
-    this.runPaginationEvent.emit(this.tableId);
+    this.sddsPagination.emit(this.tableId);
   }
 
   componentWillRender() {
@@ -100,7 +100,7 @@ export class TableBodyRowExpandable {
   }
 
   sendValue() {
-    this.singleRowExpandedEvent.emit([this.tableId, this.isExpanded]);
+    this.internalSddsRowExpanded.emit([this.tableId, this.isExpanded]);
   }
 
   onChangeHandler(event) {

--- a/tegel/src/components/data-table/table-body-row-expandable/table-body-row-expandable.tsx
+++ b/tegel/src/components/data-table/table-body-row-expandable/table-body-row-expandable.tsx
@@ -9,9 +9,9 @@ import {
   Prop,
   State,
 } from '@stencil/core';
-import { internalSddsChange } from '../table/table';
+import { InternalSddsPropChange } from '../table/table';
 
-const relevantTableProps: internalSddsChange['changed'] = [
+const relevantTableProps: InternalSddsPropChange['changed'] = [
   'verticalDividers',
   'compactDesign',
   'noMinWidth',
@@ -62,8 +62,8 @@ export class TableBodyRowExpandable {
   })
   sddsPagination: EventEmitter<string>;
 
-  @Listen('internalSddsChange', { target: 'body' })
-  internalSddsChangeListener(event: CustomEvent<internalSddsChange>) {
+  @Listen('internalSddsPropChange', { target: 'body' })
+  internalSddsPropChangeListener(event: CustomEvent<InternalSddsPropChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))

--- a/tegel/src/components/data-table/table-body-row-expandable/table-body-row-expandable.tsx
+++ b/tegel/src/components/data-table/table-body-row-expandable/table-body-row-expandable.tsx
@@ -62,7 +62,7 @@ export class TableBodyRowExpandable {
   })
   sddsPagination: EventEmitter<string>;
 
-  @Listen('internalSddsPropChange', { target: 'body' })
+  @Listen('internalSddsTablePropChange', { target: 'body' })
   internalSddsPropChangeListener(event: CustomEvent<InternalSddsPropChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed

--- a/tegel/src/components/data-table/table-body-row-expandable/table-body-row-expandable.tsx
+++ b/tegel/src/components/data-table/table-body-row-expandable/table-body-row-expandable.tsx
@@ -44,7 +44,7 @@ export class TableBodyRowExpandable {
 
   tableEl: HTMLSddsTableElement;
 
-  /** @internal Sends out status of itw own expended status feature to table header component */
+  /** @internal Sends out expanded status which is used by the table header component */
   @Event({
     eventName: 'internalSddsRowExpanded',
     bubbles: true,
@@ -53,14 +53,14 @@ export class TableBodyRowExpandable {
   })
   internalSddsRowExpanded: EventEmitter<any>;
 
-  /** Event that triggers pagination function. Needed as first rows have to be rendered in order for pagination to run */
+  /** @internal Event that triggers pagination function. Needed as first rows have to be rendered in order for pagination to run */
   @Event({
-    eventName: 'sddsPagination',
+    eventName: 'internalSddsPagination',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  sddsPagination: EventEmitter<string>;
+  internalSddsPagination: EventEmitter<string>;
 
   @Listen('internalSddsTablePropChange', { target: 'body' })
   internalSddsPropChangeListener(event: CustomEvent<InternalSddsPropChange>) {
@@ -88,7 +88,7 @@ export class TableBodyRowExpandable {
   }
 
   componentDidLoad() {
-    this.sddsPagination.emit(this.tableId);
+    this.internalSddsPagination.emit(this.tableId);
   }
 
   componentWillRender() {

--- a/tegel/src/components/data-table/table-body-row/readme.md
+++ b/tegel/src/components/data-table/table-body-row/readme.md
@@ -7,10 +7,9 @@
 
 ## Events
 
-| Event                | Description                                                                                                             | Type                   |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------- | ---------------------- |
-| `bodyRowToTable`     | Send status of single row to the parent, sdds-table component that hold logic for data export and main checkbox control | `CustomEvent<boolean>` |
-| `runPaginationEvent` | Event that triggers pagination function. Needed as first rows have to be rendered in order for pagination to run        | `CustomEvent<string>`  |
+| Event            | Description                                                                                                      | Type                  |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `sddsPagination` | Event that triggers pagination function. Needed as first rows have to be rendered in order for pagination to run | `CustomEvent<string>` |
 
 
 ## Dependencies

--- a/tegel/src/components/data-table/table-body-row/readme.md
+++ b/tegel/src/components/data-table/table-body-row/readme.md
@@ -5,13 +5,6 @@
 <!-- Auto Generated Below -->
 
 
-## Events
-
-| Event            | Description                                                                                                      | Type                  |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------- | --------------------- |
-| `sddsPagination` | Event that triggers pagination function. Needed as first rows have to be rendered in order for pagination to run | `CustomEvent<string>` |
-
-
 ## Dependencies
 
 ### Used by

--- a/tegel/src/components/data-table/table-body-row/table-body-row.tsx
+++ b/tegel/src/components/data-table/table-body-row/table-body-row.tsx
@@ -89,7 +89,7 @@ export class TableBodyRow {
   })
   sddsPagination: EventEmitter<string>;
 
-  @Listen('internalSddsMainCheckboxChange', { target: 'body' })
+  @Listen('internalSddsMainCheckboxSelect', { target: 'body' })
   headCheckboxListener(event: CustomEvent<any>) {
     if (this.tableId === event.detail[0]) {
       this.bodyCheckBoxStatusUpdater(event.detail[1]);

--- a/tegel/src/components/data-table/table-body-row/table-body-row.tsx
+++ b/tegel/src/components/data-table/table-body-row/table-body-row.tsx
@@ -80,14 +80,14 @@ export class TableBodyRow {
   })
   internalSddsRowChange: EventEmitter<boolean>;
 
-  /** Event that triggers pagination function. Needed as first rows have to be rendered in order for pagination to run */
+  /** @internal Event that triggers pagination function. Needed as first rows have to be rendered in order for pagination to run */
   @Event({
-    eventName: 'sddsPagination',
+    eventName: 'internalSddsPagination',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  sddsPagination: EventEmitter<string>;
+  internalSddsPagination: EventEmitter<string>;
 
   @Listen('internalSddsMainCheckboxSelect', { target: 'body' })
   headCheckboxListener(event: CustomEvent<any>) {
@@ -116,7 +116,7 @@ export class TableBodyRow {
   }
 
   componentDidLoad() {
-    this.sddsPagination.emit(this.tableId);
+    this.internalSddsPagination.emit(this.tableId);
   }
 
   render() {

--- a/tegel/src/components/data-table/table-body-row/table-body-row.tsx
+++ b/tegel/src/components/data-table/table-body-row/table-body-row.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, h, Host, State, Event, EventEmitter, Listen } from '@stencil/core';
-import { InternalSddsPropChange } from '../table/table';
+import { InternalSddsTablePropChange } from '../table/table';
 
-const relevantTableProps: InternalSddsPropChange['changed'] = [
+const relevantTableProps: InternalSddsTablePropChange['changed'] = [
   'enableMultiselect',
   'verticalDividers',
   'compactDesign',
@@ -58,7 +58,7 @@ export class TableBodyRow {
   }
 
   @Listen('internalSddsTablePropChange', { target: 'body' })
-  internalSddsPropChangeListener(event: CustomEvent<InternalSddsPropChange>) {
+  internalSddsPropChangeListener(event: CustomEvent<InternalSddsTablePropChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))

--- a/tegel/src/components/data-table/table-body-row/table-body-row.tsx
+++ b/tegel/src/components/data-table/table-body-row/table-body-row.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, h, Host, State, Event, EventEmitter, Listen } from '@stencil/core';
-import { internalSddsChange } from '../table/table';
+import { InternalSddsPropChange } from '../table/table';
 
-const relevantTableProps: internalSddsChange['changed'] = [
+const relevantTableProps: InternalSddsPropChange['changed'] = [
   'enableMultiselect',
   'verticalDividers',
   'compactDesign',
@@ -57,8 +57,8 @@ export class TableBodyRow {
     this.internalSddsRowChange.emit(this.bodyCheckBoxStatus);
   }
 
-  @Listen('internalSddsChange', { target: 'body' })
-  internalSddsChangeListener(event: CustomEvent<internalSddsChange>) {
+  @Listen('internalSddsPropChange', { target: 'body' })
+  internalSddsPropChangeListener(event: CustomEvent<InternalSddsPropChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))

--- a/tegel/src/components/data-table/table-body-row/table-body-row.tsx
+++ b/tegel/src/components/data-table/table-body-row/table-body-row.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, h, Host, State, Event, EventEmitter, Listen } from '@stencil/core';
-import { TablePropsChangedEvent } from '../table/table';
+import { internalSddsChange } from '../table/table';
 
-const relevantTableProps: TablePropsChangedEvent['changed'] = [
+const relevantTableProps: internalSddsChange['changed'] = [
   'enableMultiselect',
   'verticalDividers',
   'compactDesign',
@@ -42,7 +42,7 @@ export class TableBodyRow {
     } else {
       row.classList.remove('sdds-table__row--selected');
     }
-    this.bodyRowToTable.emit(this.bodyCheckBoxStatus);
+    this.internalSddsRowChange.emit(this.bodyCheckBoxStatus);
   }
 
   bodyCheckBoxStatusUpdater(status) {
@@ -54,11 +54,11 @@ export class TableBodyRow {
     } else {
       row.classList.remove('sdds-table__row--selected');
     }
-    this.bodyRowToTable.emit(this.bodyCheckBoxStatus);
+    this.internalSddsRowChange.emit(this.bodyCheckBoxStatus);
   }
 
-  @Listen('tablePropsChangedEvent', { target: 'body' })
-  tablePropsChangedEventListener(event: CustomEvent<TablePropsChangedEvent>) {
+  @Listen('internalSddsChange', { target: 'body' })
+  internalSddsChangeListener(event: CustomEvent<internalSddsChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))
@@ -71,33 +71,33 @@ export class TableBodyRow {
     }
   }
 
-  /** Send status of single row to the parent, sdds-table component that hold logic for data export and main checkbox control */
+  /** @internal Send status of single row to the parent, sdds-table component that hold logic for data export and main checkbox control */
   @Event({
-    eventName: 'bodyRowToTable',
+    eventName: 'internalSddsRowChange',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  bodyRowToTable: EventEmitter<boolean>;
+  internalSddsRowChange: EventEmitter<boolean>;
 
   /** Event that triggers pagination function. Needed as first rows have to be rendered in order for pagination to run */
   @Event({
-    eventName: 'runPaginationEvent',
+    eventName: 'sddsPagination',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  runPaginationEvent: EventEmitter<string>;
+  sddsPagination: EventEmitter<string>;
 
-  @Listen('mainCheckboxSelectedEvent', { target: 'body' })
+  @Listen('internalSddsMainCheckboxChange', { target: 'body' })
   headCheckboxListener(event: CustomEvent<any>) {
     if (this.tableId === event.detail[0]) {
       this.bodyCheckBoxStatusUpdater(event.detail[1]);
     }
   }
 
-  @Listen('updateBodyCheckboxesEvent', { target: 'body' })
-  updateBodyCheckboxesEventListener(event: CustomEvent<any>) {
+  @Listen('internalSddsCheckboxChange', { target: 'body' })
+  internalSddsCheckboxChangeListener(event: CustomEvent<any>) {
     const [receivedID, receivedBodyCheckboxStatus] = event.detail;
     if (this.tableId === receivedID) {
       this.bodyCheckBoxStatusUpdater(receivedBodyCheckboxStatus);
@@ -116,7 +116,7 @@ export class TableBodyRow {
   }
 
   componentDidLoad() {
-    this.runPaginationEvent.emit(this.tableId);
+    this.sddsPagination.emit(this.tableId);
   }
 
   render() {

--- a/tegel/src/components/data-table/table-body-row/table-body-row.tsx
+++ b/tegel/src/components/data-table/table-body-row/table-body-row.tsx
@@ -57,7 +57,7 @@ export class TableBodyRow {
     this.internalSddsRowChange.emit(this.bodyCheckBoxStatus);
   }
 
-  @Listen('internalSddsPropChange', { target: 'body' })
+  @Listen('internalSddsTablePropChange', { target: 'body' })
   internalSddsPropChangeListener(event: CustomEvent<InternalSddsPropChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed

--- a/tegel/src/components/data-table/table-body/readme.md
+++ b/tegel/src/components/data-table/table-body/readme.md
@@ -15,15 +15,6 @@
 | `enableDummyData`          | `enable-dummy-data`          | Prop for showcase of rendering JSON in body-data, just for presentation purposes                                                                                        | `boolean` | `false`     |
 
 
-## Events
-
-| Event                       | Description                                                                                                                                                | Type               |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
-| `sortingSwitcherEvent`      | Event that sends unique table identifier and enable/disable status for sorting functionality                                                               | `CustomEvent<any>` |
-| `updateBodyCheckboxesEvent` | Sends unique table identifier and mainCheckbox status to all rows when multiselect feature is enabled                                                      | `CustomEvent<any>` |
-| `updateMainCheckboxEvent`   | Sends unique table identifier and status if mainCheckbox should change its state based on selection status of single rows when multiselect feature is used | `CustomEvent<any>` |
-
-
 ## Dependencies
 
 ### Depends on

--- a/tegel/src/components/data-table/table-body/table-body.tsx
+++ b/tegel/src/components/data-table/table-body/table-body.tsx
@@ -11,9 +11,9 @@ import {
   Watch,
 } from '@stencil/core';
 import dummyData from './dummy-data.json';
-import { InternalSddsPropChange } from '../table/table';
+import { InternalSddsTablePropChange } from '../table/table';
 
-const relevantTableProps: InternalSddsPropChange['changed'] = [
+const relevantTableProps: InternalSddsTablePropChange['changed'] = [
   'enableMultiselect',
   'enableExpandableRows',
 ];
@@ -115,7 +115,7 @@ export class TableBody {
   internalSddsMainCheckboxChange: EventEmitter<any>;
 
   @Listen('internalSddsTablePropChange', { target: 'body' })
-  internalSddsPropChangeListener(event: CustomEvent<InternalSddsPropChange>) {
+  internalSddsPropChangeListener(event: CustomEvent<InternalSddsTablePropChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))

--- a/tegel/src/components/data-table/table-body/table-body.tsx
+++ b/tegel/src/components/data-table/table-body/table-body.tsx
@@ -114,7 +114,7 @@ export class TableBody {
   })
   internalSddsMainCheckboxChange: EventEmitter<any>;
 
-  @Listen('internalSddsPropChange', { target: 'body' })
+  @Listen('internalSddsTablePropChange', { target: 'body' })
   internalSddsPropChangeListener(event: CustomEvent<InternalSddsPropChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed

--- a/tegel/src/components/data-table/table-body/table-body.tsx
+++ b/tegel/src/components/data-table/table-body/table-body.tsx
@@ -11,9 +11,9 @@ import {
   Watch,
 } from '@stencil/core';
 import dummyData from './dummy-data.json';
-import { internalSddsChange } from '../table/table';
+import { InternalSddsPropChange } from '../table/table';
 
-const relevantTableProps: internalSddsChange['changed'] = [
+const relevantTableProps: InternalSddsPropChange['changed'] = [
   'enableMultiselect',
   'enableExpandableRows',
 ];
@@ -114,8 +114,8 @@ export class TableBody {
   })
   internalSddsMainCheckboxChange: EventEmitter<any>;
 
-  @Listen('internalSddsChange', { target: 'body' })
-  internalSddsChangeListener(event: CustomEvent<internalSddsChange>) {
+  @Listen('internalSddsPropChange', { target: 'body' })
+  internalSddsPropChangeListener(event: CustomEvent<InternalSddsPropChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))
@@ -194,7 +194,7 @@ export class TableBody {
     this.multiselectArrayJSON = JSON.stringify(this.multiselectArray);
   };
 
-  @Listen('internalSddsMainCheckboxChange', { target: 'body' }) // - 
+  @Listen('internalSddsMainCheckboxChange', { target: 'body' }) // -
   headCheckboxListener(event: CustomEvent<any>) {
     if (this.tableId === event.detail[0]) {
       [, this.mainCheckboxStatus] = event.detail;

--- a/tegel/src/components/data-table/table-body/table-body.tsx
+++ b/tegel/src/components/data-table/table-body/table-body.tsx
@@ -169,7 +169,7 @@ export class TableBody {
   }
 
   // Listen to sortColumnData from data-table-header-element - TODO
-  @Listen('internalSddsSortColumn', { target: 'body' })
+  @Listen('sddsSortChange', { target: 'body' })
   updateOptionsContent(event: CustomEvent<any>) {
     const [receivedID, receivedKeyValue, receivedSortingDirection] = event.detail;
     if (this.tableId === receivedID) {
@@ -298,9 +298,9 @@ export class TableBody {
     }
   }
 
-  // Listen to internalSddsFilter from tableToolbar component
-  @Listen('internalSddsFilter', { target: 'body' })
-  internalSddsFilterListener(event: CustomEvent<any>) {
+  // Listen to sddsFilter from tableToolbar component
+  @Listen('sddsFilter', { target: 'body' })
+  sddsFilterListener(event: CustomEvent<any>) {
     if (this.tableId === event.detail[0]) {
       this.searchFunction(event.detail[1]);
     }

--- a/tegel/src/components/data-table/table-body/table-body.tsx
+++ b/tegel/src/components/data-table/table-body/table-body.tsx
@@ -11,9 +11,9 @@ import {
   Watch,
 } from '@stencil/core';
 import dummyData from './dummy-data.json';
-import { TablePropsChangedEvent } from '../table/table';
+import { internalSddsChange } from '../table/table';
 
-const relevantTableProps: TablePropsChangedEvent['changed'] = [
+const relevantTableProps: internalSddsChange['changed'] = [
   'enableMultiselect',
   'enableExpandableRows',
 ];
@@ -115,7 +115,7 @@ export class TableBody {
   internalSddsMainCheckboxChange: EventEmitter<any>;
 
   @Listen('internalSddsChange', { target: 'body' })
-  tablePropsChangedEventListener(event: CustomEvent<TablePropsChangedEvent>) {
+  internalSddsChangeListener(event: CustomEvent<internalSddsChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))
@@ -169,7 +169,7 @@ export class TableBody {
   }
 
   // Listen to sortColumnData from data-table-header-element - TODO
-  @Listen('sortColumnDataEvent', { target: 'body' })
+  @Listen('internalSddsSortColumn', { target: 'body' })
   updateOptionsContent(event: CustomEvent<any>) {
     const [receivedID, receivedKeyValue, receivedSortingDirection] = event.detail;
     if (this.tableId === receivedID) {
@@ -193,7 +193,7 @@ export class TableBody {
     }
     this.multiselectArrayJSON = JSON.stringify(this.multiselectArray);
   };
-´
+
   @Listen('internalSddsMainCheckboxChange', { target: 'body' }) // - 
   headCheckboxListener(event: CustomEvent<any>) {
     if (this.tableId === event.detail[0]) {
@@ -217,7 +217,7 @@ export class TableBody {
   };
 
   // No need to read the value, event is here just to trigger another function
-  @Listen('bodyRowToTable', { target: 'body' })
+  @Listen('internalSddsRowChange', { target: 'body' })
   bodyCheckboxListener() {
     this.bodyCheckBoxClicked();
   }
@@ -298,9 +298,9 @@ export class TableBody {
     }
   }
 
-  // Listen to tableFilteringTerm from tableToolbar component
-  @Listen('tableFilteringTerm', { target: 'body' })
-  tableFilteringTermListener(event: CustomEvent<any>) {
+  // Listen to internalSddsFilter from tableToolbar component
+  @Listen('internalSddsFilter', { target: 'body' })
+  internalSddsFilterListener(event: CustomEvent<any>) {
     if (this.tableId === event.detail[0]) {
       this.searchFunction(event.detail[1]);
     }

--- a/tegel/src/components/data-table/table-body/table-body.tsx
+++ b/tegel/src/components/data-table/table-body/table-body.tsx
@@ -87,34 +87,34 @@ export class TableBody {
     this.bodyDataOriginal = [...this.innerBodyData];
   }
 
-  /** Event that sends unique table identifier and enable/disable status for sorting functionality */
+  /** @internal Event that sends unique table identifier and enable/disable status for sorting functionality */
   @Event({
-    eventName: 'sortingSwitcherEvent',
+    eventName: 'internalSddsSortingChange',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  sortingSwitcherEvent: EventEmitter<any>;
+  internalSddsSortingChange: EventEmitter<any>;
 
-  /** Sends unique table identifier and mainCheckbox status to all rows when multiselect feature is enabled */
+  /** @internal Sends unique table identifier and mainCheckbox status to all rows when multiselect feature is enabled */
   @Event({
-    eventName: 'updateBodyCheckboxesEvent',
+    eventName: 'internalSddsCheckboxChange',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  updateBodyCheckboxesEvent: EventEmitter<any>;
+  internalSddsCheckboxChange: EventEmitter<any>;
 
-  /** Sends unique table identifier and status if mainCheckbox should change its state based on selection status of single rows when multiselect feature is used */
+  /** @internal Sends unique table identifier and status if mainCheckbox should change its state based on selection status of single rows when multiselect feature is used */
   @Event({
-    eventName: 'updateMainCheckboxEvent',
+    eventName: 'internalSddsMainCheckboxChange',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  updateMainCheckboxEvent: EventEmitter<any>;
+  internalSddsMainCheckboxChange: EventEmitter<any>;
 
-  @Listen('tablePropsChangedEvent', { target: 'body' })
+  @Listen('internalSddsChange', { target: 'body' })
   tablePropsChangedEventListener(event: CustomEvent<TablePropsChangedEvent>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
@@ -151,8 +151,8 @@ export class TableBody {
 
   uncheckAll = () => {
     this.mainCheckboxStatus = false;
-    this.updateMainCheckboxEvent.emit([this.tableId, this.mainCheckboxStatus]);
-    this.updateBodyCheckboxesEvent.emit([this.tableId, this.mainCheckboxStatus]);
+    this.internalSddsMainCheckboxChange.emit([this.tableId, this.mainCheckboxStatus]);
+    this.internalSddsCheckboxChange.emit([this.tableId, this.mainCheckboxStatus]);
   };
 
   sortData(keyValue, sortingDirection) {
@@ -168,7 +168,7 @@ export class TableBody {
     }
   }
 
-  // Listen to sortColumnData from data-table-header-element
+  // Listen to sortColumnData from data-table-header-element - TODO
   @Listen('sortColumnDataEvent', { target: 'body' })
   updateOptionsContent(event: CustomEvent<any>) {
     const [receivedID, receivedKeyValue, receivedSortingDirection] = event.detail;
@@ -193,8 +193,8 @@ export class TableBody {
     }
     this.multiselectArrayJSON = JSON.stringify(this.multiselectArray);
   };
-
-  @Listen('mainCheckboxSelectedEvent', { target: 'body' })
+´
+  @Listen('internalSddsMainCheckboxChange', { target: 'body' }) // - 
   headCheckboxListener(event: CustomEvent<any>) {
     if (this.tableId === event.detail[0]) {
       [, this.mainCheckboxStatus] = event.detail;
@@ -211,7 +211,7 @@ export class TableBody {
 
     this.mainCheckboxStatus = numberOfRows === numberOfRowsSelected;
 
-    this.updateMainCheckboxEvent.emit([this.tableId, this.mainCheckboxStatus]);
+    this.internalSddsMainCheckboxChange.emit([this.tableId, this.mainCheckboxStatus]);
 
     this.selectedDataExporter();
   };
@@ -272,7 +272,7 @@ export class TableBody {
         });
 
         this.disableAllSorting = true;
-        this.sortingSwitcherEvent.emit([this.tableId, this.disableAllSorting]);
+        this.internalSddsSortingChange.emit([this.tableId, this.disableAllSorting]);
 
         const dataRowsHidden = this.host.querySelectorAll('.sdds-table__row--hidden');
 
@@ -293,7 +293,7 @@ export class TableBody {
         }
 
         this.disableAllSorting = false;
-        this.sortingSwitcherEvent.emit([this.tableId, this.disableAllSorting]);
+        this.internalSddsSortingChange.emit([this.tableId, this.disableAllSorting]);
       }
     }
   }

--- a/tegel/src/components/data-table/table-component-event-listeners.stories.tsx
+++ b/tegel/src/components/data-table/table-component-event-listeners.stories.tsx
@@ -143,8 +143,8 @@ const EventListenersTemplate = ({
         document.getElementById('event-value-textarea').value = e.detail;
       });
 
-      window.addEventListener('sddsPaginationChange', e => {
-        document.getElementById('event-name-textarea').value = 'sddsPaginationChange';
+      window.addEventListener('sddsPageChange', e => {
+        document.getElementById('event-name-textarea').value = 'sddsPageChange';
         document.getElementById('event-value-textarea').value = e.detail;
       });
     </script>

--- a/tegel/src/components/data-table/table-component-event-listeners.stories.tsx
+++ b/tegel/src/components/data-table/table-component-event-listeners.stories.tsx
@@ -133,18 +133,18 @@ const EventListenersTemplate = ({
   formatHtmlPreview(`
     <script>
       // Note: Script here is only for demo purposes
-      window.addEventListener('tableFilteringTerm', e => {
-        document.getElementById('event-name-textarea').value = 'tableFilteringTerm';
+      window.addEventListener('internalSddsFilter', e => {
+        document.getElementById('event-name-textarea').value = 'internalSddsFilter';
         document.getElementById('event-value-textarea').value = e.detail;
       });
 
-      window.addEventListener('sortColumnDataEvent', e => {
-        document.getElementById('event-name-textarea').value = 'sortColumnDataEvent';
+      window.addEventListener('internalSddsSortColumn', e => {
+        document.getElementById('event-name-textarea').value = 'internalSddsSortColumn';
         document.getElementById('event-value-textarea').value = e.detail;
       });
 
-      window.addEventListener('currentPageValueEvent', e => {
-        document.getElementById('event-name-textarea').value = 'currentPageValueEvent';
+      window.addEventListener('internalSddsCurrentPage', e => {
+        document.getElementById('event-name-textarea').value = 'internalSddsCurrentPage';
         document.getElementById('event-value-textarea').value = e.detail;
       });
     </script>

--- a/tegel/src/components/data-table/table-component-event-listeners.stories.tsx
+++ b/tegel/src/components/data-table/table-component-event-listeners.stories.tsx
@@ -133,18 +133,18 @@ const EventListenersTemplate = ({
   formatHtmlPreview(`
     <script>
       // Note: Script here is only for demo purposes
-      window.addEventListener('internalSddsFilter', e => {
-        document.getElementById('event-name-textarea').value = 'internalSddsFilter';
+      window.addEventListener('sddsFilter', e => {
+        document.getElementById('event-name-textarea').value = 'sddsFilter';
         document.getElementById('event-value-textarea').value = e.detail;
       });
 
-      window.addEventListener('internalSddsSortColumn', e => {
-        document.getElementById('event-name-textarea').value = 'internalSddsSortColumn';
+      window.addEventListener('sddsSortChange', e => {
+        document.getElementById('event-name-textarea').value = 'sddsSortChange';
         document.getElementById('event-value-textarea').value = e.detail;
       });
 
-      window.addEventListener('internalSddsCurrentPage', e => {
-        document.getElementById('event-name-textarea').value = 'internalSddsCurrentPage';
+      window.addEventListener('sddsPaginationChange', e => {
+        document.getElementById('event-name-textarea').value = 'sddsPaginationChange';
         document.getElementById('event-value-textarea').value = e.detail;
       });
     </script>

--- a/tegel/src/components/data-table/table-footer/readme.md
+++ b/tegel/src/components/data-table/table-footer/readme.md
@@ -18,14 +18,6 @@
 | `rowsPerPage`               | `rows-per-page`               | Sets how many rows to display when pagination is enabled                                                                                                    | `number`  | `5`     |
 
 
-## Events
-
-| Event                   | Description                                                                                          | Type               |
-| ----------------------- | ---------------------------------------------------------------------------------------------------- | ------------------ |
-| `currentPageValueEvent` | Event to send current page value back to sdds-table-body component                                   | `CustomEvent<any>` |
-| `enablePaginationEvent` | Event that footer sends out in order to receive other necessary information from other subcomponents | `CustomEvent<any>` |
-
-
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/tegel/src/components/data-table/table-footer/readme.md
+++ b/tegel/src/components/data-table/table-footer/readme.md
@@ -20,9 +20,9 @@
 
 ## Events
 
-| Event                  | Description                                                                                                                                | Type               |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------ |
-| `sddsPaginationChange` | Event to send current page value back to sdds-table-body component, can also be listened to in order to implement custom pagination logic. | `CustomEvent<any>` |
+| Event            | Description                                                                                                                                | Type               |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------ |
+| `sddsPageChange` | Event to send current page value back to sdds-table-body component, can also be listened to in order to implement custom pagination logic. | `CustomEvent<any>` |
 
 
 ----------------------------------------------

--- a/tegel/src/components/data-table/table-footer/readme.md
+++ b/tegel/src/components/data-table/table-footer/readme.md
@@ -18,6 +18,13 @@
 | `rowsPerPage`               | `rows-per-page`               | Sets how many rows to display when pagination is enabled                                                                                                    | `number`  | `5`     |
 
 
+## Events
+
+| Event                  | Description                                                                                                                                | Type               |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------ |
+| `sddsPaginationChange` | Event to send current page value back to sdds-table-body component, can also be listened to in order to implement custom pagination logic. | `CustomEvent<any>` |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/tegel/src/components/data-table/table-footer/table-footer.tsx
+++ b/tegel/src/components/data-table/table-footer/table-footer.tsx
@@ -9,9 +9,9 @@ import {
   Prop,
   Element,
 } from '@stencil/core';
-import { InternalSddsPropChange } from '../table/table';
+import { InternalSddsTablePropChange } from '../table/table';
 
-const relevantTableProps: InternalSddsPropChange['changed'] = [
+const relevantTableProps: InternalSddsTablePropChange['changed'] = [
   'compactDesign',
   'noMinWidth',
   'verticalDividers',
@@ -84,7 +84,7 @@ export class TableFooter {
   internalSddsEnablePagination: EventEmitter<any>;
 
   @Listen('internalSddsTablePropChange', { target: 'body' })
-  internalSddsPropChangeListener(event: CustomEvent<InternalSddsPropChange>) {
+  internalSddsPropChangeListener(event: CustomEvent<InternalSddsTablePropChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))

--- a/tegel/src/components/data-table/table-footer/table-footer.tsx
+++ b/tegel/src/components/data-table/table-footer/table-footer.tsx
@@ -83,7 +83,7 @@ export class TableFooter {
   })
   internalSddsEnablePagination: EventEmitter<any>;
 
-  @Listen('internalSddsPropChange', { target: 'body' })
+  @Listen('internalSddsTablePropChange', { target: 'body' })
   internalSddsPropChangeListener(event: CustomEvent<InternalSddsPropChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
@@ -191,15 +191,15 @@ export class TableFooter {
 
   /** Event to send current page value back to sdds-table-body component, can also be listened to in order to implement custom pagination logic. */
   @Event({
-    eventName: 'sddsPaginationChange',
+    eventName: 'sddsPageChange',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  sddsPaginationChange: EventEmitter<any>;
+  sddsPageChange: EventEmitter<any>;
 
   sendPaginationValue(value) {
-    this.sddsPaginationChange.emit([this.tableId, value]);
+    this.sddsPageChange.emit([this.tableId, value]);
   }
 
   clientPaginationPrev = (event) => {

--- a/tegel/src/components/data-table/table-footer/table-footer.tsx
+++ b/tegel/src/components/data-table/table-footer/table-footer.tsx
@@ -153,7 +153,7 @@ export class TableFooter {
     this.runPagination();
   }
 
-  @Listen('sddsPagination', { target: 'body' })
+  @Listen('internalSddsPagination', { target: 'body' })
   sddsPaginationListener(event: CustomEvent<any>) {
     if (this.tableId === event.detail) {
       this.runPagination();

--- a/tegel/src/components/data-table/table-footer/table-footer.tsx
+++ b/tegel/src/components/data-table/table-footer/table-footer.tsx
@@ -189,17 +189,17 @@ export class TableFooter {
 
   /* Client based functions below */
 
-  /** @internal Event to send current page value back to sdds-table-body component */
+  /** Event to send current page value back to sdds-table-body component, can also be listened to in order to implement custom pagination logic. */
   @Event({
-    eventName: 'internalSddsCurrentPage',
+    eventName: 'sddsPaginationChange',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  internalSddsCurrentPage: EventEmitter<any>;
+  sddsPaginationChange: EventEmitter<any>;
 
   sendPaginationValue(value) {
-    this.internalSddsCurrentPage.emit([this.tableId, value]);
+    this.sddsPaginationChange.emit([this.tableId, value]);
   }
 
   clientPaginationPrev = (event) => {

--- a/tegel/src/components/data-table/table-footer/table-footer.tsx
+++ b/tegel/src/components/data-table/table-footer/table-footer.tsx
@@ -9,9 +9,9 @@ import {
   Prop,
   Element,
 } from '@stencil/core';
-import { TablePropsChangedEvent } from '../table/table';
+import { internalSddsChange } from '../table/table';
 
-const relevantTableProps: TablePropsChangedEvent['changed'] = [
+const relevantTableProps: internalSddsChange['changed'] = [
   'compactDesign',
   'noMinWidth',
   'verticalDividers',
@@ -74,17 +74,17 @@ export class TableFooter {
 
   tableEl: HTMLSddsTableElement;
 
-  /** Event that footer sends out in order to receive other necessary information from other subcomponents */
+  /** @internal Event that footer sends out in order to receive other necessary information from other subcomponents */
   @Event({
-    eventName: 'enablePaginationEvent',
+    eventName: 'internalSddsEnablePagination',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  enablePaginationEvent: EventEmitter<any>;
+  internalSddsEnablePagination: EventEmitter<any>;
 
-  @Listen('tablePropsChangedEvent', { target: 'body' })
-  tablePropsChangedEventListener(event: CustomEvent<TablePropsChangedEvent>) {
+  @Listen('internalSddsChange', { target: 'body' })
+  internalSddsChangeListener(event: CustomEvent<internalSddsChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))
@@ -120,7 +120,7 @@ export class TableFooter {
       this.columnsNumber = numberOfColumns;
     }
 
-    this.enablePaginationEvent.emit(this.tableId);
+    this.internalSddsEnablePagination.emit(this.tableId);
   }
 
   paginationPrev = (event) => {
@@ -153,8 +153,8 @@ export class TableFooter {
     this.runPagination();
   }
 
-  @Listen('runPaginationEvent', { target: 'body' })
-  runPaginationEventListener(event: CustomEvent<any>) {
+  @Listen('sddsPagination', { target: 'body' })
+  sddsPaginationListener(event: CustomEvent<any>) {
     if (this.tableId === event.detail) {
       this.runPagination();
     }
@@ -189,17 +189,17 @@ export class TableFooter {
 
   /* Client based functions below */
 
-  /** Event to send current page value back to sdds-table-body component */
+  /** @internal Event to send current page value back to sdds-table-body component */
   @Event({
-    eventName: 'currentPageValueEvent',
+    eventName: 'internalSddsCurrentPage',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  currentPageValueEvent: EventEmitter<any>;
+  internalSddsCurrentPage: EventEmitter<any>;
 
   sendPaginationValue(value) {
-    this.currentPageValueEvent.emit([this.tableId, value]);
+    this.internalSddsCurrentPage.emit([this.tableId, value]);
   }
 
   clientPaginationPrev = (event) => {

--- a/tegel/src/components/data-table/table-footer/table-footer.tsx
+++ b/tegel/src/components/data-table/table-footer/table-footer.tsx
@@ -9,9 +9,9 @@ import {
   Prop,
   Element,
 } from '@stencil/core';
-import { internalSddsChange } from '../table/table';
+import { InternalSddsPropChange } from '../table/table';
 
-const relevantTableProps: internalSddsChange['changed'] = [
+const relevantTableProps: InternalSddsPropChange['changed'] = [
   'compactDesign',
   'noMinWidth',
   'verticalDividers',
@@ -83,8 +83,8 @@ export class TableFooter {
   })
   internalSddsEnablePagination: EventEmitter<any>;
 
-  @Listen('internalSddsChange', { target: 'body' })
-  internalSddsChangeListener(event: CustomEvent<internalSddsChange>) {
+  @Listen('internalSddsPropChange', { target: 'body' })
+  internalSddsPropChangeListener(event: CustomEvent<InternalSddsPropChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))

--- a/tegel/src/components/data-table/table-header-cell/readme.md
+++ b/tegel/src/components/data-table/table-header-cell/readme.md
@@ -16,15 +16,6 @@
 | `textAlign`   | `text-align`   | Setting for text align, default is left, but user can pass "right" as string - useful for numeric values | `string`  | `undefined` |
 
 
-## Events
-
-| Event                 | Description                                                                                                                                | Type               |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------ |
-| `headCellHoverEvent`  | Sends unique table identifier, column key so the body cells with the same key change background when user hovers over header cell          | `CustomEvent<any>` |
-| `sortColumnDataEvent` | Sends unique table identifier,column key and sorting direction to the sdds-table-body component                                            | `CustomEvent<any>` |
-| `textAlignEvent`      | Sends unique table identifier, column key and text align value so the body cells with same key take the same text alignment as header cell | `CustomEvent<any>` |
-
-
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/tegel/src/components/data-table/table-header-cell/readme.md
+++ b/tegel/src/components/data-table/table-header-cell/readme.md
@@ -16,6 +16,13 @@
 | `textAlign`   | `text-align`   | Setting for text align, default is left, but user can pass "right" as string - useful for numeric values | `string`  | `undefined` |
 
 
+## Events
+
+| Event            | Description                                                                                                                                                          | Type               |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| `sddsSortChange` | Sends unique table identifier,column key and sorting direction to the sdds-table-body component, can also be listened to in order to implement custom sorting logic. | `CustomEvent<any>` |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/tegel/src/components/data-table/table-header-cell/table-header-cell.tsx
+++ b/tegel/src/components/data-table/table-header-cell/table-header-cell.tsx
@@ -9,9 +9,9 @@ import {
   Listen,
   Element,
 } from '@stencil/core';
-import { InternalSddsPropChange } from '../table/table';
+import { InternalSddsTablePropChange } from '../table/table';
 
-const relevantTableProps: InternalSddsPropChange['changed'] = [
+const relevantTableProps: InternalSddsTablePropChange['changed'] = [
   'enableMultiselect',
   'enableExpandableRows',
   'compactDesign',
@@ -94,7 +94,7 @@ export class TableHeaderCell {
   internalSddsHover: EventEmitter<any>;
 
   @Listen('internalSddsPropChange', { target: 'body' })
-  internalSddsPropChangeListener(event: CustomEvent<InternalSddsPropChange>) {
+  internalSddsPropChangeListener(event: CustomEvent<InternalSddsTablePropChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))

--- a/tegel/src/components/data-table/table-header-cell/table-header-cell.tsx
+++ b/tegel/src/components/data-table/table-header-cell/table-header-cell.tsx
@@ -9,9 +9,9 @@ import {
   Listen,
   Element,
 } from '@stencil/core';
-import { internalSddsChange } from '../table/table';
+import { InternalSddsPropChange } from '../table/table';
 
-const relevantTableProps: internalSddsChange['changed'] = [
+const relevantTableProps: InternalSddsPropChange['changed'] = [
   'enableMultiselect',
   'enableExpandableRows',
   'compactDesign',
@@ -93,8 +93,8 @@ export class TableHeaderCell {
   })
   internalSddsHover: EventEmitter<any>;
 
-  @Listen('internalSddsChange', { target: 'body' })
-  internalSddsChangeListener(event: CustomEvent<internalSddsChange>) {
+  @Listen('internalSddsPropChange', { target: 'body' })
+  internalSddsPropChangeListener(event: CustomEvent<InternalSddsPropChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))

--- a/tegel/src/components/data-table/table-header-cell/table-header-cell.tsx
+++ b/tegel/src/components/data-table/table-header-cell/table-header-cell.tsx
@@ -66,14 +66,14 @@ export class TableHeaderCell {
 
   tableEl: HTMLSddsTableElement;
 
-  /** @internal Sends unique table identifier,column key and sorting direction to the sdds-table-body component */
+  /** Sends unique table identifier,column key and sorting direction to the sdds-table-body component, can also be listened to in order to implement custom sorting logic. */
   @Event({
-    eventName: 'internalSddsSortColumn',
+    eventName: 'sddsSortChange',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  internalSddsSortColumn: EventEmitter<any>;
+  sddsSortChange: EventEmitter<any>;
 
   /** @internal Sends unique table identifier, column key and text align value so the body cells with same key take the same text alignment as header cell */
   @Event({
@@ -117,7 +117,7 @@ export class TableHeaderCell {
   }
 
   // target is set to body so other instances of same component "listen" and react to the change
-  @Listen('internalSddsSortColumn', { target: 'body' })
+  @Listen('sddsSortChange', { target: 'body' })
   updateOptionsContent(event: CustomEvent<any>) {
     if (this.tableId === event.detail[0]) {
       // grab only value at position 1 as it is the "key"
@@ -166,7 +166,7 @@ export class TableHeaderCell {
     // Setting to true we can set enable CSS class for "active" state of column
     this.sortedByMyKey = true;
     // Use array to send both key and sorting direction
-    this.internalSddsSortColumn.emit([this.tableId, key, this.sortingDirection]);
+    this.sddsSortChange.emit([this.tableId, key, this.sortingDirection]);
   };
 
   headerCellContent = () => {

--- a/tegel/src/components/data-table/table-header-cell/table-header-cell.tsx
+++ b/tegel/src/components/data-table/table-header-cell/table-header-cell.tsx
@@ -9,9 +9,9 @@ import {
   Listen,
   Element,
 } from '@stencil/core';
-import { TablePropsChangedEvent } from '../table/table';
+import { internalSddsChange } from '../table/table';
 
-const relevantTableProps: TablePropsChangedEvent['changed'] = [
+const relevantTableProps: internalSddsChange['changed'] = [
   'enableMultiselect',
   'enableExpandableRows',
   'compactDesign',
@@ -66,35 +66,35 @@ export class TableHeaderCell {
 
   tableEl: HTMLSddsTableElement;
 
-  /** Sends unique table identifier,column key and sorting direction to the sdds-table-body component */
+  /** @internal Sends unique table identifier,column key and sorting direction to the sdds-table-body component */
   @Event({
-    eventName: 'sortColumnDataEvent',
+    eventName: 'internalSddsSortColumn',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  sortColumnDataEvent: EventEmitter<any>;
+  internalSddsSortColumn: EventEmitter<any>;
 
-  /** Sends unique table identifier, column key and text align value so the body cells with same key take the same text alignment as header cell */
+  /** @internal Sends unique table identifier, column key and text align value so the body cells with same key take the same text alignment as header cell */
   @Event({
-    eventName: 'textAlignEvent',
+    eventName: 'internalSddsTextAlign',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  textAlignEvent: EventEmitter<any>;
+  internalSddsTextAlign: EventEmitter<any>;
 
-  /** Sends unique table identifier, column key so the body cells with the same key change background when user hovers over header cell */
+  /** @internal Sends unique table identifier, column key so the body cells with the same key change background when user hovers over header cell */
   @Event({
-    eventName: 'headCellHoverEvent',
+    eventName: 'internalSddsHover',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  headCellHoverEvent: EventEmitter<any>;
+  internalSddsHover: EventEmitter<any>;
 
-  @Listen('tablePropsChangedEvent', { target: 'body' })
-  tablePropsChangedEventListener(event: CustomEvent<TablePropsChangedEvent>) {
+  @Listen('internalSddsChange', { target: 'body' })
+  internalSddsChangeListener(event: CustomEvent<internalSddsChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))
@@ -108,8 +108,8 @@ export class TableHeaderCell {
   }
 
   // Listen to parent data-table if sorting is allowed
-  @Listen('sortingSwitcherEvent', { target: 'body' })
-  sortingSwitcherEventListener(event: CustomEvent<any>) {
+  @Listen('internalSddsSortingChange', { target: 'body' })
+  internalSddsSortingChangeListener(event: CustomEvent<any>) {
     const [receivedID, receivedSortingStatus] = event.detail;
     if (this.tableId === receivedID) {
       this.disableSortingBtn = receivedSortingStatus;
@@ -117,7 +117,7 @@ export class TableHeaderCell {
   }
 
   // target is set to body so other instances of same component "listen" and react to the change
-  @Listen('sortColumnDataEvent', { target: 'body' })
+  @Listen('internalSddsSortColumn', { target: 'body' })
   updateOptionsContent(event: CustomEvent<any>) {
     if (this.tableId === event.detail[0]) {
       // grab only value at position 1 as it is the "key"
@@ -129,11 +129,6 @@ export class TableHeaderCell {
         }, 200);
       }
     }
-  }
-
-  @Listen('enableMultiselectEvent', { target: 'body' })
-  enableMultiselectEventListener(event: CustomEvent<any>) {
-    if (this.tableId === event.detail[0]) [, this.enableMultiselect] = event.detail;
   }
 
   connectedCallback() {
@@ -155,7 +150,7 @@ export class TableHeaderCell {
       this.textAlignState = 'left';
     }
     // To enable body cells text align per rules set in head cell
-    this.textAlignEvent.emit([this.tableId, this.columnKey, this.textAlignState]);
+    this.internalSddsTextAlign.emit([this.tableId, this.columnKey, this.textAlignState]);
 
     this.enableToolbarDesign =
       this.host.closest('sdds-table').getElementsByTagName('sdds-table-toolbar').length >= 1;
@@ -171,7 +166,7 @@ export class TableHeaderCell {
     // Setting to true we can set enable CSS class for "active" state of column
     this.sortedByMyKey = true;
     // Use array to send both key and sorting direction
-    this.sortColumnDataEvent.emit([this.tableId, key, this.sortingDirection]);
+    this.internalSddsSortColumn.emit([this.tableId, key, this.sortingDirection]);
   };
 
   headerCellContent = () => {
@@ -237,7 +232,7 @@ export class TableHeaderCell {
   };
 
   onHeadCellHover = (key) => {
-    this.headCellHoverEvent.emit([this.tableId, key]);
+    this.internalSddsHover.emit([this.tableId, key]);
   };
 
   render() {

--- a/tegel/src/components/data-table/table-header/readme.md
+++ b/tegel/src/components/data-table/table-header/readme.md
@@ -5,13 +5,6 @@
 <!-- Auto Generated Below -->
 
 
-## Events
-
-| Event                       | Description                                                                | Type               |
-| --------------------------- | -------------------------------------------------------------------------- | ------------------ |
-| `mainCheckboxSelectedEvent` | Send status of main checkbox in header to the parent, sdds-table component | `CustomEvent<any>` |
-
-
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/tegel/src/components/data-table/table-header/table-header.tsx
+++ b/tegel/src/components/data-table/table-header/table-header.tsx
@@ -1,7 +1,7 @@
 import { Component, h, Host, State, Event, EventEmitter, Listen, Element } from '@stencil/core';
-import { internalSddsChange } from '../table/table';
+import { InternalSddsPropChange } from '../table/table';
 
-const relevantTableProps: internalSddsChange['changed'] = [
+const relevantTableProps: InternalSddsPropChange['changed'] = [
   'enableMultiselect',
   'enableExpandableRows',
   'verticalDividers',
@@ -48,8 +48,8 @@ export class TableHeaderRow {
   })
   internalSddsMainCheckboxSelect: EventEmitter<any>;
 
-  @Listen('internalSddsChange', { target: 'body' })
-  internalSddsChangeListener(event: CustomEvent<internalSddsChange>) {
+  @Listen('internalSddsPropChange', { target: 'body' })
+  internalSddsPropChangeListener(event: CustomEvent<InternalSddsPropChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))

--- a/tegel/src/components/data-table/table-header/table-header.tsx
+++ b/tegel/src/components/data-table/table-header/table-header.tsx
@@ -1,7 +1,7 @@
 import { Component, h, Host, State, Event, EventEmitter, Listen, Element } from '@stencil/core';
-import { TablePropsChangedEvent } from '../table/table';
+import { internalSddsChange } from '../table/table';
 
-const relevantTableProps: TablePropsChangedEvent['changed'] = [
+const relevantTableProps: internalSddsChange['changed'] = [
   'enableMultiselect',
   'enableExpandableRows',
   'verticalDividers',
@@ -39,17 +39,17 @@ export class TableHeaderRow {
 
   tableEl: HTMLSddsTableElement;
 
-  /** Send status of main checkbox in header to the parent, sdds-table component */
+  /** @internal Send status of main checkbox in header to the parent, sdds-table component */
   @Event({
-    eventName: 'mainCheckboxSelectedEvent',
+    eventName: 'internalSddsMainCheckboxChange',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  mainCheckboxSelectedEvent: EventEmitter<any>;
+  internalSddsMainCheckboxChange: EventEmitter<any>;
 
-  @Listen('tablePropsChangedEvent', { target: 'body' })
-  tablePropsChangedEventListener(event: CustomEvent<TablePropsChangedEvent>) {
+  @Listen('internalSddsChange', { target: 'body' })
+  internalSddsChangeListener(event: CustomEvent<internalSddsChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))
@@ -62,16 +62,16 @@ export class TableHeaderRow {
     }
   }
 
-  @Listen('updateMainCheckboxEvent', { target: 'body' })
-  updateMainCheckboxEventListener(event: CustomEvent<any>) {
+  @Listen('internalSddsMainCheckboxChange', { target: 'body' })
+  internalSddsMainCheckboxChangeListener(event: CustomEvent<any>) {
     const [receivedID, receivedMainCheckboxStatus] = event.detail;
     if (this.tableId === receivedID) {
       this.mainCheckboxSelected = receivedMainCheckboxStatus;
     }
   }
-
-  @Listen('singleRowExpandedEvent', { target: 'body' })
-  singleRowExpandedEventListener(event: CustomEvent<any>) {
+  
+  @Listen('internalSddsRowExpanded', { target: 'body' })
+  internalSddsRowExpandedListener(event: CustomEvent<any>) {
     if (this.tableId === event.detail[0]) {
       // TODO: Improve this logic. Why we get late repose in DOM?
       setTimeout(() => {
@@ -113,7 +113,7 @@ export class TableHeaderRow {
 
   headCheckBoxClicked(event) {
     this.mainCheckboxSelected = event.currentTarget.checked;
-    this.mainCheckboxSelectedEvent.emit([this.tableId, this.mainCheckboxSelected]);
+    this.internalSddsMainCheckboxChange.emit([this.tableId, this.mainCheckboxSelected]);
   }
 
   render() {

--- a/tegel/src/components/data-table/table-header/table-header.tsx
+++ b/tegel/src/components/data-table/table-header/table-header.tsx
@@ -48,7 +48,7 @@ export class TableHeaderRow {
   })
   internalSddsMainCheckboxSelect: EventEmitter<any>;
 
-  @Listen('internalSddsPropChange', { target: 'body' })
+  @Listen('internalSddsTablePropChange', { target: 'body' })
   internalSddsPropChangeListener(event: CustomEvent<InternalSddsPropChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed

--- a/tegel/src/components/data-table/table-header/table-header.tsx
+++ b/tegel/src/components/data-table/table-header/table-header.tsx
@@ -1,7 +1,7 @@
 import { Component, h, Host, State, Event, EventEmitter, Listen, Element } from '@stencil/core';
-import { InternalSddsPropChange } from '../table/table';
+import { InternalSddsTablePropChange } from '../table/table';
 
-const relevantTableProps: InternalSddsPropChange['changed'] = [
+const relevantTableProps: InternalSddsTablePropChange['changed'] = [
   'enableMultiselect',
   'enableExpandableRows',
   'verticalDividers',
@@ -49,7 +49,7 @@ export class TableHeaderRow {
   internalSddsMainCheckboxSelect: EventEmitter<any>;
 
   @Listen('internalSddsTablePropChange', { target: 'body' })
-  internalSddsPropChangeListener(event: CustomEvent<InternalSddsPropChange>) {
+  internalSddsPropChangeListener(event: CustomEvent<InternalSddsTablePropChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))

--- a/tegel/src/components/data-table/table-header/table-header.tsx
+++ b/tegel/src/components/data-table/table-header/table-header.tsx
@@ -41,12 +41,12 @@ export class TableHeaderRow {
 
   /** @internal Send status of main checkbox in header to the parent, sdds-table component */
   @Event({
-    eventName: 'internalSddsMainCheckboxChange',
+    eventName: 'internalSddsMainCheckboxSelect',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  internalSddsMainCheckboxChange: EventEmitter<any>;
+  internalSddsMainCheckboxSelect: EventEmitter<any>;
 
   @Listen('internalSddsChange', { target: 'body' })
   internalSddsChangeListener(event: CustomEvent<internalSddsChange>) {
@@ -69,7 +69,7 @@ export class TableHeaderRow {
       this.mainCheckboxSelected = receivedMainCheckboxStatus;
     }
   }
-  
+
   @Listen('internalSddsRowExpanded', { target: 'body' })
   internalSddsRowExpandedListener(event: CustomEvent<any>) {
     if (this.tableId === event.detail[0]) {
@@ -113,7 +113,7 @@ export class TableHeaderRow {
 
   headCheckBoxClicked(event) {
     this.mainCheckboxSelected = event.currentTarget.checked;
-    this.internalSddsMainCheckboxChange.emit([this.tableId, this.mainCheckboxSelected]);
+    this.internalSddsMainCheckboxSelect.emit([this.tableId, this.mainCheckboxSelected]);
   }
 
   render() {

--- a/tegel/src/components/data-table/table-toolbar/readme.md
+++ b/tegel/src/components/data-table/table-toolbar/readme.md
@@ -13,6 +13,13 @@
 | `tableTitle`      | `table-title`      | Adds title to the data-table | `string`  | `''`    |
 
 
+## Events
+
+| Event        | Description                                                                                                                             | Type               |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| `sddsFilter` | Used for sending users input to main parent <sdds-table> component, can also be listened to in order to implement custom sorting logic. | `CustomEvent<any>` |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/tegel/src/components/data-table/table-toolbar/readme.md
+++ b/tegel/src/components/data-table/table-toolbar/readme.md
@@ -13,13 +13,6 @@
 | `tableTitle`      | `table-title`      | Adds title to the data-table | `string`  | `''`    |
 
 
-## Events
-
-| Event                | Description                                                        | Type               |
-| -------------------- | ------------------------------------------------------------------ | ------------------ |
-| `tableFilteringTerm` | Used for sending users input to main parent <sdds-table> component | `CustomEvent<any>` |
-
-
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/tegel/src/components/data-table/table-toolbar/table-toolbar.tsx
+++ b/tegel/src/components/data-table/table-toolbar/table-toolbar.tsx
@@ -9,9 +9,9 @@ import {
   State,
   Element,
 } from '@stencil/core';
-import { internalSddsChange } from '../table/table';
+import { InternalSddsPropChange } from '../table/table';
 
-const relevantTableProps: internalSddsChange['changed'] = [
+const relevantTableProps: InternalSddsPropChange['changed'] = [
   'compactDesign',
   'noMinWidth',
   'verticalDividers',
@@ -52,8 +52,8 @@ export class TableToolbar {
   })
   internalSddsFilter: EventEmitter<any>;
 
-  @Listen('internalSddsChange', { target: 'body' })
-  internalSddsChangeListener(event: CustomEvent<internalSddsChange>) {
+  @Listen('internalSddsPropChange', { target: 'body' })
+  internalSddsPropChangeListener(event: CustomEvent<InternalSddsPropChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))

--- a/tegel/src/components/data-table/table-toolbar/table-toolbar.tsx
+++ b/tegel/src/components/data-table/table-toolbar/table-toolbar.tsx
@@ -52,7 +52,7 @@ export class TableToolbar {
   })
   sddsFilter: EventEmitter<any>;
 
-  @Listen('internalSddsPropChange', { target: 'body' })
+  @Listen('internalSddsTablePropChange', { target: 'body' })
   internalSddsPropChangeListener(event: CustomEvent<InternalSddsPropChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed

--- a/tegel/src/components/data-table/table-toolbar/table-toolbar.tsx
+++ b/tegel/src/components/data-table/table-toolbar/table-toolbar.tsx
@@ -9,9 +9,9 @@ import {
   State,
   Element,
 } from '@stencil/core';
-import { InternalSddsPropChange } from '../table/table';
+import { InternalSddsTablePropChange } from '../table/table';
 
-const relevantTableProps: InternalSddsPropChange['changed'] = [
+const relevantTableProps: InternalSddsTablePropChange['changed'] = [
   'compactDesign',
   'noMinWidth',
   'verticalDividers',
@@ -53,7 +53,7 @@ export class TableToolbar {
   sddsFilter: EventEmitter<any>;
 
   @Listen('internalSddsTablePropChange', { target: 'body' })
-  internalSddsPropChangeListener(event: CustomEvent<InternalSddsPropChange>) {
+  internalSddsPropChangeListener(event: CustomEvent<InternalSddsTablePropChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))

--- a/tegel/src/components/data-table/table-toolbar/table-toolbar.tsx
+++ b/tegel/src/components/data-table/table-toolbar/table-toolbar.tsx
@@ -43,14 +43,14 @@ export class TableToolbar {
 
   tableEl: HTMLSddsTableElement;
 
-  /** @internal Used for sending users input to main parent <sdds-table> component */
+  /** Used for sending users input to main parent <sdds-table> component, can also be listened to in order to implement custom sorting logic. */
   @Event({
-    eventName: 'internalSddsFilter',
+    eventName: 'sddsFilter',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  internalSddsFilter: EventEmitter<any>;
+  sddsFilter: EventEmitter<any>;
 
   @Listen('internalSddsPropChange', { target: 'body' })
   internalSddsPropChangeListener(event: CustomEvent<InternalSddsPropChange>) {
@@ -81,7 +81,7 @@ export class TableToolbar {
     const searchTerm = event.currentTarget.value.toLowerCase();
     const sddsTableSearchBar = event.currentTarget.parentElement;
 
-    this.internalSddsFilter.emit([this.tableId, searchTerm]);
+    this.sddsFilter.emit([this.tableId, searchTerm]);
 
     if (searchTerm.length > 0) {
       sddsTableSearchBar.classList.add('sdds-table__searchbar--active');

--- a/tegel/src/components/data-table/table-toolbar/table-toolbar.tsx
+++ b/tegel/src/components/data-table/table-toolbar/table-toolbar.tsx
@@ -9,9 +9,9 @@ import {
   State,
   Element,
 } from '@stencil/core';
-import { TablePropsChangedEvent } from '../table/table';
+import { internalSddsChange } from '../table/table';
 
-const relevantTableProps: TablePropsChangedEvent['changed'] = [
+const relevantTableProps: internalSddsChange['changed'] = [
   'compactDesign',
   'noMinWidth',
   'verticalDividers',
@@ -43,17 +43,17 @@ export class TableToolbar {
 
   tableEl: HTMLSddsTableElement;
 
-  /** Used for sending users input to main parent <sdds-table> component */
+  /** @internal Used for sending users input to main parent <sdds-table> component */
   @Event({
-    eventName: 'tableFilteringTerm',
+    eventName: 'internalSddsFilter',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  tableFilteringTerm: EventEmitter<any>;
+  internalSddsFilter: EventEmitter<any>;
 
-  @Listen('tablePropsChangedEvent', { target: 'body' })
-  tablePropsChangedEventListener(event: CustomEvent<TablePropsChangedEvent>) {
+  @Listen('internalSddsChange', { target: 'body' })
+  internalSddsChangeListener(event: CustomEvent<internalSddsChange>) {
     if (this.tableId === event.detail.tableId) {
       event.detail.changed
         .filter((changedProp) => relevantTableProps.includes(changedProp))
@@ -81,7 +81,7 @@ export class TableToolbar {
     const searchTerm = event.currentTarget.value.toLowerCase();
     const sddsTableSearchBar = event.currentTarget.parentElement;
 
-    this.tableFilteringTerm.emit([this.tableId, searchTerm]);
+    this.internalSddsFilter.emit([this.tableId, searchTerm]);
 
     if (searchTerm.length > 0) {
       sddsTableSearchBar.classList.add('sdds-table__searchbar--active');

--- a/tegel/src/components/data-table/table/readme.md
+++ b/tegel/src/components/data-table/table/readme.md
@@ -19,13 +19,6 @@
 | `verticalDividers`     | `vertical-dividers`      | Enables style with vertical dividers between columns                                                                                                                                                                                       | `boolean`                  | `false`               |
 
 
-## Events
-
-| Event                    | Description                            | Type                                                                           |
-| ------------------------ | -------------------------------------- | ------------------------------------------------------------------------------ |
-| `tablePropsChangedEvent` | Broadcasts changes to the tables props | `CustomEvent<{ tableId: string; changed: (keyof Props)[]; } & Partial<Props>>` |
-
-
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/tegel/src/components/data-table/table/table.tsx
+++ b/tegel/src/components/data-table/table/table.tsx
@@ -54,17 +54,17 @@ export class Table {
 
   @Element() host: HTMLElement;
 
-  /** Broadcasts changes to the tables props */
+  /** @internal Broadcasts changes to the tables props */
   @Event({
-    eventName: 'tablePropsChangedEvent',
+    eventName: 'internalSddsChange',
     bubbles: true,
     composed: true,
     cancelable: true,
   })
-  tablePropsChangedEvent: EventEmitter<TablePropsChangedEvent>;
+  internalSddsChange: EventEmitter<TablePropsChangedEvent>;
 
   emitTablePropsChangedEvent(changedValueName: keyof Props, changedValue: Props[keyof Props]) {
-    this.tablePropsChangedEvent.emit({
+    this.internalSddsChange.emit({
       tableId: this.tableId,
       changed: [changedValueName],
       [changedValueName]: changedValue,

--- a/tegel/src/components/data-table/table/table.tsx
+++ b/tegel/src/components/data-table/table/table.tsx
@@ -13,7 +13,7 @@ type Props = {
   modeVariant: 'primary' | 'secondary' | null;
 };
 
-export type InternalSddsChange = {
+export type InternalSddsPropChange = {
   tableId: string;
   changed: Array<keyof Props>;
 } & Partial<Props>;
@@ -56,15 +56,15 @@ export class Table {
 
   /** @internal Broadcasts changes to the tables props */
   @Event({
-    eventName: 'internalSddsChange',
+    eventName: 'internalSddsPropChange',
     bubbles: true,
     composed: true,
     cancelable: true,
   })
-  internalSddsChange: EventEmitter<InternalSddsChange>;
+  internalSddsPropChange: EventEmitter<InternalSddsPropChange>;
 
-  emitinternalSddsChange(changedValueName: keyof Props, changedValue: Props[keyof Props]) {
-    this.internalSddsChange.emit({
+  emitInternalSddsPropChange(changedValueName: keyof Props, changedValue: Props[keyof Props]) {
+    this.internalSddsPropChange.emit({
       tableId: this.tableId,
       changed: [changedValueName],
       [changedValueName]: changedValue,
@@ -73,32 +73,32 @@ export class Table {
 
   @Watch('enableMultiselect')
   enableMultiselectChanged(newValue: boolean) {
-    this.emitinternalSddsChange('enableMultiselect', newValue);
+    this.emitInternalSddsPropChange('enableMultiselect', newValue);
   }
 
   @Watch('enableExpandableRows')
   enableExpandableRowsChanged(newValue: boolean) {
-    this.emitinternalSddsChange('enableExpandableRows', newValue);
+    this.emitInternalSddsPropChange('enableExpandableRows', newValue);
   }
 
   @Watch('compactDesign')
   compactDesignChanged(newValue: boolean) {
-    this.emitinternalSddsChange('compactDesign', newValue);
+    this.emitInternalSddsPropChange('compactDesign', newValue);
   }
 
   @Watch('verticalDividers')
   verticalDividersChanged(newValue: boolean) {
-    this.emitinternalSddsChange('verticalDividers', newValue);
+    this.emitInternalSddsPropChange('verticalDividers', newValue);
   }
 
   @Watch('noMinWidth')
   noMinWidthChanged(newValue: boolean) {
-    this.emitinternalSddsChange('noMinWidth', newValue);
+    this.emitInternalSddsPropChange('noMinWidth', newValue);
   }
 
   @Watch('modeVariant')
   modeVariantChanged(newValue: 'primary' | 'secondary' | null) {
-    this.emitinternalSddsChange('modeVariant', newValue);
+    this.emitInternalSddsPropChange('modeVariant', newValue);
   }
 
   render() {

--- a/tegel/src/components/data-table/table/table.tsx
+++ b/tegel/src/components/data-table/table/table.tsx
@@ -11,6 +11,7 @@ type Props = {
   enableExpandableRows: boolean;
   enableResponsive: boolean;
   modeVariant: 'primary' | 'secondary' | null;
+  textAlign: string;
 };
 
 export type InternalSddsPropChange = {
@@ -56,15 +57,15 @@ export class Table {
 
   /** @internal Broadcasts changes to the tables props */
   @Event({
-    eventName: 'internalSddsPropChange',
+    eventName: 'internalSddsTablePropChange',
     bubbles: true,
     composed: true,
     cancelable: true,
   })
-  internalSddsPropChange: EventEmitter<InternalSddsPropChange>;
+  internalSddsTablePropChange: EventEmitter<InternalSddsPropChange>;
 
   emitInternalSddsPropChange(changedValueName: keyof Props, changedValue: Props[keyof Props]) {
-    this.internalSddsPropChange.emit({
+    this.internalSddsTablePropChange.emit({
       tableId: this.tableId,
       changed: [changedValueName],
       [changedValueName]: changedValue,

--- a/tegel/src/components/data-table/table/table.tsx
+++ b/tegel/src/components/data-table/table/table.tsx
@@ -13,7 +13,7 @@ type Props = {
   modeVariant: 'primary' | 'secondary' | null;
 };
 
-export type TablePropsChangedEvent = {
+export type InternalSddsChange = {
   tableId: string;
   changed: Array<keyof Props>;
 } & Partial<Props>;
@@ -61,9 +61,9 @@ export class Table {
     composed: true,
     cancelable: true,
   })
-  internalSddsChange: EventEmitter<TablePropsChangedEvent>;
+  internalSddsChange: EventEmitter<InternalSddsChange>;
 
-  emitTablePropsChangedEvent(changedValueName: keyof Props, changedValue: Props[keyof Props]) {
+  emitinternalSddsChange(changedValueName: keyof Props, changedValue: Props[keyof Props]) {
     this.internalSddsChange.emit({
       tableId: this.tableId,
       changed: [changedValueName],
@@ -73,32 +73,32 @@ export class Table {
 
   @Watch('enableMultiselect')
   enableMultiselectChanged(newValue: boolean) {
-    this.emitTablePropsChangedEvent('enableMultiselect', newValue);
+    this.emitinternalSddsChange('enableMultiselect', newValue);
   }
 
   @Watch('enableExpandableRows')
   enableExpandableRowsChanged(newValue: boolean) {
-    this.emitTablePropsChangedEvent('enableExpandableRows', newValue);
+    this.emitinternalSddsChange('enableExpandableRows', newValue);
   }
 
   @Watch('compactDesign')
   compactDesignChanged(newValue: boolean) {
-    this.emitTablePropsChangedEvent('compactDesign', newValue);
+    this.emitinternalSddsChange('compactDesign', newValue);
   }
 
   @Watch('verticalDividers')
   verticalDividersChanged(newValue: boolean) {
-    this.emitTablePropsChangedEvent('verticalDividers', newValue);
+    this.emitinternalSddsChange('verticalDividers', newValue);
   }
 
   @Watch('noMinWidth')
   noMinWidthChanged(newValue: boolean) {
-    this.emitTablePropsChangedEvent('noMinWidth', newValue);
+    this.emitinternalSddsChange('noMinWidth', newValue);
   }
 
   @Watch('modeVariant')
   modeVariantChanged(newValue: 'primary' | 'secondary' | null) {
-    this.emitTablePropsChangedEvent('modeVariant', newValue);
+    this.emitinternalSddsChange('modeVariant', newValue);
   }
 
   render() {

--- a/tegel/src/components/data-table/table/table.tsx
+++ b/tegel/src/components/data-table/table/table.tsx
@@ -14,7 +14,7 @@ type Props = {
   textAlign: string;
 };
 
-export type InternalSddsPropChange = {
+export type InternalSddsTablePropChange = {
   tableId: string;
   changed: Array<keyof Props>;
 } & Partial<Props>;
@@ -62,7 +62,7 @@ export class Table {
     composed: true,
     cancelable: true,
   })
-  internalSddsTablePropChange: EventEmitter<InternalSddsPropChange>;
+  internalSddsTablePropChange: EventEmitter<InternalSddsTablePropChange>;
 
   emitInternalSddsPropChange(changedValueName: keyof Props, changedValue: Props[keyof Props]) {
     this.internalSddsTablePropChange.emit({


### PR DESCRIPTION
**Describe pull-request**  
Refactored event names and updated story. 


**Solving issue**  
Fixes: [AB#3361](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3361)

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Data Table -> Check all web component stories
3. Check the readme and event names to make sure they conform with convention.
4. Check if there are any events that are marked as internal now that should be external, and vice versa.
5. Check the event names. Since some event are so specific to this component I had to digress a bit from the naming convention.. 😢 

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
