### PR TITLE
fix(checkbox): standardise order of controls in Storybook

### DIFF
--- a/tegel/src/components/checkbox/checkbox.stories.tsx
+++ b/tegel/src/components/checkbox/checkbox.stories.tsx
@@ -31,12 +31,18 @@ export default {
       control: {
         type: 'boolean',
       },
+      table: {
+        defaultValue: { summary: false },
+      },
     },
     disabled: {
       name: 'Disabled',
       description: 'Disables the checkbox.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
       },
     },
   },

--- a/tegel/src/components/checkbox/checkbox.stories.tsx
+++ b/tegel/src/components/checkbox/checkbox.stories.tsx
@@ -21,7 +21,9 @@ export default {
     label: {
       name: 'Label text',
       description: 'Sets the label of the component.',
-      type: 'string',
+      control: {
+        type: 'text',
+      },
     },
     checked: {
       name: 'Checked',

--- a/tegel/src/components/checkbox/checkbox.stories.tsx
+++ b/tegel/src/components/checkbox/checkbox.stories.tsx
@@ -18,12 +18,10 @@ export default {
     ],
   },
   argTypes: {
-    disabled: {
-      name: 'Disabled',
-      description: 'Disables the checkbox',
-      control: {
-        type: 'boolean',
-      },
+    label: {
+      name: 'Label text',
+      description: 'The label of the component',
+      type: 'string',
     },
     checked: {
       name: 'Checked',
@@ -32,20 +30,22 @@ export default {
         type: 'boolean',
       },
     },
-    label: {
-      name: 'Label text',
-      description: 'The label of the component',
-      type: 'string',
+    disabled: {
+      name: 'Disabled',
+      description: 'Disables the checkbox',
+      control: {
+        type: 'boolean',
+      },
     },
   },
   args: {
-    disabled: false,
-    checked: false,
     label: 'Label',
+    checked: false,
+    disabled: false,
   },
 };
 
-const Template = ({ checked, disabled, label }) =>
+const Template = ({ label, checked, disabled }) =>
   formatHtmlPreview(`
     <div class="sdds-checkbox-item">
       <input class="sdds-form-input" type="checkbox" id="unique-id" ${

--- a/tegel/src/components/checkbox/checkbox.stories.tsx
+++ b/tegel/src/components/checkbox/checkbox.stories.tsx
@@ -20,19 +20,19 @@ export default {
   argTypes: {
     label: {
       name: 'Label text',
-      description: 'The label of the component',
+      description: 'Sets the label of the component.',
       type: 'string',
     },
     checked: {
       name: 'Checked',
-      description: 'Checks the checkbox',
+      description: 'Checks the checkbox.',
       control: {
         type: 'boolean',
       },
     },
     disabled: {
       name: 'Disabled',
-      description: 'Disables the checkbox',
+      description: 'Disables the checkbox.',
       control: {
         type: 'boolean',
       },

--- a/tegel/src/components/checkbox/sdds-checkbox.stories.tsx
+++ b/tegel/src/components/checkbox/sdds-checkbox.stories.tsx
@@ -20,12 +20,10 @@ export default {
     ],
   },
   argTypes: {
-    disabled: {
-      name: 'Disabled',
-      description: 'Disables the checkbox',
-      control: {
-        type: 'boolean',
-      },
+    label: {
+      name: 'Label text',
+      description: 'The label of the component',
+      type: 'string',
     },
     checked: {
       name: 'Checked',
@@ -34,20 +32,22 @@ export default {
         type: 'boolean',
       },
     },
-    label: {
-      name: 'Label text',
-      description: 'The label of the component',
-      type: 'string',
+    disabled: {
+      name: 'Disabled',
+      description: 'Disables the checkbox',
+      control: {
+        type: 'boolean',
+      },
     },
   },
   args: {
-    disabled: false,
-    checked: false,
     label: 'Label',
+    checked: false,
+    disabled: false,
   },
 };
 
-const Template = ({ checked, disabled, label }) =>
+const Template = ({ label, checked, disabled }) =>
   formatHtmlPreview(`
     <sdds-checkbox
         ${checked ? 'checked' : ''}

--- a/tegel/src/components/checkbox/sdds-checkbox.stories.tsx
+++ b/tegel/src/components/checkbox/sdds-checkbox.stories.tsx
@@ -22,19 +22,19 @@ export default {
   argTypes: {
     label: {
       name: 'Label text',
-      description: 'The label of the component',
+      description: 'Sets the label of the component.',
       type: 'string',
     },
     checked: {
       name: 'Checked',
-      description: 'Checks the checkbox',
+      description: 'Checks the checkbox.',
       control: {
         type: 'boolean',
       },
     },
     disabled: {
       name: 'Disabled',
-      description: 'Disables the checkbox',
+      description: 'Disables the checkbox.',
       control: {
         type: 'boolean',
       },

--- a/tegel/src/components/checkbox/sdds-checkbox.stories.tsx
+++ b/tegel/src/components/checkbox/sdds-checkbox.stories.tsx
@@ -33,12 +33,18 @@ export default {
       control: {
         type: 'boolean',
       },
+      table: {
+        defaultValue: { summary: false },
+      },
     },
     disabled: {
       name: 'Disabled',
       description: 'Disables the checkbox.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
       },
     },
   },

--- a/tegel/src/components/checkbox/sdds-checkbox.stories.tsx
+++ b/tegel/src/components/checkbox/sdds-checkbox.stories.tsx
@@ -23,7 +23,9 @@ export default {
     label: {
       name: 'Label text',
       description: 'Sets the label of the component.',
-      type: 'string',
+      control: {
+        type: 'text',
+      },
     },
     checked: {
       name: 'Checked',


### PR DESCRIPTION
**Describe pull-request**  
Standardised order of controls in Storybook for checkbox component. Also updated descriptions and deprecated controls and added default values.

**Solving issue**  
_In case of GitHub issue add # plus the number of the issue (for example #123) OR if it is Azure then AB# and number of ticket_
Fixes: [AB#3428](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3428)

**How to test**  
_Add description how to test if possible_
1. Go to Storybook link below
2. Check in Checkbox-> Web Component and Native
3. Inspect order of controls
4. Read control descriptions

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events