### PR TITLE
fix(accordion): standardise order of Storybook controls

### DIFF
--- a/tegel/src/components/accordion/accordion.stories.tsx
+++ b/tegel/src/components/accordion/accordion.stories.tsx
@@ -5,46 +5,46 @@ import readmeItem from './accordion-item/readme.md';
 export default {
   title: 'Components/Accordion',
   argTypes: {
-    iconPosition: {
-      name: 'Expand icon position',
-      control: {
-        type: 'radio',
-      },
-      options: { End: 'end', Start: 'start' },
-      description: 'The horizontal position of the expand icon.',
-      table: {
-        defaultValue: { summary: 'end' },
-      },
-    },
-    disabled: {
-      name: 'Disable all items',
-      description: 'Disable all accordion items.',
-      control: {
-        type: 'boolean',
-      },
-      table: {
-        defaultValue: { summary: 'false' },
-      },
-    },
-    paddingReset: {
-      name: 'Less padding right',
-      description: 'Less padding on the right inside accordion items.',
-      control: {
-        type: 'boolean',
-      },
-      table: {
-        defaultValue: { summary: 'false' },
-      },
-    },
     modeVariant: {
       name: 'Mode variant',
-      description: 'Mode variant of the component.',
+      description: 'Mode variation adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
       options: ['Inherit from parent', 'Primary', 'Secondary'],
       table: {
         defaultValue: { summary: 'Inherit from parent' },
+      },
+    },
+    iconPosition: {
+      name: 'Expand icon position',
+      description: 'Sets the horizontal position of the expand icon.',
+      control: {
+        type: 'radio',
+      },
+      options: { End: 'end', Start: 'start' },
+      table: {
+        defaultValue: { summary: 'end' },
+      },
+    },
+    paddingReset: {
+      name: 'Less padding right',
+      description: 'Sets less padding on the right inside accordion items.',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: 'false' },
+      },
+    },
+    disabled: {
+      name: 'Disable all items',
+      description: 'Disables all accordion items.',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: 'false' },
       },
     },
   },
@@ -64,10 +64,10 @@ export default {
     ],
   },
   args: {
-    disabled: false,
-    paddingReset: false,
-    iconPosition: 'end',
     modeVariant: 'Inherit from parent',
+    iconPosition: 'end',
+    paddingReset: false,
+    disabled: false,
   },
 };
 

--- a/tegel/src/components/accordion/accordion.stories.tsx
+++ b/tegel/src/components/accordion/accordion.stories.tsx
@@ -7,7 +7,7 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
-      description: 'Mode variant adjusts the components colors to have better visibility depending on global mode and background.',
+      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },

--- a/tegel/src/components/accordion/accordion.stories.tsx
+++ b/tegel/src/components/accordion/accordion.stories.tsx
@@ -7,7 +7,7 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
-      description: 'Mode variation adjusts component colors to have better visibility depending on global mode and background.',
+      description: 'Mode variant adjusts the components colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },


### PR DESCRIPTION
**Describe pull-request**  
Standardised order of controls in Storybook for accordion component.

**Solving issue**  
_In case of GitHub issue add # plus the number of the issue (for example #123) OR if it is Azure then AB# and number of ticket_
Fixes: [AB#3423](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3423)

**How to test**  
_Add description how to test if possible_
1. Go to Storybook link below
2. Check in Accordion - Default
3. Inspect order on controls
4. Read descriptions of controls

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
