### PR TITLE
fix(accordion): events name update

### DIFF
--- a/tegel/src/components/accordion/accordion-item/accordion-item.tsx
+++ b/tegel/src/components/accordion/accordion-item/accordion-item.tsx
@@ -23,25 +23,24 @@ export class AccordionItem {
 
   /** Fires after the accordion item is closed or opened, emitting the value (as boolean) of the current state of the accordion */
   @Event({
-    eventName: 'accordionItemToggle',
+    eventName: 'sddsToggle',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  accordionItemToggle: EventEmitter<boolean>;
+  sddsToggle: EventEmitter<boolean>;
 
   openAccordion() {
     this.expanded = !this.expanded;
-
-    this.accordionItemToggle.emit(this.expanded);
+    this.sddsToggle.emit(this.expanded);
   }
 
   render() {
     return (
       <Host>
         <div
-          class={`sdds-accordion-item 
-        ${this.disabled ? 'disabled' : ''} 
+          class={`sdds-accordion-item
+        ${this.disabled ? 'disabled' : ''}
         ${this.expanded ? 'expanded' : ''}
         `}
         >
@@ -58,8 +57,8 @@ export class AccordionItem {
             </div>
           </button>
           <div
-            class={`sdds-accordion-panel 
-            ${this.paddingReset ? 'sdds-accordion-panel--padding-reset ' : ''}         
+            class={`sdds-accordion-panel
+            ${this.paddingReset ? 'sdds-accordion-panel--padding-reset ' : ''}
             `}
           >
             <slot></slot>

--- a/tegel/src/components/accordion/accordion-item/readme.md
+++ b/tegel/src/components/accordion/accordion-item/readme.md
@@ -17,9 +17,9 @@
 
 ## Events
 
-| Event                 | Description                                                                                                               | Type                   |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
-| `accordionItemToggle` | Fires after the accordion item is closed or opened, emitting the value (as boolean) of the current state of the accordion | `CustomEvent<boolean>` |
+| Event        | Description                                                                                                               | Type                   |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `sddsToggle` | Fires after the accordion item is closed or opened, emitting the value (as boolean) of the current state of the accordion | `CustomEvent<boolean>` |
 
 
 ## Dependencies

--- a/tegel/src/components/accordion/accordion.stories.tsx
+++ b/tegel/src/components/accordion/accordion.stories.tsx
@@ -77,7 +77,9 @@ const Template = ({ disabled, iconPosition, paddingReset, modeVariant }) => {
   const paddingResetAttr = paddingReset ? 'padding-reset' : '';
 
   return formatHtmlPreview(`
-    <sdds-accordion ${modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"`: ''}>
+    <sdds-accordion ${
+      modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''
+    }>
       <sdds-accordion-item header="First item" ${affixAttr} ${disabledAttr} ${paddingResetAttr}>
         This is the panel, which contains associated information with the header. Usually it contains text, set in the same size as the header.
         Lorem ipsum doler sit amet.
@@ -87,7 +89,16 @@ const Template = ({ disabled, iconPosition, paddingReset, modeVariant }) => {
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis laoreet vestibulum fermentum.
       </sdds-accordion-item>
     </sdds-accordion>
-  `);
+
+    <!-- Script tag for demo purposes -->
+  <script>
+    accordionItems = document.querySelectorAll('sdds-accordion-item');
+    for (let i = 0; i < accordionItems.length; i++) {
+      accordionItems[i].addEventListener('sddsToggle',() => {
+        console.log(i + 1 + ". item of accordion is toggled")
+      })
+    }
+  </script>`);
 };
 
 export const Default = Template.bind({});


### PR DESCRIPTION
## **Describe pull-request**
Changing event name to reflect "sdds + eventName" standard we settle upon. 

## **Solving issue**  
Fixes: [AB#3357](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3357)

## **How to test**  
1. Check the code and readme file, the event name needs to reflect "sdds + eventName" standard
2. In Storybook, inspect and see if in the console you get logging of events

## **Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

## **Additional context**  
This is an onClick event that does toggling so I was not 100% if this naming is OK. Let's see, no problem changing it to whatever is suggested in the review. 
