### PR TITLE
fix(button): standardise order of controls in Storybook

### DIFF
--- a/tegel/src/components/button/button-native.stories.tsx
+++ b/tegel/src/components/button/button-native.stories.tsx
@@ -22,13 +22,16 @@ export default {
     ],
   },
   argTypes: {
-    text: {
-      name: 'Text',
-      description: 'The text to be displayed on the button',
+    modeVariant: {
+      name: 'Mode variant',
       control: {
-        type: 'text',
+        type: 'radio',
       },
-      if: { arg: 'onlyIcon', truthy: false },
+      options: ['Inherit from parent', 'Primary', 'Secondary'],
+      description: 'Button mode variant.',
+      table: {
+        defaultValue: { summary: 'Inherit from parent' },
+      },
     },
     btnType: {
       name: 'Type',
@@ -53,16 +56,13 @@ export default {
         defaultValue: { summary: 'lg' },
       },
     },
-    modeVariant: {
-      name: 'Mode variant',
+    text: {
+      name: 'Text',
+      description: 'The text to be displayed on the button',
       control: {
-        type: 'radio',
+        type: 'text',
       },
-      options: ['Inherit from parent', 'Primary', 'Secondary'],
-      description: 'Button mode variant.',
-      table: {
-        defaultValue: { summary: 'Inherit from parent' },
-      },
+      if: { arg: 'onlyIcon', truthy: false },
     },
     fullbleed: {
       name: 'Fullbleed',
@@ -75,14 +75,6 @@ export default {
         defaultValue: { summary: false },
       },
       if: { arg: 'onlyIcon', eq: false },
-    },
-    disabled: {
-      name: 'Disabled',
-      type: 'boolean',
-      description: 'Choose to disable the button',
-      table: {
-        defaultValue: { summary: false },
-      },
     },
     onlyIcon: {
       name: 'Only Icon',
@@ -113,30 +105,38 @@ export default {
       options: ['Native', 'Web Component'],
       if: { arg: 'size', neq: 'Extra small' },
     },
+    disabled: {
+      name: 'Disabled',
+      type: 'boolean',
+      description: 'Choose to disable the button',
+      table: {
+        defaultValue: { summary: false },
+      },
+    },
   },
   args: {
-    text: 'Button',
+    modeVariant: 'Primary',
     btnType: 'Primary',
     size: 'Large',
-    modeVariant: 'Primary',
+    text: 'Button',
     fullbleed: false,
-    disabled: false,
     onlyIcon: false,
     icon: 'none',
     iconType: 'Native',
+    disabled: false,
   },
 };
 
 const NativeTemplate = ({
-  size,
   modeVariant,
   btnType,
-  fullbleed,
+  size,
   text = 'Button',
-  disabled = '',
+  fullbleed,
   onlyIcon,
   icon,
   iconType,
+  disabled = '',
 }) => {
   const fbClass = fullbleed ? 'sdds-btn-fullbleed' : '';
   const onlyIconCss = onlyIcon ? 'sdds-btn-icon' : '';

--- a/tegel/src/components/button/button-native.stories.tsx
+++ b/tegel/src/components/button/button-native.stories.tsx
@@ -24,19 +24,18 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
+      description: 'Mode variant adjusts the components colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
       options: ['Inherit from parent', 'Primary', 'Secondary'],
-      description: 'Mode variant adjusts the components colors to have better visibility depending on global mode and background.',
       table: {
         defaultValue: { summary: 'Inherit from parent' },
       },
     },
     btnType: {
       name: 'Type',
-      description:
-        'Four different button types to help the user to distinguish the level of importance of the task they represent.',
+      description: 'Four different button types to help the user to distinguish the level of importance of the task they represent.',
       control: {
         type: 'radio',
       },
@@ -66,7 +65,6 @@ export default {
     },
     fullbleed: {
       name: 'Fullbleed',
-      defaultValue: false,
       description: 'Sets a fluid width on the button.',
       control: {
         type: 'boolean',
@@ -113,8 +111,10 @@ export default {
     },
     disabled: {
       name: 'Disabled',
-      type: 'boolean',
       description: 'Disables the button.',
+      control: {
+        type: 'boolean',
+      },
       table: {
         defaultValue: { summary: false },
       },

--- a/tegel/src/components/button/button-native.stories.tsx
+++ b/tegel/src/components/button/button-native.stories.tsx
@@ -24,7 +24,7 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
-      description: 'Mode variant adjusts the components colors to have better visibility depending on global mode and background.',
+      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },

--- a/tegel/src/components/button/button-native.stories.tsx
+++ b/tegel/src/components/button/button-native.stories.tsx
@@ -28,7 +28,7 @@ export default {
         type: 'radio',
       },
       options: ['Inherit from parent', 'Primary', 'Secondary'],
-      description: 'Button mode variant.',
+      description: 'Mode variant adjusts the components colors to have better visibility depending on global mode and background.',
       table: {
         defaultValue: { summary: 'Inherit from parent' },
       },
@@ -36,7 +36,7 @@ export default {
     btnType: {
       name: 'Type',
       description:
-        'Four different button types to help the user to distinguish the level of importance of the task they represent',
+        'Four different button types to help the user to distinguish the level of importance of the task they represent.',
       control: {
         type: 'radio',
       },
@@ -47,7 +47,7 @@ export default {
     },
     size: {
       name: 'Size',
-      description: 'Size of the button',
+      description: 'Sets the size of the button.',
       control: {
         type: 'radio',
       },
@@ -58,7 +58,7 @@ export default {
     },
     text: {
       name: 'Text',
-      description: 'The text to be displayed on the button',
+      description: 'Sets the text to be displayed on the button.',
       control: {
         type: 'text',
       },
@@ -67,7 +67,7 @@ export default {
     fullbleed: {
       name: 'Fullbleed',
       defaultValue: false,
-      description: 'Fluid width in certain components-old',
+      description: 'Sets a fluid width on the button.',
       control: {
         type: 'boolean',
       },
@@ -78,7 +78,7 @@ export default {
     },
     onlyIcon: {
       name: 'Only Icon',
-      description: 'Displays only the icon and excludes any text from the button',
+      description: 'Displays only the icon and excludes any text from the button.',
       control: {
         type: 'boolean',
       },
@@ -89,7 +89,7 @@ export default {
     },
     icon: {
       name: 'Icon',
-      description: 'Icon to display on the button. Choose "none" to exclude the icon.',
+      description: 'Sets icon to be displayed on the button. Choose "none" to exclude the icon.',
       control: {
         type: 'select',
       },
@@ -101,7 +101,7 @@ export default {
     },
     iconType: {
       name: 'Icon type',
-      description: 'Native/Web Component',
+      description: 'Switch between showing a native or a web component icon.',
       control: {
         type: 'radio',
       },
@@ -114,7 +114,7 @@ export default {
     disabled: {
       name: 'Disabled',
       type: 'boolean',
-      description: 'Choose to disable the button',
+      description: 'Disables the button.',
       table: {
         defaultValue: { summary: false },
       },

--- a/tegel/src/components/button/button-native.stories.tsx
+++ b/tegel/src/components/button/button-native.stories.tsx
@@ -93,6 +93,9 @@ export default {
       control: {
         type: 'select',
       },
+      table: {
+        defaultValue: { summary: 'none' },
+      },
       options: ['none', ...iconsNames],
       if: { arg: 'size', neq: 'Extra small' },
     },
@@ -103,6 +106,9 @@ export default {
         type: 'radio',
       },
       options: ['Native', 'Web Component'],
+      table: {
+        defaultValue: { summary: 'Native' },
+      },
       if: { arg: 'size', neq: 'Extra small' },
     },
     disabled: {
@@ -115,7 +121,7 @@ export default {
     },
   },
   args: {
-    modeVariant: 'Primary',
+    modeVariant: 'Inherit from parent',
     btnType: 'Primary',
     size: 'Large',
     text: 'Button',

--- a/tegel/src/components/button/button-webcomponent.stories.tsx
+++ b/tegel/src/components/button/button-webcomponent.stories.tsx
@@ -26,19 +26,18 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
+      description: 'Mode variant adjusts the components colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
       options: ['Inherit from parent', 'Primary', 'Secondary'],
-      description: 'Mode variant adjusts the components colors to have better visibility depending on global mode and background.',
       table: {
         defaultValue: { summary: 'Inherit from parent' },
       },
     },
     btnType: {
       name: 'Type',
-      description:
-        'Four different button types to help the user to distinguish the level of importance of the task they represent.',
+      description: 'Four different button types to help the user to distinguish the level of importance of the task they represent.',
       control: {
         type: 'radio',
       },
@@ -68,8 +67,10 @@ export default {
     },
     fullbleed: {
       name: 'Fullbleed',
-      type: 'boolean',
       description: 'Sets a fluid width on the button.',
+      control: {
+        type: 'boolean',
+      },
       table: {
         defaultValue: { summary: false },
       },
@@ -112,8 +113,10 @@ export default {
     },
     disabled: {
       name: 'Disabled',
-      type: 'boolean',
       description: 'Disables the button.',
+      control: {
+        type: 'boolean',
+      },
       table: {
         defaultValue: { summary: false },
       },

--- a/tegel/src/components/button/button-webcomponent.stories.tsx
+++ b/tegel/src/components/button/button-webcomponent.stories.tsx
@@ -26,7 +26,7 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
-      description: 'Mode variant adjusts the components colors to have better visibility depending on global mode and background.',
+      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },

--- a/tegel/src/components/button/button-webcomponent.stories.tsx
+++ b/tegel/src/components/button/button-webcomponent.stories.tsx
@@ -30,7 +30,7 @@ export default {
         type: 'radio',
       },
       options: ['Inherit from parent', 'Primary', 'Secondary'],
-      description: 'Button mode variant.',
+      description: 'Mode variant adjusts the components colors to have better visibility depending on global mode and background.',
       table: {
         defaultValue: { summary: 'Inherit from parent' },
       },
@@ -38,7 +38,7 @@ export default {
     btnType: {
       name: 'Type',
       description:
-        'Four different button types to help the user to distinguish the level of importance of the task they represent',
+        'Four different button types to help the user to distinguish the level of importance of the task they represent.',
       control: {
         type: 'radio',
       },
@@ -49,6 +49,7 @@ export default {
     },
     size: {
       name: 'Size',
+      description: 'Sets the size of the button.',
       control: {
         type: 'radio',
       },
@@ -56,11 +57,10 @@ export default {
       table: {
         defaultValue: { summary: 'lg' },
       },
-      description: 'Size of the button',
     },
     text: {
       name: 'Text',
-      description: 'The text to be displayed on the button',
+      description: 'Sets the text to be displayed on the button.',
       control: {
         type: 'text',
       },
@@ -69,7 +69,7 @@ export default {
     fullbleed: {
       name: 'Fullbleed',
       type: 'boolean',
-      description: 'Fluid width in certain components-old',
+      description: 'Sets a fluid width on the button.',
       table: {
         defaultValue: { summary: false },
       },
@@ -77,7 +77,7 @@ export default {
     },
     onlyIcon: {
       name: 'Only Icon',
-      description: 'Displays only the icon and excludes any text from the button',
+      description: 'Displays only the icon and excludes any text from the button.',
       control: {
         type: 'boolean',
       },
@@ -88,7 +88,7 @@ export default {
     },
     icon: {
       name: 'Icon',
-      description: 'Icon to display on the button. Choose "none" to exclude the icon.',
+      description: 'Sets icon to be displayed on the button. Choose "none" to exclude the icon.',
       control: {
         type: 'select',
       },
@@ -100,7 +100,7 @@ export default {
     },
     iconType: {
       name: 'Icon type',
-      description: 'Native/Web Component',
+      description: 'Switch between showing a native or a web component icon.',
       control: {
         type: 'radio',
       },
@@ -113,7 +113,7 @@ export default {
     disabled: {
       name: 'Disabled',
       type: 'boolean',
-      description: 'Choose to disable the button',
+      description: 'Disables the button.',
       table: {
         defaultValue: { summary: false },
       },

--- a/tegel/src/components/button/button-webcomponent.stories.tsx
+++ b/tegel/src/components/button/button-webcomponent.stories.tsx
@@ -24,13 +24,16 @@ export default {
     ],
   },
   argTypes: {
-    text: {
-      name: 'Text',
-      description: 'The text to be displayed on the button',
+    modeVariant: {
+      name: 'Mode variant',
       control: {
-        type: 'text',
+        type: 'radio',
       },
-      if: { arg: 'onlyIcon', truthy: false },
+      options: ['Inherit from parent', 'Primary', 'Secondary'],
+      description: 'Button mode variant.',
+      table: {
+        defaultValue: { summary: 'Inherit from parent' },
+      },
     },
     btnType: {
       name: 'Type',
@@ -55,16 +58,13 @@ export default {
       },
       description: 'Size of the button',
     },
-    modeVariant: {
-      name: 'Mode variant',
+    text: {
+      name: 'Text',
+      description: 'The text to be displayed on the button',
       control: {
-        type: 'radio',
+        type: 'text',
       },
-      options: ['Inherit from parent', 'Primary', 'Secondary'],
-      description: 'Button mode variant.',
-      table: {
-        defaultValue: { summary: 'Inherit from parent' },
-      },
+      if: { arg: 'onlyIcon', truthy: false },
     },
     fullbleed: {
       name: 'Fullbleed',
@@ -74,14 +74,6 @@ export default {
         defaultValue: { summary: false },
       },
       if: { arg: 'onlyIcon', truthy: false },
-    },
-    disabled: {
-      name: 'Disabled',
-      type: 'boolean',
-      description: 'Choose to disable the button',
-      table: {
-        defaultValue: { summary: false },
-      },
     },
     onlyIcon: {
       name: 'Only Icon',
@@ -112,30 +104,38 @@ export default {
       options: ['Native', 'Web Component'],
       if: { arg: 'size', neq: 'Extra small' },
     },
+    disabled: {
+      name: 'Disabled',
+      type: 'boolean',
+      description: 'Choose to disable the button',
+      table: {
+        defaultValue: { summary: false },
+      },
+    },
   },
   args: {
-    text: 'Button',
+    modeVariant: 'Primary',
     btnType: 'Primary',
     size: 'Large',
-    modeVariant: 'Primary',
+    text: 'Button',
     fullbleed: false,
-    disabled: false,
     onlyIcon: false,
     icon: 'none',
     iconType: 'Web Component',
+    disabled: false,
   },
 };
 
 const WebComponentTemplate = ({
-  onlyIcon,
-  size,
   modeVariant,
   btnType,
+  size,
+  text = 'Button',
   fullbleed,
-  disabled,
+  onlyIcon,
   icon,
   iconType,
-  text = 'Button',
+  disabled,
 }) => {
   const btnTypeLookUp = {
     Primary: 'primary',

--- a/tegel/src/components/button/button-webcomponent.stories.tsx
+++ b/tegel/src/components/button/button-webcomponent.stories.tsx
@@ -93,6 +93,9 @@ export default {
         type: 'select',
       },
       options: ['none', ...iconsNames],
+      table: {
+        defaultValue: { summary: 'none' },
+      },
       if: { arg: 'size', neq: 'Extra small' },
     },
     iconType: {
@@ -102,6 +105,9 @@ export default {
         type: 'radio',
       },
       options: ['Native', 'Web Component'],
+      table: {
+        defaultValue: { summary: 'Web Component' },
+      },
       if: { arg: 'size', neq: 'Extra small' },
     },
     disabled: {
@@ -114,7 +120,7 @@ export default {
     },
   },
   args: {
-    modeVariant: 'Primary',
+    modeVariant: 'Inherit from parent',
     btnType: 'Primary',
     size: 'Large',
     text: 'Button',

--- a/tegel/src/components/button/button.scss
+++ b/tegel/src/components/button/button.scss
@@ -324,7 +324,7 @@ i.sdds-btn-icon[slot='icon'] {
 }
 
 :host(sdds-button[fullbleed]) {
-  width: inherit;
+  width: 100%;
   justify-content: center;
 }
 


### PR DESCRIPTION
**Describe pull-request**  
Standardised order of controls in Storybook for button component. Also updated descriptions and deprecated controls and fixed fullbleed bug in web component.

**Solving issue**
Fixes: [AB#3426](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3426)

**How to test** 
1. Go to Storybook link below
2. Check in Button -> Web Component and Native (and all sub stories)
3. Inspect order of controls
4. Read control descriptions

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events