### PR TITLE
fix(radio button): align event names

### DIFF
--- a/tegel/src/components/radio-button/radio-button-component.stories.tsx
+++ b/tegel/src/components/radio-button/radio-button-component.stories.tsx
@@ -62,12 +62,14 @@ const Template = ({label, disabled}) =>
     radio-id="option-1"
     aria-labelled-by="option-1"
     aria-describedby="option-1"
-    ${label ? `label="${label} 1"` : ''}
     required=false
     ${disabled ? 'disabled' : ''}
-    checked="true" >
+    checked="true" 
+  >
+    ${label} 1
   </sdds-radio-button>
-  <sdds-radio-button ${label ? `label="${label} 2"` : ''}
+
+  <sdds-radio-button
     name="rb-example"
     value="option2"
     radio-id="option-2"
@@ -75,7 +77,9 @@ const Template = ({label, disabled}) =>
     aria-described-by="option-2"
     ${label ? `label="${label} 2"` : ''}
     required=false
-    ${disabled ? 'disabled' : ''} >
+    ${disabled ? 'disabled' : ''} 
+  >
+    ${label} 2
   </sdds-radio-button>
     
   </fieldset>

--- a/tegel/src/components/radio-button/radio-button-component.stories.tsx
+++ b/tegel/src/components/radio-button/radio-button-component.stories.tsx
@@ -86,7 +86,7 @@ const Template = ({label, disabled}) =>
 
   <!-- Script tag with eventlistener for demo purposes. -->
   <script>
-  document.addEventListener('sddsRadioButtonChangeEvent', (event) => {
+  document.addEventListener('sddsChange', (event) => {
     console.log('Radio button with id: ', event.detail.radioId, ' with value:', event.detail.value, ' was selected.')
   })
   </script>

--- a/tegel/src/components/radio-button/radio-button.tsx
+++ b/tegel/src/components/radio-button/radio-button.tsx
@@ -57,6 +57,7 @@ export class RadioButton {
         type="radio" 
         name={this.name}
         id={this.radioId} 
+        value={this.value}
         checked={this.checked} 
         aria-checked={this.checked} 
 

--- a/tegel/src/components/radio-button/radio-button.tsx
+++ b/tegel/src/components/radio-button/radio-button.tsx
@@ -39,12 +39,12 @@ export class RadioButton {
 
   /** Sends unique radio button identifier and status when it is checked. If no ID is specified a random one will be generated. To use this listener don't use the randomized ID, use a specific one of your choosing. */
   @Event({
-    eventName: 'sddsRadioButtonChangeEvent',
+    eventName: 'sddsChange',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  sddsRadioButtonChangeEvent: EventEmitter<{
+  sddsChange: EventEmitter<{
     radioId: string;
     value: string;
   }>;
@@ -66,7 +66,7 @@ export class RadioButton {
         required={this.required} 
         disabled={this.disabled}
         onChange={() => {
-          this.sddsRadioButtonChangeEvent.emit({
+          this.sddsChange.emit({
              radioId: this.radioId,
              value: this.value,
           })

--- a/tegel/src/components/radio-button/radio-button.tsx
+++ b/tegel/src/components/radio-button/radio-button.tsx
@@ -12,9 +12,6 @@ export class RadioButton {
   /** Name of radio button, used for reference. */
   @Prop() name: string;
 
-  /** Label text connected to radio button. */
-  @Prop() label: string;
-
   /** Value of input. */
   @Prop() value: string;
 
@@ -75,7 +72,7 @@ export class RadioButton {
           })
         }} />
         <label htmlFor={this.radioId}>
-          {this.label}
+          <slot></slot>
         </label>
         </div>
     );

--- a/tegel/src/components/radio-button/readme.md
+++ b/tegel/src/components/radio-button/readme.md
@@ -11,7 +11,6 @@
 | ---------- | ---------- | ----------------------------------------------- | --------- | --------------------- |
 | `checked`  | `checked`  | Decides if the radio button is checked or not.  | `boolean` | `false`               |
 | `disabled` | `disabled` | Decides if the radio button is disabled or not. | `boolean` | `false`               |
-| `label`    | `label`    | Label text connected to radio button.           | `string`  | `undefined`           |
 | `name`     | `name`     | Name of radio button, used for reference.       | `string`  | `undefined`           |
 | `radioId`  | `radio-id` | Unique radio button identifier.                 | `string`  | `crypto.randomUUID()` |
 | `required` | `required` | Decides if the radio button is required or not. | `boolean` | `false`               |

--- a/tegel/src/components/radio-button/readme.md
+++ b/tegel/src/components/radio-button/readme.md
@@ -19,9 +19,9 @@
 
 ## Events
 
-| Event                        | Description                                                                                                                                                                                                      | Type                                               |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| `sddsRadioButtonChangeEvent` | Sends unique radio button identifier and status when it is checked. If no ID is specified a random one will be generated. To use this listener don't use the randomized ID, use a specific one of your choosing. | `CustomEvent<{ radioId: string; value: string; }>` |
+| Event        | Description                                                                                                                                                                                                      | Type                                               |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `sddsChange` | Sends unique radio button identifier and status when it is checked. If no ID is specified a random one will be generated. To use this listener don't use the randomized ID, use a specific one of your choosing. | `CustomEvent<{ radioId: string; value: string; }>` |
 
 
 ----------------------------------------------


### PR DESCRIPTION
**Describe pull-request**  
Refactored event name to follow established conventions. Also refactored radio button label to adhere to the way it's implemented in checkbox web component.

**Solving issue**  
Fixes: #

**How to test**  
Go to storybook link below.
Check in Components -> Radio Button-> Web Component
Check the readme for the event specification.
Check the console for events being emitted on story.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

**Screenshots**  
_If applicable, add screenshots to help explain_

**Additional context**  
_Add any other context about the pull-request here._
