### PR TITLE
fix(banner): update control descriptions in Storybook

### DIFF
--- a/tegel/src/components/banner/banner.stories.tsx
+++ b/tegel/src/components/banner/banner.stories.tsx
@@ -20,7 +20,7 @@ export default {
   argTypes: {
     state: {
       name: 'Type',
-      description: 'Changes type of component',
+      description: 'Changes the type of the component.',
       options: ['Default', 'Error', 'Info'],
       control: {
         type: 'radio',
@@ -31,21 +31,21 @@ export default {
     },
     header: {
       name: 'Header',
-      description: 'Text to display in header section',
+      description: 'Sets text to be displayed in the header section.',
       control: {
         type: 'text',
       },
     },
     subheader: {
       name: 'Subheader',
-      description: 'Text to display in subheader section',
+      description: 'Sets text to be displayed in the subheader section.',
       control: {
         type: 'text',
       },
     },
     link: {
       name: 'Link',
-      description: 'Text to display in link section',
+      description: 'Sets text to be displayed in the link section.',
       control: {
         type: 'text',
       },
@@ -53,7 +53,7 @@ export default {
     hideIcon: {
       name: 'Hide icon',
       description:
-        'If an icon should be displayed. For type default the truck icon is used in this example, but it should be changed to suit your needs.',
+        'Sets if an icon should be displayed. For type default the truck icon is used in this example, but it should be changed to suit your needs.',
       control: {
         type: 'boolean',
       },

--- a/tegel/src/components/banner/banner.stories.tsx
+++ b/tegel/src/components/banner/banner.stories.tsx
@@ -53,7 +53,7 @@ export default {
     hideIcon: {
       name: 'Hide icon',
       description:
-        'Sets if an icon should be displayed. For type default the truck icon is used in this example, but it should be changed to suit your needs.',
+        'Controls if an icon should be displayed. The truck icon is used here as an example, but it should be changed to suit your needs.',
       control: {
         type: 'boolean',
       },

--- a/tegel/src/components/banner/sdds-banner.stories.tsx
+++ b/tegel/src/components/banner/sdds-banner.stories.tsx
@@ -25,7 +25,7 @@ export default {
   argTypes: {
     type: {
       name: 'Type',
-      description: 'Changes type of component',
+      description: 'Changes the type of the component.',
       options: ['Default', 'Error', 'Information'],
       control: {
         type: 'radio',
@@ -36,35 +36,35 @@ export default {
     },
     header: {
       name: 'Header',
-      description: 'Text to display in header section',
+      description: 'Sets text to be displayed in the header section.',
       control: {
         type: 'text',
       },
     },
     subheader: {
       name: 'Subheader',
-      description: 'Text to display in subheader section',
+      description: 'Sets text to be displayed in the subheader section.',
       control: {
         type: 'text',
       },
     },
     linkText: {
       name: 'Link',
-      description: 'Text to display in link section',
+      description: 'Sets text to be displayed in the link section.',
       control: {
         type: 'text',
       },
     },
     href: {
       name: 'Link href',
-      description: 'Href for link',
+      description: 'Sets the href for the link.',
       control: {
         type: 'text',
       },
     },
     linkTarget: {
       name: 'Link target',
-      description: 'Where to open the linked URL.',
+      description: 'Sets where to open the linked URL.',
       control: {
         type: 'radio',
       },


### PR DESCRIPTION
Describe pull-request
Updated control descriptions in Storybook for banner component.

Solving issue
Fixes: [AB#3425](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3425)

How to test
Add description how to test if possible

1. Go to Storybook link below
2. Check in Banner-> Native and Web Component
3. Inspect order of controls
4. Read control descriptions

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events