### PR TITLE
fix(textfield/textarea): scope css

### DIFF
--- a/tegel/src/components/textarea/textarea-vars.scss
+++ b/tegel/src/components/textarea/textarea-vars.scss
@@ -1,4 +1,3 @@
-:root,
 .sdds-mode-light {
   --sdds-textarea-background-primary: var(--sdds-grey-50);
   --sdds-textarea-background-secondary: var(--sdds-white);

--- a/tegel/src/components/textarea/textarea.scss
+++ b/tegel/src/components/textarea/textarea.scss
@@ -1,5 +1,3 @@
-@import './textarea-vars.scss';
-
 @mixin textfield-base {
   border-radius: 4px 4px 0 0;
   width: 100%;
@@ -29,7 +27,7 @@
       color: var(--sdds-textarea-disabled-placeholder);
     }
 
-    ~ .sdds-textfield-label-inside {
+    ~ .textfield-label-inside {
       color: var(--sdds-textarea-disabled-label);
     }
   }
@@ -51,7 +49,7 @@
   }
 }
 
-.sdds-textarea-container {
+.textarea-container {
   //@extend .sdds-textfield-container;
   border-radius: 4px 4px 0 0;
   position: relative;
@@ -72,16 +70,16 @@
   }
 }
 
-.sdds-textarea-container {
-  .sdds-textarea-wrapper {
+.textarea-container {
+  .textarea-wrapper {
     position: relative;
     width: unset;
     min-width: 100%;
   }
 }
 
-.sdds-textarea-container:not(.sdds-textarea-disabled) {
-  .sdds-textarea-wrapper {
+.textarea-container:not(.textarea-disabled) {
+  .textarea-wrapper {
     &::before,
     &::after {
       content: '';
@@ -107,7 +105,7 @@
   }
 }
 
-.sdds-textarea-input {
+.textarea-input {
   @include textfield-base;
 
   font: var(--sdds-detail-02);
@@ -129,7 +127,7 @@
 }
 
 // Need to override default resizer in FF & Safari
-.sdds-textarea-resizer-icon {
+.textarea-resizer-icon {
   color: var(--sdds-textarea-resize-icon);
   position: absolute;
   display: block;
@@ -145,7 +143,7 @@
   }
 }
 
-.sdds-textarea-label {
+.textarea-label {
   font: var(--sdds-detail-05);
   letter-spacing: var(--sdds-detail-05-ls);
   display: block;
@@ -154,9 +152,9 @@
   color: var(--sdds-textarea-label-color);
 }
 
-.sdds-textarea-container {
-  &.sdds-textarea-label-inside {
-    .sdds-textarea-label {
+.textarea-container {
+  &.textarea-label-inside {
+    .textarea-label {
       font: var(--sdds-detail-02);
       letter-spacing: var(--sdds-detail-02-ls);
       transition: 0.1s ease all;
@@ -169,21 +167,21 @@
       left: var(--sdds-spacing-element-16);
     }
 
-    .sdds-textarea-input {
+    .textarea-input {
       @include placeholder-label;
     }
   }
 
-  &.sdds-textarea-focus {
-    &.sdds-textarea-label-inside {
-      .sdds-textarea-label {
+  &.textarea-focus {
+    &.textarea-label-inside {
+      .textarea-label {
         font: var(--sdds-detail-07);
         letter-spacing: var(--sdds-detail-07-ls);
         top: var(--sdds-spacing-element-8);
       }
     }
 
-    .sdds-textarea-wrapper {
+    .textarea-wrapper {
       &::before,
       &::after {
         width: 50%;
@@ -191,9 +189,9 @@
     }
   }
 
-  &.sdds-textarea-data {
-    &.sdds-textarea-label-inside {
-      .sdds-textarea-label {
+  &.textarea-data {
+    &.textarea-label-inside {
+      .textarea-label {
         font: var(--sdds-detail-07);
         letter-spacing: var(--sdds-detail-07-ls);
         top: var(--sdds-spacing-element-8);
@@ -202,14 +200,14 @@
   }
 }
 
-.sdds-textarea-textcounter {
+.textarea-textcounter {
   //@extend .sdds-textfield-textcounter;
   font: var(--sdds-detail-05);
   letter-spacing: var(--sdds-detail-05-ls);
   color: var(--sdds-textarea-textcounter);
   float: right;
 
-  & .sdds-textfield-textcounter-divider {
+  & .textfield-textcounter-divider {
     font: var(--sdds-detail-05);
     letter-spacing: var(--sdds-detail-05-ls);
     color: var(--sdds-textarea-textcounter-divider);
@@ -222,7 +220,7 @@
   padding-top: var(--sdds-spacing-element-4);
 }
 
-.sdds-textarea-helper {
+.textarea-helper {
   font: var(--sdds-detail-05);
   letter-spacing: var(--sdds-detail-05-ls);
   display: flex;
@@ -233,50 +231,50 @@
   flex-grow: 2;
   flex-basis: auto;
 
-  ~ .sdds-textarea-textcounter {
+  ~ .textarea-textcounter {
     flex-basis: auto;
   }
 }
 
 // Different state
 
-.sdds-textarea-success {
-  .sdds-textarea-input {
+.textarea-success {
+  .textarea-input {
     border-bottom-color: var(--sdds-textarea-border-bottom-success);
   }
 }
 
-.sdds-textarea-error {
-  .sdds-textarea-input {
+.textarea-error {
+  .textarea-input {
     border-bottom-color: var(--sdds-textarea-border-bottom-error);
   }
 
-  .sdds-textarea-wrapper {
+  .textarea-wrapper {
     &::after,
     &::before {
       background: var(--sdds-textarea-bar-error);
     }
   }
 
-  .sdds-textarea-helper {
+  .textarea-helper {
     color: var(--sdds-textarea-helper-error);
   }
 }
 
 //Disabled state
-.sdds-textarea-disabled {
-  .sdds-textarea-input {
+.textarea-disabled {
+  .textarea-input {
     border-bottom-color: transparent;
   }
 
-  .sdds-textarea-label {
+  .textarea-label {
     color: var(--sdds-textarea-disabled-label);
   }
 }
 
 //Read only state
 
-.sdds-textarea-icon__readonly {
+.textarea-icon__readonly {
   display: none;
   position: absolute;
   right: 18px;
@@ -298,25 +296,25 @@
   }
 }
 
-.sdds-textarea-readonly {
+.textarea-readonly {
   pointer-events: none;
 
-  .sdds-textarea-icon__readonly {
+  .textarea-icon__readonly {
     display: block;
 
     &:hover {
-      ~ .sdds-textarea-icon__readonly-label {
+      ~ .textarea-icon__readonly-label {
         display: block;
       }
     }
   }
 
-  .sdds-textfield-input {
+  .textfield-input {
     padding-right: 54px;
     background-color: transparent;
   }
 
-  .sdds-textfield-container {
+  .textfield-container {
     background-color: transparent;
   }
 }

--- a/tegel/src/components/textarea/textarea.tsx
+++ b/tegel/src/components/textarea/textarea.tsx
@@ -4,6 +4,7 @@ import { Component, h, Prop, State, Event, EventEmitter } from '@stencil/core';
   tag: 'sdds-textarea',
   styleUrl: 'textarea.scss',
   shadow: false,
+  scoped: true,
 })
 export class Textarea {
   /** Textinput for focus state */

--- a/tegel/src/components/textarea/textarea.tsx
+++ b/tegel/src/components/textarea/textarea.tsx
@@ -120,23 +120,21 @@ export class Textarea {
     return (
       <div
         class={`
-        sdds-textarea-container
-        ${this.noMinWidth ? 'no-min-width' : ''}
-        ${this.labelPosition === 'inside' ? 'sdds-textarea-label-inside' : ''}
-        ${this.focusInput ? 'sdds-textarea-focus' : ''}
-        ${this.disabled ? 'sdds-textarea-disabled' : ''}
-        ${this.readOnly ? 'sdds-textarea-readonly' : ''}
+        textarea-container
+        ${this.labelPosition === 'inside' ? 'textarea-label-inside' : ''}
+        ${this.focusInput ? 'textarea-focus' : ''}
+        ${this.disabled ? 'textarea-disabled' : ''}
+        ${this.readOnly ? 'textarea-readonly' : ''}
         ${this.modeVariant !== null ? `sdds-mode-variant-${this.modeVariant}` : ''}
-        ${this.value ? 'sdds-textarea-data' : ''}
-        ${this.state === 'error' || this.state === 'success' ? `sdds-textarea-${this.state}` : ''}
+        ${this.value ? 'textarea-data' : ''}
+        ${this.state === 'error' || this.state === 'success' ? `textarea-${this.state}` : ''}
+        ${this.noMinWidth ? 'no-min-width' : ''}
         `}
       >
-        {this.labelPosition !== 'no-label' && (
-          <span class={'sdds-textarea-label'}>{this.label}</span>
-        )}
-        <div class="sdds-textarea-wrapper">
+        {this.labelPosition !== 'no-label' && <span class={'textarea-label'}>{this.label}</span>}
+        <div class="textarea-wrapper">
           <textarea
-            class={'sdds-textarea-input'}
+            class={'textarea-input'}
             ref={(inputEl) => (this.textEl = inputEl as HTMLTextAreaElement)}
             disabled={this.disabled}
             readonly={this.readOnly}
@@ -160,7 +158,7 @@ export class Textarea {
             onInput={(event) => this.handleInput(event)}
             onChange={(event) => this.handleChange(event)}
           ></textarea>
-          <span class="sdds-textarea-resizer-icon">
+          <span class="textarea-resizer-icon">
             <svg
               width="12"
               height="12"
@@ -176,20 +174,20 @@ export class Textarea {
               />
             </svg>
           </span>
-          <span class="sdds-textarea-icon__readonly">
+          <span class="textarea-icon__readonly">
             <sdds-icon name="edit_inactive"></sdds-icon>
           </span>
-          <span class="sdds-textarea-icon__readonly-label">This field is non-editable</span>
+          <span class="textarea-icon__readonly-label">This field is non-editable</span>
         </div>
-        <span class={'sdds-textarea-helper'}>
+        <span class={'textarea-helper'}>
           {this.state === 'error' && <sdds-icon name="error" size="16px"></sdds-icon>}
           {this.helper}
         </span>
 
         {this.maxLength > 0 && (
-          <div class={'sdds-textarea-textcounter'}>
+          <div class={'textarea-textcounter'}>
             {this.value === null ? 0 : this.value?.length}
-            <span class="sdds-textfield-textcounter-divider"> / </span> {this.maxLength}
+            <span class="textfield-textcounter-divider"> / </span> {this.maxLength}
           </div>
         )}
       </div>

--- a/tegel/src/components/textfield/textfield.scss
+++ b/tegel/src/components/textfield/textfield.scss
@@ -156,7 +156,7 @@
 //Textfield container with label inside
 //Handling position, focus and transition for label inside
 .form-textfield.textfield-container-label-inside {
-  .textfield-input {
+  .textfield-input-lg {
     padding-top: var(--sdds-spacing-element-24);
     padding-bottom: 15px;
 
@@ -209,7 +209,7 @@
       top: 8px;
     }
 
-    .textfield-input ~ .textfield-label-inside {
+    .textfield-input-lg ~ .textfield-label-inside {
       font: var(--sdds-detail-07);
       letter-spacing: var(--sdds-detail-07-ls);
 

--- a/tegel/src/components/textfield/textfield.scss
+++ b/tegel/src/components/textfield/textfield.scss
@@ -1,6 +1,5 @@
-@import './textfield-vars.scss';
-
 @mixin textfield-base {
+  all: unset;
   border-radius: 4px 4px 0 0;
   width: 100%;
   box-sizing: border-box;
@@ -29,14 +28,14 @@
       color: var(--sdds-textfield-placeholder-disabled);
     }
 
-    ~ .sdds-textfield-label-inside {
+    ~ .textfield-label-inside {
       color: var(--sdds-textfield-label-disabled);
     }
   }
 }
 
 //Sizes
-.sdds-textfield-input {
+.textfield-input-lg {
   @include textfield-base;
 
   font: var(--sdds-detail-02);
@@ -44,7 +43,7 @@
   padding: var(--sdds-spacing-element-20) var(--sdds-spacing-element-16);
 }
 
-.sdds-textfield-input-md {
+.textfield-input-md {
   @include textfield-base;
 
   font: var(--sdds-detail-02);
@@ -52,7 +51,7 @@
   padding: var(--sdds-spacing-element-16);
 }
 
-.sdds-textfield-input-sm {
+.textfield-input-sm {
   @include textfield-base;
 
   font: var(--sdds-detail-02);
@@ -61,7 +60,7 @@
 }
 
 //Container for input field and prefix/suffix
-.sdds-textfield-container {
+.textfield-container {
   border-radius: 4px 4px 0 0;
   display: flex;
   position: relative;
@@ -75,16 +74,16 @@
     border-bottom-color: var(--sdds-textfield-border-bottom-hover);
   }
 
-  .sdds-form-textfield-md & {
+  .form-textfield-md & {
     height: 48px;
   }
 
-  .sdds-form-textfield-sm & {
+  .form-textfield-sm & {
     height: 40px;
   }
 }
 
-.sdds-textfield-input-container {
+.textfield-input-container {
   position: relative;
   width: 100%;
 }
@@ -99,7 +98,7 @@
 } */
 
 //Textfield label
-.sdds-textfield-label-outside > * {
+.textfield-label-outside > * {
   font: var(--sdds-detail-05);
   letter-spacing: var(--sdds-detail-05-ls);
   display: block;
@@ -107,7 +106,7 @@
   color: var(--sdds-textfield-label-color);
 }
 
-.sdds-textfield-label-inside {
+.textfield-label-inside {
   font: var(--sdds-detail-02);
   letter-spacing: var(--sdds-detail-02-ls);
   position: absolute;
@@ -145,7 +144,7 @@
 }
 
 //Form control
-.sdds-form-textfield {
+.form-textfield {
   display: block;
   min-width: 208px;
 
@@ -156,43 +155,43 @@
 
 //Textfield container with label inside
 //Handling position, focus and transition for label inside
-.sdds-form-textfield.sdds-textfield-container-label-inside {
-  .sdds-textfield-input {
+.form-textfield.textfield-container-label-inside {
+  .textfield-input {
     padding-top: var(--sdds-spacing-element-24);
     padding-bottom: 15px;
 
-    ~ .sdds-textfield-label-inside {
+    ~ .textfield-label-inside {
       top: 20px;
     }
 
     @include placeholder-label;
   }
 
-  .sdds-textfield-input-md {
+  .textfield-input-md {
     padding-top: var(--sdds-spacing-element-20);
     padding-bottom: 11px;
 
-    ~ .sdds-textfield-label-inside {
+    ~ .textfield-label-inside {
       top: 16px;
     }
 
     @include placeholder-label;
   }
 
-  .sdds-textfield-input-sm {
+  .textfield-input-sm {
     padding-top: var(--sdds-spacing-element-20);
     padding-bottom: 11px;
 
-    ~ .sdds-textfield-label-inside {
+    ~ .textfield-label-inside {
       top: 16px;
     }
 
     @include placeholder-label;
   }
 
-  &.sdds-textfield-focus,
-  &.sdds-textfield-data {
-    .sdds-textfield-input-sm ~ .sdds-textfield-label-inside {
+  &.textfield-focus,
+  &.textfield-data {
+    .textfield-input-sm ~ .textfield-label-inside {
       font: var(--sdds-detail-07);
       letter-spacing: var(--sdds-detail-07-ls);
 
@@ -201,7 +200,7 @@
       top: 8px;
     }
 
-    .sdds-textfield-input-md ~ .sdds-textfield-label-inside {
+    .textfield-input-md ~ .textfield-label-inside {
       font: var(--sdds-detail-07);
       letter-spacing: var(--sdds-detail-07-ls);
 
@@ -210,7 +209,7 @@
       top: 8px;
     }
 
-    .sdds-textfield-input ~ .sdds-textfield-label-inside {
+    .textfield-input ~ .textfield-label-inside {
       font: var(--sdds-detail-07);
       letter-spacing: var(--sdds-detail-07-ls);
 
@@ -222,7 +221,7 @@
 }
 
 //Textfield bottom bar when in focus
-.sdds-textfield-bar {
+.textfield-bar {
   position: absolute;
   width: 100%;
 
@@ -236,11 +235,11 @@
     background: var(--sdds-textfield-bar);
     transition: 0.35s ease all;
 
-    .sdds-form-textfield-md & {
+    .form-textfield-md & {
       top: 46px;
     }
 
-    .sdds-form-textfield-sm & {
+    .form-textfield-sm & {
       top: 40px;
     }
   }
@@ -253,21 +252,21 @@
     right: 50%;
   }
 
-  .sdds-textfield-focus &::before,
-  .sdds-textfield-focus &::after {
+  .textfield-focus &::before,
+  .textfield-focus &::after {
     width: 50%;
   }
 }
 
 //Helper text
-.sdds-textfield-helper {
+.textfield-helper {
   font: var(--sdds-detail-05);
   letter-spacing: var(--sdds-detail-05-ls);
   display: flex;
   gap: 8px;
   justify-content: space-between;
 
-  & .sdds-textfield-textcounter {
+  & .textfield-textcounter {
     margin-left: auto;
   }
 
@@ -277,19 +276,19 @@
 }
 
 //Disabled state
-.sdds-form-textfield-disabled {
-  .sdds-textfield-container {
+.form-textfield-disabled {
+  .textfield-container {
     border-bottom-color: transparent;
   }
 
-  .sdds-textfield-slot-wrap-prefix,
-  .sdds-textfield-slot-wrap-suffix {
+  .textfield-slot-wrap-prefix,
+  .textfield-slot-wrap-suffix {
     > * {
       color: var(--sdds-textfield-ps-color-disabled);
     }
   }
 
-  .sdds-textfield-label-outside {
+  .textfield-label-outside {
     > * {
       color: var(--sdds-textfield-label-disabled);
     }
@@ -298,7 +297,7 @@
 
 //Read only state
 
-.sdds-textfield-icon__readonly {
+.textfield-icon__readonly {
   display: none;
   position: absolute;
   right: 18px;
@@ -319,43 +318,43 @@
   }
 }
 
-.sdds-form-textfield-readonly {
+.form-textfield-readonly {
   pointer-events: none;
 
-  .sdds-textfield-icon__readonly {
+  .textfield-icon__readonly {
     display: block;
 
     &:hover {
-      ~ .sdds-textfield-icon__readonly-label {
+      ~ .textfield-icon__readonly-label {
         display: block;
       }
     }
   }
 
-  .sdds-textfield-input {
+  .textfield-input {
     padding-right: 54px;
     background-color: transparent;
   }
 }
 
 //Success state
-.sdds-form-textfield-success {
-  .sdds-textfield-container {
+.form-textfield-success {
+  .textfield-container {
     border-bottom-color: var(--sdds-textfield-border-bottom-success);
   }
 }
 
 //Error State
-.sdds-form-textfield-error {
-  .sdds-textfield-helper {
+.form-textfield-error {
+  .textfield-helper {
     color: var(--sdds-textfield-helper-error);
   }
 
-  .sdds-textfield-container {
+  .textfield-container {
     border-bottom-color: var(--sdds-textfield-border-bottom-error);
   }
 
-  .sdds-textfield-bar {
+  .textfield-bar {
     &::before,
     &::after {
       background: var(--sdds-textfield-bar-error);
@@ -368,20 +367,20 @@
   }
 }
 
-// .sdds-textfield-textcounter {
-.sdds-textfield-helper-error-state {
+// .textfield-textcounter {
+.textfield-helper-error-state {
   display: flex;
   gap: 8px;
   flex-wrap: nowrap;
 }
 
-.sdds-textfield-textcounter {
+.textfield-textcounter {
   font: var(--sdds-detail-05);
   letter-spacing: var(--sdds-detail-05-ls);
   color: var(--sdds-textfield-textcounter);
   float: right;
 
-  & .sdds-textfield-textcounter-divider {
+  & .textfield-textcounter-divider {
     // @include type-style('detail-05');
     color: var(--sdds-textfield-textcounter-divider);
   }
@@ -394,7 +393,7 @@ slot[name="sdds-suffix"]::slotted(*) {
   color: var(--sdds-textfield-ps-color);
 } */
 
-.sdds-textfield-slot-wrap-prefix {
+.textfield-slot-wrap-prefix {
   align-self: center;
 
   > * {
@@ -404,15 +403,15 @@ slot[name="sdds-suffix"]::slotted(*) {
     color: var(--sdds-textfield-ps-color);
   }
 
-  &.sdds-textfield-error {
+  &.textfield-error {
     sdds-icon,
-    .sdds-icon {
+    .icon {
       color: var(--sdds-negative);
     }
   }
 }
 
-.sdds-textfield-slot-wrap-suffix {
+.textfield-slot-wrap-suffix {
   align-self: center;
 
   > * {
@@ -422,9 +421,9 @@ slot[name="sdds-suffix"]::slotted(*) {
     color: var(--sdds-textfield-ps-color);
   }
 
-  &.sdds-textfield-error {
+  &.textfield-error {
     sdds-icon,
-    .sdds-icon {
+    .icon {
       color: var(--sdds-negative);
     }
   }
@@ -441,7 +440,7 @@ slot[name='sdds-suffix']::slotted(sdds-icon) {
 slot[name='sdds-prefix']::slotted(*) {
   padding-left: var(--sdds-spacing-element-20);
 
-  & ~ .sdds-textfield-input {
+  & ~ .textfield-input {
     padding-left: var(--sdds-spacing-element-12);
   }
 }

--- a/tegel/src/components/textfield/textfield.tsx
+++ b/tegel/src/components/textfield/textfield.tsx
@@ -4,6 +4,7 @@ import { Component, h, State, Prop, Event, EventEmitter } from '@stencil/core';
   tag: 'sdds-textfield',
   styleUrl: 'textfield.scss',
   shadow: false,
+  scoped: true,
 })
 export class Textfield {
   /** Textinput for focus state */
@@ -118,13 +119,6 @@ export class Textfield {
   }
 
   render() {
-    let className = ' sdds-textfield-input';
-    if (this.size === 'md') {
-      className += `${className}-md`;
-    }
-    if (this.size === 'sm') {
-      className += `${className}-sm`;
-    }
     return (
       <div
         class={`
@@ -165,7 +159,7 @@ export class Textfield {
           <div class="sdds-textfield-input-container">
             <input
               ref={(inputEl) => (this.textInput = inputEl as HTMLInputElement)}
-              class={className}
+              class={`sdds-textfield-input-${this.size}`}
               type={this.type}
               disabled={this.disabled}
               readonly={this.readOnly}

--- a/tegel/src/components/textfield/textfield.tsx
+++ b/tegel/src/components/textfield/textfield.tsx
@@ -151,7 +151,7 @@ export class Textfield {
           <div class="textfield-input-container">
             <input
               ref={(inputEl) => (this.textInput = inputEl as HTMLInputElement)}
-              class={`textfield-input-${this.size}`}
+              class={`textfield-input textfield-input-${this.size}`}
               type={this.type}
               disabled={this.disabled}
               readonly={this.readOnly}

--- a/tegel/src/components/textfield/textfield.tsx
+++ b/tegel/src/components/textfield/textfield.tsx
@@ -122,44 +122,36 @@ export class Textfield {
     return (
       <div
         class={`
-        ${this.noMinWidth ? 'sdds-form-textfield-nomin' : ''}
-        ${
-          this.focusInput && !this.disabled
-            ? 'sdds-form-textfield sdds-textfield-focus'
-            : ' sdds-form-textfield'
-        }
-        ${this.value ? 'sdds-textfield-data' : ''}
+        ${this.noMinWidth ? 'form-textfield-nomin' : ''}
+        ${this.focusInput && !this.disabled ? 'form-textfield textfield-focus' : ' form-textfield'}
+        ${this.value ? 'textfield-data' : ''}
         ${
           this.labelPosition === 'inside' && this.size !== 'sm'
-            ? 'sdds-textfield-container-label-inside'
+            ? 'textfield-container-label-inside'
             : ''
         }
-        ${this.disabled ? 'sdds-form-textfield-disabled' : ''}
-        ${this.readOnly ? 'sdds-form-textfield-readonly' : ''}
+        ${this.disabled ? 'form-textfield-disabled' : ''}
+        ${this.readOnly ? 'form-textfield-readonly' : ''}
         ${this.modeVariant !== null ? `sdds-mode-variant-${this.modeVariant}` : ''}
-        ${this.size === 'md' ? 'sdds-form-textfield-md' : ''}
-        ${this.size === 'sm' ? 'sdds-form-textfield-sm' : ''}
-        ${
-          this.state === 'error' || this.state === 'success'
-            ? `sdds-form-textfield-${this.state}`
-            : ''
-        }
+        ${this.size === 'md' ? 'form-textfield-md' : ''}
+        ${this.size === 'sm' ? 'form-textfield-sm' : ''}
+        ${this.state === 'error' || this.state === 'success' ? `form-textfield-${this.state}` : ''}
         `}
       >
         {this.labelPosition === 'outside' && (
-          <div class="sdds-textfield-label-outside">
+          <div class="textfield-label-outside">
             <div>{this.label}</div>
           </div>
         )}
-        <div onClick={() => this.textInput.focus()} class="sdds-textfield-container">
-          <div class={`sdds-textfield-slot-wrap-prefix sdds-textfield-${this.state}`}>
-            <slot name="sdds-prefix" />
+        <div onClick={() => this.textInput.focus()} class="textfield-container">
+          <div class={`textfield-slot-wrap-prefix textfield-${this.state}`}>
+            <slot name="prefix" />
           </div>
 
-          <div class="sdds-textfield-input-container">
+          <div class="textfield-input-container">
             <input
               ref={(inputEl) => (this.textInput = inputEl as HTMLInputElement)}
-              class={`sdds-textfield-input-${this.size}`}
+              class={`textfield-input-${this.size}`}
               type={this.type}
               disabled={this.disabled}
               readonly={this.readOnly}
@@ -183,23 +175,23 @@ export class Textfield {
             />
 
             {this.labelPosition === 'inside' && this.size !== 'sm' && (
-              <label class="sdds-textfield-label-inside">{this.label}</label>
+              <label class="textfield-label-inside">{this.label}</label>
             )}
           </div>
-          <div class="sdds-textfield-bar"></div>
+          <div class="textfield-bar"></div>
 
-          <div class={`sdds-textfield-slot-wrap-suffix sdds-textfield-${this.state}`}>
-            <slot name="sdds-suffix" />
+          <div class={`textfield-slot-wrap-suffix textfield-${this.state}`}>
+            <slot name="suffix" />
           </div>
-          <span class="sdds-textfield-icon__readonly">
+          <span class="textfield-icon__readonly">
             <sdds-icon name="edit_inactive" size="20px"></sdds-icon>
           </span>
-          <span class="sdds-textfield-icon__readonly-label">This field is non-editable</span>
+          <span class="textfield-icon__readonly-label">This field is non-editable</span>
         </div>
 
-        <div class="sdds-textfield-helper">
+        <div class="textfield-helper">
           {this.state === 'error' && (
-            <div class="sdds-textfield-helper-error-state">
+            <div class="textfield-helper-error-state">
               <sdds-icon name="error" size="16px"></sdds-icon>
               {this.helper}
             </div>
@@ -207,9 +199,9 @@ export class Textfield {
           {this.state !== 'error' && this.helper}
 
           {this.maxLength > 0 && (
-            <div class="sdds-textfield-textcounter">
+            <div class="textfield-textcounter">
               {this.value === null ? 0 : this.value?.length}
-              <span class="sdds-textfield-textcounter-divider"> / </span>
+              <span class="textfield-textcounter-divider"> / </span>
               {this.maxLength}
             </div>
           )}

--- a/tegel/src/global/global.scss
+++ b/tegel/src/global/global.scss
@@ -62,6 +62,8 @@
 @import 'src/components/tabs/inline-tabs-default/inline-tabs-vars';
 @import 'src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed-vars';
 @import 'src/components/tabs/navigation-tabs/navigation-tabs-vars';
+@import 'src/components/textarea/textarea-vars';
+@import 'src/components/textfield/textfield-vars';
 @import 'src/components/tooltip/tooltip-vars';
 @import 'src/components/block/block-vars';
 @import 'src/components/spinner/spinner';


### PR DESCRIPTION
**Describe pull-request**  
Scoped css and removed class name creation in render method.

**Solving issue**  
Fixes: -

**How to test**  
1. Go to storybook link below
2. Check in Components -> Textfield/Textarea
3. Check that the styling is still correct.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
