### PR TITLE
fix(datetime): standardise order of controls in Storybook

### DIFF
--- a/tegel/src/components/datetime/datetime.stories.tsx
+++ b/tegel/src/components/datetime/datetime.stories.tsx
@@ -31,6 +31,14 @@ export default {
         defaultValue: { summary: 'Inherit from parent' },
       },
     },
+    state: {
+      name: 'State',
+      description: 'Switch between success or error state',
+      control: {
+        type: 'radio',
+      },
+      options: ['None', 'Success', 'Error'],
+    },
     type: {
       name: 'Type',
       description: 'Set the field to display date, time or both',
@@ -38,15 +46,6 @@ export default {
         type: 'radio',
       },
       options: ['Datetime', 'Date', 'Time'],
-    },
-    defaultValue: {
-      name: 'Default value',
-      description:
-        'Default value of the component. Format for time: HH-MM. Format for date: YY-MM-DD. Format for date-time: YY-MM-DDTHH-MM ',
-      control: {
-        type: 'radio',
-      },
-      options: ['None', 'Custom'],
     },
     size: {
       name: 'Size',
@@ -57,16 +56,18 @@ export default {
       },
       options: ['Large', 'Medium', 'Small'],
     },
+    defaultValue: {
+      name: 'Default value',
+      description:
+        'Default value of the component. Format for time: HH-MM. Format for date: YY-MM-DD. Format for date-time: YY-MM-DDTHH-MM ',
+      control: {
+        type: 'radio',
+      },
+      options: ['None', 'Custom'],
+    },
     minWidth: {
       name: 'Min width',
       description: 'Toggle min width',
-      control: {
-        type: 'boolean',
-      },
-    },
-    disabled: {
-      description: 'Set textfield to disabled state',
-      name: 'Disabled',
       control: {
         type: 'boolean',
       },
@@ -101,42 +102,41 @@ export default {
       },
       if: { arg: 'helper', eq: true },
     },
-    state: {
-      name: 'State',
-      description: 'Switch between success or error state',
+    disabled: {
+      description: 'Set textfield to disabled state',
+      name: 'Disabled',
       control: {
-        type: 'radio',
+        type: 'boolean',
       },
-      options: ['None', 'Success', 'Error'],
     },
   },
   args: {
+    modeVariant: 'Inherit from parent',
+    state: 'None',
     type: 'Datetime',
     size: 'Large',
     defaultValue: 'None',
     minWidth: 'Default',
-    disabled: false,
-    state: 'None',
     label: true,
     labelText: 'Label text',
     helper: true,
     helperText: 'Helper text',
-    modeVariant: 'Inherit from parent',
+    disabled: false,
   },
 };
 
 const datetimeTemplate = ({
   modeVariant,
+  state,
   type,
   size,
+  defaultValue,
   minWidth,
-  disabled,
   label,
   labelText,
-  state,
   helper,
   helperText,
-  defaultValue,
+  disabled,
 }) => {
   const typeLookup = {
     Datetime: 'datetime-local',

--- a/tegel/src/components/datetime/datetime.stories.tsx
+++ b/tegel/src/components/datetime/datetime.stories.tsx
@@ -38,6 +38,9 @@ export default {
         type: 'radio',
       },
       options: ['None', 'Success', 'Error'],
+      table: {
+        defaultValue: { summary: 'none' },
+      },
     },
     type: {
       name: 'Type',
@@ -46,6 +49,9 @@ export default {
         type: 'radio',
       },
       options: ['Datetime', 'Date', 'Time'],
+      table: {
+        defaultValue: { summary: 'datetime-local' },
+      },
     },
     size: {
       name: 'Size',
@@ -55,15 +61,20 @@ export default {
         // todo: make consistent with other sizes, for example 'xs', 'sm', etc
       },
       options: ['Large', 'Medium', 'Small'],
+      table: {
+        defaultValue: { summary: 'lg' },
+      },
     },
     defaultValue: {
       name: 'Default value',
-      description:
-        'Default value of the component. Format for time: HH-MM. Format for date: YY-MM-DD. Format for date-time: YY-MM-DDTHH-MM.',
+      description: 'Default value of the component. Format for time: HH-MM. Format for date: YY-MM-DD. Format for date-time: YY-MM-DDTHH-MM.',
       control: {
         type: 'radio',
       },
       options: ['None', 'Custom'],
+      table: {
+        defaultValue: { summary: 'none' },
+      },
     },
     noMinWidth: {
       name: 'No minimum width',
@@ -71,10 +82,13 @@ export default {
       control: {
         type: 'boolean',
       },
+      table: {
+        defaultValue: { summary: false },
+      },
     },
     label: {
-      description: 'Sets the label text.',
       name: 'Label text',
+      description: 'Sets the label text.',
       control: {
         type: 'text',
       },
@@ -87,10 +101,13 @@ export default {
       },
     },
     disabled: {
-      description: 'Disables the component.',
       name: 'Disabled',
+      description: 'Disables the component.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
       },
     },
   },

--- a/tegel/src/components/datetime/datetime.stories.tsx
+++ b/tegel/src/components/datetime/datetime.stories.tsx
@@ -95,7 +95,7 @@ export default {
     },
     helper: {
       name: 'Helper text',
-      description: 'Adds a helper text.',
+      description: 'Sets the helper text.',
       control: {
         type: 'text',
       },

--- a/tegel/src/components/datetime/datetime.stories.tsx
+++ b/tegel/src/components/datetime/datetime.stories.tsx
@@ -117,7 +117,7 @@ export default {
     type: 'Datetime',
     size: 'Large',
     defaultValue: 'None',
-    noMinWidth: 'Default',
+    noMinWidth: false,
     label: 'Label text',
     helper: 'Helper text',
     disabled: false,

--- a/tegel/src/components/datetime/datetime.stories.tsx
+++ b/tegel/src/components/datetime/datetime.stories.tsx
@@ -22,7 +22,7 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
-      description: 'Mode variant of the component.',
+      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
@@ -33,7 +33,7 @@ export default {
     },
     state: {
       name: 'State',
-      description: 'Switch between success or error state',
+      description: 'Switches between success or error state.',
       control: {
         type: 'radio',
       },
@@ -41,7 +41,7 @@ export default {
     },
     type: {
       name: 'Type',
-      description: 'Set the field to display date, time or both',
+      description: 'Sets the field to display date, time or both.',
       control: {
         type: 'radio',
       },
@@ -49,7 +49,7 @@ export default {
     },
     size: {
       name: 'Size',
-      description: 'Switch between different sizes',
+      description: 'Switches between different sizes.',
       control: {
         type: 'radio',
         // todo: make consistent with other sizes, for example 'xs', 'sm', etc
@@ -59,7 +59,7 @@ export default {
     defaultValue: {
       name: 'Default value',
       description:
-        'Default value of the component. Format for time: HH-MM. Format for date: YY-MM-DD. Format for date-time: YY-MM-DDTHH-MM ',
+        'Default value of the component. Format for time: HH-MM. Format for date: YY-MM-DD. Format for date-time: YY-MM-DDTHH-MM.',
       control: {
         type: 'radio',
       },
@@ -73,7 +73,7 @@ export default {
       },
     },
     label: {
-      description: 'Label text for specific textfield',
+      description: 'Sets the label text.',
       name: 'Label text',
       control: {
         type: 'text',
@@ -81,13 +81,13 @@ export default {
     },
     helper: {
       name: 'Helper text',
-      description: 'Add helper text for the textfield',
+      description: 'Adds a helper text.',
       control: {
         type: 'text',
       },
     },
     disabled: {
-      description: 'Set textfield to disabled state',
+      description: 'Disables the component.',
       name: 'Disabled',
       control: {
         type: 'boolean',

--- a/tegel/src/components/datetime/datetime.stories.tsx
+++ b/tegel/src/components/datetime/datetime.stories.tsx
@@ -33,7 +33,7 @@ export default {
     },
     state: {
       name: 'State',
-      description: 'Switches between success or error state.',
+      description: 'Switches between success and error state.',
       control: {
         type: 'radio',
       },

--- a/tegel/src/components/datetime/datetime.stories.tsx
+++ b/tegel/src/components/datetime/datetime.stories.tsx
@@ -65,9 +65,9 @@ export default {
       },
       options: ['None', 'Custom'],
     },
-    minWidth: {
-      name: 'Min width',
-      description: 'Toggle min width',
+    noMinWidth: {
+      name: 'No minimum width',
+      description: 'Enables component to shrink below 208px which is the default width.',
       control: {
         type: 'boolean',
       },
@@ -116,7 +116,7 @@ export default {
     type: 'Datetime',
     size: 'Large',
     defaultValue: 'None',
-    minWidth: 'Default',
+    noMinWidth: 'Default',
     label: true,
     labelText: 'Label text',
     helper: true,
@@ -131,7 +131,7 @@ const datetimeTemplate = ({
   type,
   size,
   defaultValue,
-  minWidth,
+  noMinWidth,
   label,
   labelText,
   helper,
@@ -174,28 +174,26 @@ const datetimeTemplate = ({
     <style>
         /* Note: Demo classes used here are just for demo purposes in Storybook */
         .demo-wrapper {
-            width: 208px;
+            width: 150px;
         }
     </style>
 
-    <div class="demo-wrapper">
-      <sdds-datetime
-        id="storybook-datetime"
-        name="datetime-input"
-        ${defaultValue !== 'None' ? `default-value="${getDefaultValue(defaultValue, type)}"` : ''}
-        ${
-          modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''
-        }
-        type="${typeLookup[type]}"
-        size="${sizeLookup[size]}"
-        state="${stateLookup[state]}"
-        ${disabled ? 'disabled' : ''}
-        ${minWidth ? 'no-min-width' : ''}
-        ${label ? `label="${labelText}" ` : ''}
-        ${helper ? `helper="${helperText}" ` : ''}
-        >
-      </sdds-datetime>
-    </div>
+  <div class="demo-wrapper">
+
+    <sdds-datetime
+      id="datetime"
+      ${defaultValue !== 'None' ? `default-value="${getDefaultValue(defaultValue, type)}"` : ''}
+      ${modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"`: ''}
+      type="${typeLookup[type]}"
+      size="${sizeLookup[size]}"
+      state="${stateLookup[state]}"
+      ${disabled ? 'disabled' : ''}
+      ${noMinWidth ? 'no-min-width' : ''}
+      ${label ? `label="${labelText}" ` : ''}
+      ${helper ? `helper="${helperText}" ` : ''}
+      >
+    </sdds-datetime>
+
 
     <script>
     /* DEMO Code: Used only for Storybook demo purposes */

--- a/tegel/src/components/datetime/datetime.stories.tsx
+++ b/tegel/src/components/datetime/datetime.stories.tsx
@@ -171,7 +171,7 @@ const datetimeTemplate = ({
     <style>
         /* Note: Demo classes used here are just for demo purposes in Storybook */
         .demo-wrapper {
-            width: 150px;
+            width: 180px;
         }
     </style>
 

--- a/tegel/src/components/datetime/datetime.stories.tsx
+++ b/tegel/src/components/datetime/datetime.stories.tsx
@@ -73,34 +73,18 @@ export default {
       },
     },
     label: {
-      name: 'Label',
-      description: 'Add/remove a label text for the component',
-      control: {
-        type: 'boolean',
-      },
-    },
-    labelText: {
       description: 'Label text for specific textfield',
       name: 'Label text',
       control: {
         type: 'text',
       },
-      if: { arg: 'label', eq: true },
     },
     helper: {
-      name: 'Helper',
-      description: 'Add/remove a helper text for the component',
-      control: {
-        type: 'boolean',
-      },
-    },
-    helperText: {
       name: 'Helper text',
       description: 'Add helper text for the textfield',
       control: {
         type: 'text',
       },
-      if: { arg: 'helper', eq: true },
     },
     disabled: {
       description: 'Set textfield to disabled state',
@@ -117,10 +101,8 @@ export default {
     size: 'Large',
     defaultValue: 'None',
     noMinWidth: 'Default',
-    label: true,
-    labelText: 'Label text',
-    helper: true,
-    helperText: 'Helper text',
+    label: 'Label text',
+    helper: 'Helper text',
     disabled: false,
   },
 };
@@ -133,9 +115,7 @@ const datetimeTemplate = ({
   defaultValue,
   noMinWidth,
   label,
-  labelText,
   helper,
-  helperText,
   disabled,
 }) => {
   const typeLookup = {
@@ -189,8 +169,8 @@ const datetimeTemplate = ({
       state="${stateLookup[state]}"
       ${disabled ? 'disabled' : ''}
       ${noMinWidth ? 'no-min-width' : ''}
-      ${label ? `label="${labelText}" ` : ''}
-      ${helper ? `helper="${helperText}" ` : ''}
+      ${label ? `label="${label}" ` : ''}
+      ${helper ? `helper="${helper}" ` : ''}
       >
     </sdds-datetime>
 

--- a/tegel/src/components/footer/webcomponent/sdds-footer-link/readme.md
+++ b/tegel/src/components/footer/webcomponent/sdds-footer-link/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property   | Attribute   | Description                                                                                                                                            | Type                                         | Default      |
-| ---------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------- | ------------ |
-| `linkHref` | `link-href` | URL for the link                                                                                                                                       | `string`                                     | `undefined`  |
-| `rel`      | `rel`       | 'noopener' is a security measure for legacy browsers that preventsthe opened page from getting access to the original page when using target='_blank'. | `string`                                     | `'noopener'` |
-| `target`   | `target`    | Where to open the linked URL                                                                                                                           | `"_blank" \| "_parent" \| "_self" \| "_top"` | `'_self'`    |
+| Property   | Attribute   | Description                                                                                                                                             | Type                                         | Default      |
+| ---------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | ------------ |
+| `linkHref` | `link-href` | URL for the link                                                                                                                                        | `string`                                     | `undefined`  |
+| `rel`      | `rel`       | 'noopener' is a security measure for legacy browsers that prevents the opened page from getting access to the original page when using target='_blank'. | `string`                                     | `'noopener'` |
+| `target`   | `target`    | Where to open the linked URL                                                                                                                            | `"_blank" \| "_parent" \| "_self" \| "_top"` | `'_self'`    |
 
 
 ----------------------------------------------


### PR DESCRIPTION
**Describe pull-request**  
Standardised order of controls in Storybook for datetime component. Also updated descriptions, refactored noMinWidth control and remover unnecessary controls.

**Solving issue**  
Fixes: [AB#3431](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3431)

**How to test**  
1. Go to Storybook link below
2. Check in Datetime -> All sub stories
3. Inspect order of controls
4. Read control descriptions

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events