### PR TITLE
feat(textarea): added prop for no minwidth

### DIFF
--- a/components/src/components/textarea/readme.md
+++ b/components/src/components/textarea/readme.md
@@ -15,6 +15,7 @@
 | `labelPosition` | `label-position` | Label position: `no-label` (default), `inside`, `outside` | `string`  | `'no-label'` |
 | `maxlength`     | `maxlength`      | Max length of input                                       | `number`  | `undefined`  |
 | `name`          | `name`           | Name attribute                                            | `string`  | `''`         |
+| `nominwidth`    | `nominwidth`     | With setting                                              | `boolean` | `false`      |
 | `placeholder`   | `placeholder`    | Placeholder text                                          | `string`  | `''`         |
 | `readonly`      | `readonly`       | Set input in readonly state                               | `boolean` | `false`      |
 | `rows`          | `rows`           | Textarea rows attribute                                   | `number`  | `undefined`  |

--- a/components/src/components/textarea/readme.md
+++ b/components/src/components/textarea/readme.md
@@ -15,7 +15,7 @@
 | `labelPosition` | `label-position` | Label position: `no-label` (default), `inside`, `outside` | `string`  | `'no-label'` |
 | `maxlength`     | `maxlength`      | Max length of input                                       | `number`  | `undefined`  |
 | `name`          | `name`           | Name attribute                                            | `string`  | `''`         |
-| `nominwidth`    | `nominwidth`     | With setting                                              | `boolean` | `false`      |
+| `noMinWidth`    | `no-min-width`   | With setting                                              | `boolean` | `false`      |
 | `placeholder`   | `placeholder`    | Placeholder text                                          | `string`  | `''`         |
 | `readonly`      | `readonly`       | Set input in readonly state                               | `boolean` | `false`      |
 | `rows`          | `rows`           | Textarea rows attribute                                   | `number`  | `undefined`  |

--- a/components/src/components/textarea/textarea.scss
+++ b/components/src/components/textarea/textarea.scss
@@ -1,5 +1,5 @@
 //TODO: Remove dependencies on textfield!!!
-@import "../textfield/textfield.scss";
+@import '../textfield/textfield.scss';
 
 .sdds-textarea-container {
   @extend .sdds-textfield-container;
@@ -11,6 +11,10 @@
   background-color: transparent;
   flex-flow: row wrap;
   border-bottom: 0;
+
+  &.no-min-width {
+    min-width: unset;
+  }
 }
 
 .sdds-textarea-wrapper {
@@ -63,7 +67,7 @@
 }
 
 .sdds-textarea-label {
-  @include type-style("detail-05");
+  @include type-style('detail-05');
 
   display: block;
   z-index: 2;
@@ -74,7 +78,7 @@
 .sdds-textarea-container {
   &.sdds-textarea-label-inside {
     .sdds-textarea-label {
-      @include type-style("detail-02");
+      @include type-style('detail-02');
       @include label-inside-transition;
 
       color: var(--sdds-textfield-label-inside-color);
@@ -91,7 +95,7 @@
   &.sdds-textarea-focus {
     &.sdds-textarea-label-inside {
       .sdds-textarea-label {
-        @include type-style("detail-07");
+        @include type-style('detail-07');
 
         top: var(--sdds-spacing-element-8);
       }
@@ -108,7 +112,7 @@
   &.sdds-textarea-data {
     &.sdds-textarea-label-inside {
       .sdds-textarea-label {
-        @include type-style("detail-07");
+        @include type-style('detail-07');
 
         top: var(--sdds-spacing-element-8);
       }
@@ -185,7 +189,7 @@
     right: 18px;
     top: 48px;
 
-    @include type-style("detail-05");
+    @include type-style('detail-05');
 
     padding: 8px;
     color: var(--sdds-white);

--- a/components/src/components/textarea/textarea.tsx
+++ b/components/src/components/textarea/textarea.tsx
@@ -48,6 +48,9 @@ export class Textarea {
   /** Control of autofocus */
   @Prop() autofocus: boolean = false;
 
+  /** With setting */
+  @Prop() nominwidth: boolean = false;
+
   /** Listen to the focus state of the input */
   @State() focusInput;
 
@@ -79,6 +82,7 @@ export class Textarea {
       <div
         class={`
         sdds-textarea-container
+        ${this.nominwidth ? 'no-min-width' : ''}
         ${this.labelPosition === 'inside' ? 'sdds-textarea-label-inside' : ''}
         ${this.focusInput ? 'sdds-textarea-focus' : ''}
         ${this.disabled ? 'sdds-textarea-disabled' : ''}

--- a/components/src/components/textarea/textarea.tsx
+++ b/components/src/components/textarea/textarea.tsx
@@ -49,7 +49,7 @@ export class Textarea {
   @Prop() autofocus: boolean = false;
 
   /** With setting */
-  @Prop() nominwidth: boolean = false;
+  @Prop() noMinWidth: boolean = false;
 
   /** Listen to the focus state of the input */
   @State() focusInput;
@@ -82,7 +82,7 @@ export class Textarea {
       <div
         class={`
         sdds-textarea-container
-        ${this.nominwidth ? 'no-min-width' : ''}
+        ${this.noMinWidth ? 'no-min-width' : ''}
         ${this.labelPosition === 'inside' ? 'sdds-textarea-label-inside' : ''}
         ${this.focusInput ? 'sdds-textarea-focus' : ''}
         ${this.disabled ? 'sdds-textarea-disabled' : ''}

--- a/tegel/src/components/textarea/readme.md
+++ b/tegel/src/components/textarea/readme.md
@@ -16,6 +16,7 @@
 | `maxLength`     | `max-length`     | Max length of input                      | `number`                              | `undefined`  |
 | `modeVariant`   | `mode-variant`   | Mode variant of the textarea             | `"primary" \| "secondary"`            | `null`       |
 | `name`          | `name`           | Name attribute                           | `string`                              | `''`         |
+| `noMinWidth`    | `no-min-width`   | Unset minimum width of 208px.            | `boolean`                             | `false`      |
 | `placeholder`   | `placeholder`    | Placeholder text                         | `string`                              | `''`         |
 | `readOnly`      | `read-only`      | Set input in readonly state              | `boolean`                             | `false`      |
 | `rows`          | `rows`           | Textarea rows attribute                  | `number`                              | `undefined`  |

--- a/tegel/src/components/textarea/textarea.scss
+++ b/tegel/src/components/textarea/textarea.scss
@@ -66,6 +66,10 @@
   background-color: transparent;
   flex-flow: row wrap;
   border-bottom: 0;
+
+  &.no-min-width {
+    min-width: unset;
+  }
 }
 
 .sdds-textarea-container {

--- a/tegel/src/components/textarea/textarea.stories.tsx
+++ b/tegel/src/components/textarea/textarea.stories.tsx
@@ -94,6 +94,16 @@ export default {
         type: 'number',
       },
     },
+    minWidth: {
+      name: 'No minimum width',
+      description: 'Toggle the minimum width.',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
+      },
+    },
     state: {
       name: 'State',
       description: 'Switch between success or error state',
@@ -114,6 +124,7 @@ export default {
     rows: 5,
     state: 'Default',
     modeVariant: 'Inherit from parent',
+    minWidth: false,
   },
 };
 
@@ -127,6 +138,7 @@ const Template = ({
   helper,
   maxLength,
   modeVariant,
+  minWidth,
   rows,
 }) => {
   const maxlength = maxLength > 0 ? `max-length="${maxLength}"` : '';
@@ -158,6 +170,7 @@ const Template = ({
           label-position="${labelPosLookup[labelPosition]}"
           ${disabled ? 'disabled' : ''}
           ${readonly ? 'read-only' : ''}
+          ${minWidth ? 'no-min-width' : ''}
           placeholder="${placeholder}"
           ${maxlength}>
         </sdds-textarea>

--- a/tegel/src/components/textarea/textarea.tsx
+++ b/tegel/src/components/textarea/textarea.tsx
@@ -51,6 +51,9 @@ export class Textarea {
   /** Control of autofocus */
   @Prop() autoFocus: boolean = false;
 
+  /** Unset minimum width of 208px. */
+  @Prop() noMinWidth: boolean = false;
+
   /** Listen to the focus state of the input */
   @State() focusInput;
 
@@ -117,6 +120,7 @@ export class Textarea {
       <div
         class={`
         sdds-textarea-container
+        ${this.noMinWidth ? 'no-min-width' : ''}
         ${this.labelPosition === 'inside' ? 'sdds-textarea-label-inside' : ''}
         ${this.focusInput ? 'sdds-textarea-focus' : ''}
         ${this.disabled ? 'sdds-textarea-disabled' : ''}


### PR DESCRIPTION
**Describe pull-request**  
Added a prop for nominwidth for the textarea.

**Solving issue**  
Fixes: #855

**How to test**  
1. Check out branch and run storybook for components
2. Add nom nominwidth prop to textarea and check that the min-width is unset.

**Suggested test steps**
- [x] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events