### PR TITLE
fix(textarea): correct disabled styling

### DIFF
--- a/tegel/src/components/textarea/textarea-vars.scss
+++ b/tegel/src/components/textarea/textarea-vars.scss
@@ -9,7 +9,9 @@
 
   // Disabled
   --sdds-textarea-disabled-color: var(--sdds-grey-400);
-  --sdds-textarea-disabled-background: var(--sdds-white);
+  --sdds-textarea-disabled-background-primary: var(--sdds-grey-50);
+  --sdds-textarea-disabled-background-secondary: var(--sdds-white);
+  --sdds-textarea-disabled-background: var(--sdds-textarea-disabled-background-primary);
   --sdds-textarea-disabled-placeholder: var(--sdds-grey-400);
   --sdds-textarea-disabled-label: var(--sdds-grey-400);
 
@@ -47,10 +49,12 @@
 
   .sdds-mode-variant-primary {
     --sdds-textarea-background: var(--sdds-textarea-background-primary);
+    --sdds-textarea-disabled-background: var(--sdds-textarea-disabled-background-primary);
   }
 
   .sdds-mode-variant-secondary {
     --sdds-textarea-background: var(--sdds-textarea-background-secondary);
+    --sdds-textarea-disabled-background: var(--sdds-textarea-disabled-background-secondary);
   }
 }
 
@@ -64,7 +68,9 @@
 
   // Disabled
   --sdds-textarea-disabled-color: var(--sdds-grey-800);
-  --sdds-textarea-disabled-background: var(--sdds-grey-868);
+  --sdds-textarea-disabled-background-primary: var(--sdds-grey-900);
+  --sdds-textarea-disabled-background-secondary: var(--sdds-grey-868);
+  --sdds-textarea-disabled-background: var(--sdds-textarea-disabled-background-primary);
   --sdds-textarea-disabled-placeholder: var(--sdds-grey-800);
   --sdds-textarea-disabled-label: var(--sdds-grey-700);
 
@@ -102,9 +108,11 @@
 
   .sdds-mode-variant-primary {
     --sdds-textarea-background: var(--sdds-textarea-background-primary);
+    --sdds-textarea-disabled-background: var(--sdds-textarea-disabled-background-primary);
   }
 
   .sdds-mode-variant-secondary {
     --sdds-textarea-background: var(--sdds-textarea-background-secondary);
+    --sdds-textarea-disabled-background: var(--sdds-textarea-disabled-background-secondary);
   }
 }


### PR DESCRIPTION
**Describe pull-request**  
The textarea didn't have styling for different mode variants

**Solving issue**  
_In case of GitHub issue add # plus the number of the issue (for example #123) OR if it is Azure then AB# and number of ticket_
Fixes: [AB#3475](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3475)

**How to test**  
1. Go to storybook and open textarea component
2. disable component and test different mode variants.

Color from Figma:
Background:
Light primary: grey-50
Light Secondary: white
Dark primary: grey-900
Dark primary: grey-868

Placeholder:
Light primary + secondary: grey-400
Dark primary + secondary: grey-800

label:
Light primary + secondary: grey-400
Dark primary + secondary: grey-700


**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
