### PR TITLE
fix(badge): standardise order of controls in Storybook

### DIFF
--- a/tegel/src/components/badge/badge.stories.tsx
+++ b/tegel/src/components/badge/badge.stories.tsx
@@ -22,7 +22,7 @@ export default {
   argTypes: {
     size: {
       name: 'Size',
-      description: 'Size of the component',
+      description: 'Sets the size of the component.',
       control: {
         type: 'radio',
       },
@@ -36,7 +36,7 @@ export default {
     },
     value: {
       name: 'Value',
-      description: 'Set a value to show on the badge',
+      description: 'Sets a value to show on the badge.',
       control: {
         type: 'number',
       },
@@ -47,7 +47,7 @@ export default {
     },
     hidden: {
       name: 'Hidden',
-      description: 'Toggle visibility of badge',
+      description: 'Toggles visibility of the badge.',
       control: {
         type: 'boolean',
       },

--- a/tegel/src/components/badge/badge.stories.tsx
+++ b/tegel/src/components/badge/badge.stories.tsx
@@ -20,14 +20,18 @@ export default {
     ],
   },
   argTypes: {
-    hidden: {
-      name: 'Hidden',
-      description: 'Toggle visibility of badge',
+    size: {
+      name: 'Size',
+      description: 'Size of the component',
       control: {
-        type: 'boolean',
+        type: 'radio',
+      },
+      options: {
+        Large: 'lg',
+        Small: 'sm',
       },
       table: {
-        defaultValue: { summary: false },
+        defaultValue: { summary: 'lg' },
       },
     },
     value: {
@@ -41,25 +45,21 @@ export default {
         defaultValue: { summary: null },
       },
     },
-    size: {
-      name: 'Size',
-      description: 'Size of the component',
-      options: {
-        Large: 'lg',
-        Small: 'sm',
-      },
+    hidden: {
+      name: 'Hidden',
+      description: 'Toggle visibility of badge',
       control: {
-        type: 'radio',
+        type: 'boolean',
       },
       table: {
-        defaultValue: { summary: 'lg' },
+        defaultValue: { summary: false },
       },
     },
   },
   args: {
-    hidden: false,
     size: 'lg',
     value: 1,
+    hidden: false,
   },
 };
 


### PR DESCRIPTION
**Describe pull-request**  
Standardised order of controls in Storybook for badge component.

**Solving issue**  
Fixes: [AB#3424](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3424)

**How to test**  
_Add description how to test if possible_
1. Go to Storybook link below
2. Check in Badge -> Default (and With Demo Component)
3. Inspect order of controls
4. Read control descriptions

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events