### PR TITLE
fix(card): standardise order of controls in Storybook

### DIFF
--- a/tegel/src/components/card/card.stories.tsx
+++ b/tegel/src/components/card/card.stories.tsx
@@ -46,7 +46,7 @@ export default {
     },
     headerImg: {
       name: 'Header image',
-      description: 'Sets the image for the header.',
+      description: 'Toggles an image in the header.',
       control: {
         type: 'boolean',
       },
@@ -67,7 +67,7 @@ export default {
     },
     bodyImg: {
       name: 'Body image',
-      description: 'Sets the image in the card body. Cannot be combined with divider.',
+      description: 'Toggles an image in the card body. Cannot be combined with divider.',
       control: {
         type: 'boolean',
       },

--- a/tegel/src/components/card/card.stories.tsx
+++ b/tegel/src/components/card/card.stories.tsx
@@ -116,15 +116,15 @@ export default {
     },
   },
   args: {
+    modeVariant: 'Inherit from parent',
     header: 'Header text',
     subheader: 'Subheader text',
     headerImg: true,
-    headerPlacement: 'Above',
     bodyImg: false,
+    headerPlacement: 'Above',
     bodyText: '',
     bodyDivider: false,
     cardBottom: '<sdds-icon style="font-size: 20px;" name="arrow_right"></sdds-icon>',
-    modeVariant: 'Inherit from parent',
     clickable: false,
   },
 };

--- a/tegel/src/components/card/card.stories.tsx
+++ b/tegel/src/components/card/card.stories.tsx
@@ -74,6 +74,7 @@ export default {
       table: {
         defaultValue: { summary: false },
       },
+      if: { arg: 'bodyDivider', eq: false },
     },
     bodyText: {
       name: 'Body text',

--- a/tegel/src/components/card/card.stories.tsx
+++ b/tegel/src/components/card/card.stories.tsx
@@ -21,7 +21,7 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
-      description: 'Change the components mode variant',
+      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
@@ -32,28 +32,28 @@ export default {
     },
     header: {
       name: 'Header text',
-      description: 'The header text',
+      description: 'Sets the header text.',
       control: {
         type: 'text',
       },
     },
     subheader: {
       name: 'Subheader text',
-      description: 'The subheader text',
+      description: 'Sets the subheader text.',
       control: {
         type: 'text',
       },
     },
     headerImg: {
       name: 'Header image',
-      description: 'Image for the header',
+      description: 'Sets the image for the header.',
       control: {
         type: 'boolean',
       },
     },
     headerPlacement: {
       name: 'Header placement',
-      description: 'Placement of the header',
+      description: 'Sets the placement of the header, above or below the body image.',
       control: {
         type: 'radio',
       },
@@ -64,21 +64,21 @@ export default {
     },
     bodyImg: {
       name: 'Body image',
-      description: 'Image in body on card.',
+      description: 'Sets the image in the card body. Cannot be combined with divider.',
       control: {
         type: 'boolean',
       },
     },
     bodyText: {
       name: 'Body text',
-      description: 'The body text for the card',
+      description: 'Sets the body text for the card.',
       control: {
         type: 'text',
       },
     },
     bodyDivider: {
       name: 'Body divider',
-      description: 'Add a divider to the card',
+      description: 'Adds a divider above the body content. Cannot be combined with body image.',
       control: {
         type: 'boolean',
       },
@@ -89,6 +89,7 @@ export default {
     },
     cardBottom: {
       name: 'Content of the bottom of the card',
+      description: 'Slot to add custom HTML elements to the bottom of the card.',
       control: {
         type: 'text',
       },

--- a/tegel/src/components/card/card.stories.tsx
+++ b/tegel/src/components/card/card.stories.tsx
@@ -50,6 +50,9 @@ export default {
       control: {
         type: 'boolean',
       },
+      table: {
+        defaultValue: { summary: true },
+      },
     },
     headerPlacement: {
       name: 'Header placement',
@@ -67,6 +70,9 @@ export default {
       description: 'Sets the image in the card body. Cannot be combined with divider.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
       },
     },
     bodyText: {

--- a/tegel/src/components/card/card.stories.tsx
+++ b/tegel/src/components/card/card.stories.tsx
@@ -19,6 +19,17 @@ export default {
     ],
   },
   argTypes: {
+    modeVariant: {
+      name: 'Mode variant',
+      description: 'Change the components mode variant',
+      control: {
+        type: 'radio',
+      },
+      options: ['Inherit from parent', 'Primary', 'Secondary'],
+      table: {
+        defaultValue: { summary: 'Inherit from parent' },
+      },
+    },
     header: {
       name: 'Header text',
       description: 'The header text',
@@ -31,6 +42,31 @@ export default {
       description: 'The subheader text',
       control: {
         type: 'text',
+      },
+    },
+    headerImg: {
+      name: 'Header image',
+      description: 'Image for the header',
+      control: {
+        type: 'boolean',
+      },
+    },
+    headerPlacement: {
+      name: 'Header placement',
+      description: 'Placement of the header',
+      control: {
+        type: 'radio',
+      },
+      options: ['Above', 'Below'],
+      table: {
+        defaultValue: { summary: 'above' },
+      },
+    },
+    bodyImg: {
+      name: 'Body image',
+      description: 'Image in body on card.',
+      control: {
+        type: 'boolean',
       },
     },
     bodyText: {
@@ -67,61 +103,14 @@ export default {
         defaultValue: { summary: false },
       },
     },
-    bodyImg: {
-      name: 'Body image',
-      description: 'Image in body on card.',
-      control: {
-        type: 'boolean',
-      },
-    },
-    imageTop: {
-      name: 'Image on top',
-      description: 'Sets the image on top',
-      control: {
-        type: 'boolean',
-      },
-      table: {
-        defaultValue: { summary: false },
-      },
-      if: { arg: 'image', eq: true },
-    },
-    headerImg: {
-      name: 'Header image',
-      description: 'Image for the header',
-      control: {
-        type: 'boolean',
-      },
-    },
-    headerPlacement: {
-      name: 'Header placement',
-      description: 'Placement of the header',
-      control: {
-        type: 'radio',
-      },
-      options: ['Above', 'Below'],
-      table: {
-        defaultValue: { summary: 'above' },
-      },
-    },
-    modeVariant: {
-      name: 'Mode variant',
-      description: 'Change the components mode variant',
-      control: {
-        type: 'radio',
-      },
-      options: ['Inherit from parent', 'Primary', 'Secondary'],
-      table: {
-        defaultValue: { summary: 'Inherit from parent' },
-      },
-    },
   },
   args: {
     modeVariant: 'Inherit from parent',
     header: 'Header text',
     subheader: 'Subheader text',
     headerImg: true,
-    bodyImg: false,
     headerPlacement: 'Above',
+    bodyImg: false,
     bodyText: '',
     bodyDivider: false,
     cardBottom: '<sdds-icon style="font-size: 20px;" name="arrow_right"></sdds-icon>',
@@ -130,16 +119,16 @@ export default {
 };
 
 const Template = ({
+  modeVariant,
   header,
   subheader,
-  cardBottom,
-  clickable,
+  headerImg,
+  headerPlacement,
+  bodyImg,
   bodyText,
   bodyDivider,
-  headerPlacement,
-  headerImg,
-  modeVariant,
-  bodyImg,
+  cardBottom,
+  clickable,
 }) =>
   formatHtmlPreview(
     `

--- a/tegel/src/components/card/sdds-card.scss
+++ b/tegel/src/components/card/sdds-card.scss
@@ -5,6 +5,7 @@
   border-radius: 4px;
   max-width: 368px;
   overflow: hidden;
+  width: 100%;
 
   &.clickable {
     &:hover {

--- a/tegel/src/components/card/sdds-card.stories.tsx
+++ b/tegel/src/components/card/sdds-card.stories.tsx
@@ -52,6 +52,9 @@ export default {
       control: {
         type: 'boolean',
       },
+      table: {
+        defaultValue: { summary: true },
+      },
     },
     headerPlacement: {
       name: 'Header placement',
@@ -69,6 +72,9 @@ export default {
       description: 'Sets the image in the card body. Cannot be combined with divider.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
       },
     },
     bodyContent: {

--- a/tegel/src/components/card/sdds-card.stories.tsx
+++ b/tegel/src/components/card/sdds-card.stories.tsx
@@ -23,7 +23,7 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
-      description: 'Mode variant of the component, based on current mode.',
+      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
@@ -34,28 +34,28 @@ export default {
     },
     header: {
       name: 'Header text',
-      description: 'The header text',
+      description: 'Sets the header text.',
       control: {
         type: 'text',
       },
     },
     subheader: {
       name: 'Subheader text',
-      description: 'The subheader text',
+      description: 'Sets the subheader text.',
       control: {
         type: 'text',
       },
     },
     headerImg: {
       name: 'Header image',
-      description: 'Image for the header',
+      description: 'Sets the image for the header.',
       control: {
         type: 'boolean',
       },
     },
     headerPlacement: {
       name: 'Header placement',
-      description: 'Placement of the header',
+      description: 'Sets the placement of the header, above or below the body image.',
       control: {
         type: 'radio',
       },
@@ -66,21 +66,21 @@ export default {
     },
     bodyImg: {
       name: 'Body image',
-      description: 'Image in body on card.',
+      description: 'Sets the image in the card body. Cannot be combined with divider.',
       control: {
         type: 'boolean',
       },
     },
     bodyContent: {
       name: 'Body text',
-      description: 'The body text for the card',
+      description: 'Sets the body text for the card.',
       control: {
         type: 'text',
       },
     },
     bodyDivider: {
       name: 'Body divider',
-      description: 'Adds a divider above the body content.',
+      description: 'Adds a divider above the body content. Cannot be combined with body image.',
       control: {
         type: 'boolean',
       },
@@ -91,6 +91,7 @@ export default {
     },
     cardBottom: {
       name: 'Content of the bottom of the card',
+      description: 'Slot to add custom HTML elements to the bottom of the card.',
       control: {
         type: 'text',
       },

--- a/tegel/src/components/card/sdds-card.stories.tsx
+++ b/tegel/src/components/card/sdds-card.stories.tsx
@@ -118,15 +118,15 @@ export default {
     },
   },
   args: {
+    modeVariant: 'Inherit from parent',
     header: 'Header text',
     subheader: 'Subheader text',
     headerImg: true,
-    headerPlacement: 'Above',
     bodyImg: false,
+    headerPlacement: 'Above',
     bodyContent: '',
     bodyDivider: false,
     cardBottom: `<div slot="card-bottom"><sdds-icon style="font-size: 20px;" name="arrow_right"></sdds-icon></div>`,
-    modeVariant: 'Inherit from parent',
     clickable: false,
   },
 };

--- a/tegel/src/components/card/sdds-card.stories.tsx
+++ b/tegel/src/components/card/sdds-card.stories.tsx
@@ -48,7 +48,7 @@ export default {
     },
     headerImg: {
       name: 'Header image',
-      description: 'Sets the image for the header.',
+      description: 'Toggles an image in the header.',
       control: {
         type: 'boolean',
       },
@@ -69,7 +69,7 @@ export default {
     },
     bodyImg: {
       name: 'Body image',
-      description: 'Sets the image in the card body. Cannot be combined with divider.',
+      description: 'Toggles an image in the card body. Cannot be combined with divider.',
       control: {
         type: 'boolean',
       },

--- a/tegel/src/components/card/sdds-card.stories.tsx
+++ b/tegel/src/components/card/sdds-card.stories.tsx
@@ -76,6 +76,7 @@ export default {
       table: {
         defaultValue: { summary: false },
       },
+      if: { arg: 'bodyDivider', eq: false },
     },
     bodyContent: {
       name: 'Body text',

--- a/tegel/src/components/card/sdds-card.stories.tsx
+++ b/tegel/src/components/card/sdds-card.stories.tsx
@@ -64,9 +64,33 @@ export default {
         defaultValue: { summary: 'above' },
       },
     },
+    bodyImg: {
+      name: 'Body image',
+      description: 'Image in body on card.',
+      control: {
+        type: 'boolean',
+      },
+    },
     bodyContent: {
       name: 'Body text',
       description: 'The body text for the card',
+      control: {
+        type: 'text',
+      },
+    },
+    bodyDivider: {
+      name: 'Body divider',
+      description: 'Adds a divider above the body content.',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
+      },
+      if: { arg: 'bodyImg', eq: false },
+    },
+    cardBottom: {
+      name: 'Content of the bottom of the card',
       control: {
         type: 'text',
       },
@@ -81,49 +105,14 @@ export default {
         defaultValue: { summary: false },
       },
     },
-    bodyDivider: {
-      name: 'Body divider',
-      description: 'Adds a divider above the body content.',
-      control: {
-        type: 'boolean',
-      },
-      table: {
-        defaultValue: { summary: false },
-      },
-      if: { arg: 'bodyImg', eq: false },
-    },
-    bodyImg: {
-      name: 'Body image',
-      description: 'Image in body on card.',
-      control: {
-        type: 'boolean',
-      },
-    },
-    imageTop: {
-      name: 'Image on top',
-      description: 'Places the body image above the header.',
-      control: {
-        type: 'text',
-      },
-      table: {
-        defaultValue: { summary: false },
-      },
-      if: { arg: 'image', eq: true },
-    },
-    cardBottom: {
-      name: 'Content of the bottom of the card',
-      control: {
-        type: 'text',
-      },
-    },
   },
   args: {
     modeVariant: 'Inherit from parent',
     header: 'Header text',
     subheader: 'Subheader text',
     headerImg: true,
-    bodyImg: false,
     headerPlacement: 'Above',
+    bodyImg: false,
     bodyContent: '',
     bodyDivider: false,
     cardBottom: `<div slot="card-bottom"><sdds-icon style="font-size: 20px;" name="arrow_right"></sdds-icon></div>`,
@@ -133,15 +122,15 @@ export default {
 
 const Template = ({
   modeVariant,
-  headerPlacement,
   header,
   subheader,
-  bodyContent,
-  clickable,
   headerImg,
+  headerPlacement,
   bodyImg,
+  bodyContent,
   bodyDivider,
   cardBottom,
+  clickable,
 }) =>
   formatHtmlPreview(
     `<style>


### PR DESCRIPTION
**Describe pull-request**  
Standardised order of controls in Storybook for card component. Also updated descriptions and made bodyImg control conditional on bodyDivider control to make it consistent.

**Solving issue**
Fixes: [AB#3427](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3427)

**How to test**  
1. Go to Storybook link below
2. Check in Card-> Web Component and Native
3. Inspect order of controls
4. Read control descriptions

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events