### PR TITLE
fix(modal): fix overflow/z-index issue within modal

### DIFF
--- a/components/src/components/modal/_modal-core.scss
+++ b/components/src/components/modal/_modal-core.scss
@@ -160,6 +160,7 @@ $modals: (
   position: sticky;
   top: 0;
   background-color: var(--sdds-modal-bg);
+  z-index: 1000;
 
   &::before {
     content: ' ';

--- a/components/src/components/modal/_modal-core.scss
+++ b/components/src/components/modal/_modal-core.scss
@@ -160,7 +160,7 @@ $modals: (
   position: sticky;
   top: 0;
   background-color: var(--sdds-modal-bg);
-  z-index: 1000;
+  z-index: 1;
 
   &::before {
     content: ' ';


### PR DESCRIPTION
**Describe pull-request**  
Added a high z-index for the modal header in order for all elements that needs to scroll goes behind it.

**Solving issue**  
Fixes: #525

**How to test**  
1. Go to checkout branch
2. Run storybook for components
3. Add som elements to the scroll body and make sure the header scroll "above" all elements.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

