### PR TITLE
fix(chips): standardise order of controls in Storybook

### DIFF
--- a/tegel/src/components/chips/chips.stories.tsx
+++ b/tegel/src/components/chips/chips.stories.tsx
@@ -25,6 +25,9 @@ export default {
         type: 'radio',
       },
       options: ['Default', 'Active'],
+      table: {
+        defaultValue: { summary: 'Default' },
+      },
     },
     size: {
       name: 'Size',
@@ -33,6 +36,9 @@ export default {
         type: 'radio',
       },
       options: ['Default', 'Small'],
+      table: {
+        defaultValue: { summary: 'Default' },
+      },
     },
     placeholderText: {
       name: 'Placeholder',
@@ -47,6 +53,9 @@ export default {
       control: {
         type: 'boolean',
       },
+      table: {
+        defaultValue: { summary: false },
+      },
     },
     iconPosition: {
       name: 'Icon position',
@@ -56,6 +65,9 @@ export default {
       },
       options: ['Icon left', 'Icon right'],
       if: { arg: 'icon', eq: true },
+      table: {
+        defaultValue: { summary: 'Icon right' },
+      },
     },
     iconType: {
       name: 'Icon type',
@@ -65,6 +77,9 @@ export default {
       },
       options: ['Native', 'Web Component'],
       if: { arg: 'icon', eq: true },
+      table: {
+        defaultValue: { summary: 'Native' },
+      },
     },
   },
   args: {

--- a/tegel/src/components/chips/chips.stories.tsx
+++ b/tegel/src/components/chips/chips.stories.tsx
@@ -18,15 +18,14 @@ export default {
     ],
   },
   argTypes: {
-    state: {
-      name: 'State',
-      description: 'Sets the chips state as active or default.',
+    active: {
+      name: 'Active',
+      description: 'Toggles if the chip is active or not.',
       control: {
-        type: 'radio',
+        type: 'boolean',
       },
-      options: ['Default', 'Active'],
       table: {
-        defaultValue: { summary: 'Default' },
+        defaultValue: { summary: false },
       },
     },
     size: {
@@ -83,7 +82,7 @@ export default {
     },
   },
   args: {
-    state: 'Default',
+    active: false,
     size: 'Default',
     placeholderText: 'Chip text',
     icon: false,
@@ -93,14 +92,14 @@ export default {
 };
 
 const Template = ({ 
-  state,
+  active,
   size,
   placeholderText, 
   icon, 
   iconPosition, 
   iconType
    }) => {
-  const stateValue = state === 'Active' ? 'sdds-chip-active' : '';
+  const activeValue = active === true ? 'sdds-chip-active' : '';
   const sizeValue = size === 'Small' ? 'sdds-chip-sm' : '';
   const iconPositionLookup = {
     'Icon left': 'sdds-chip-icon-left',
@@ -130,7 +129,7 @@ const Template = ({
     depending on usage (button, checkbox, radio, etc) -->
     <button class="sdds-chip ${
       icon ? iconPositionLookup[iconPosition] : ''
-    } ${stateValue} ${sizeValue}">
+    } ${activeValue} ${sizeValue}">
       ${icon ? iconSvg : ''}<span class="sdds-chip-text">${placeholderText}</span>
     </button>
     `);

--- a/tegel/src/components/chips/chips.stories.tsx
+++ b/tegel/src/components/chips/chips.stories.tsx
@@ -20,7 +20,7 @@ export default {
   argTypes: {
     state: {
       name: 'State',
-      description: 'Set the chips state as active or default',
+      description: 'Sets the chips state as active or default.',
       control: {
         type: 'radio',
       },
@@ -28,7 +28,7 @@ export default {
     },
     size: {
       name: 'Size',
-      description: 'Set the chip size',
+      description: 'Sets the chip size.',
       control: {
         type: 'radio',
       },
@@ -36,21 +36,21 @@ export default {
     },
     placeholderText: {
       name: 'Placeholder',
-      description: 'Set custom chip text',
+      description: 'Sets custom chip text.',
       control: {
         type: 'text',
       },
     },
     icon: {
       name: 'Icon',
-      description: 'Add an icon to the chip.',
+      description: 'Adds an icon to the chip.',
       control: {
         type: 'boolean',
       },
     },
     iconPosition: {
       name: 'Icon position',
-      description: 'Set the placement of the icon',
+      description: 'Sets the placement of the icon.',
       control: {
         type: 'radio',
       },
@@ -59,7 +59,7 @@ export default {
     },
     iconType: {
       name: 'Icon type',
-      description: 'Choose what icon type to use',
+      description: 'Switch between showing a native or a web component icon.',
       control: {
         type: 'radio',
       },

--- a/tegel/src/components/chips/chips.stories.tsx
+++ b/tegel/src/components/chips/chips.stories.tsx
@@ -34,9 +34,9 @@ export default {
       control: {
         type: 'radio',
       },
-      options: ['Default', 'Small'],
+      options: ['Large', 'Small'],
       table: {
-        defaultValue: { summary: 'Default' },
+        defaultValue: { summary: 'Large' },
       },
     },
     placeholderText: {
@@ -83,7 +83,7 @@ export default {
   },
   args: {
     active: false,
-    size: 'Default',
+    size: 'Large',
     placeholderText: 'Chip text',
     icon: false,
     iconPosition: 'Icon right',

--- a/tegel/src/components/chips/chips.stories.tsx
+++ b/tegel/src/components/chips/chips.stories.tsx
@@ -18,38 +18,6 @@ export default {
     ],
   },
   argTypes: {
-    placeholderText: {
-      name: 'Placeholder',
-      description: 'Set custom chip text',
-      control: {
-        type: 'text',
-      },
-    },
-    icon: {
-      name: 'Icon',
-      description: 'Add an icon to the chip.',
-      control: {
-        type: 'boolean',
-      },
-    },
-    iconType: {
-      name: 'Icon type',
-      description: 'Choose what icon type to use',
-      control: {
-        type: 'radio',
-      },
-      options: ['Native', 'Web Component'],
-      if: { arg: 'icon', eq: true },
-    },
-    iconPosition: {
-      name: 'Icon position',
-      description: 'Set the placement of the icon',
-      control: {
-        type: 'radio',
-      },
-      options: ['Icon left', 'Icon right'],
-      if: { arg: 'icon', eq: true },
-    },
     state: {
       name: 'State',
       description: 'Set the chips state as active or default',
@@ -66,18 +34,57 @@ export default {
       },
       options: ['Default', 'Small'],
     },
+    placeholderText: {
+      name: 'Placeholder',
+      description: 'Set custom chip text',
+      control: {
+        type: 'text',
+      },
+    },
+    icon: {
+      name: 'Icon',
+      description: 'Add an icon to the chip.',
+      control: {
+        type: 'boolean',
+      },
+    },
+    iconPosition: {
+      name: 'Icon position',
+      description: 'Set the placement of the icon',
+      control: {
+        type: 'radio',
+      },
+      options: ['Icon left', 'Icon right'],
+      if: { arg: 'icon', eq: true },
+    },
+    iconType: {
+      name: 'Icon type',
+      description: 'Choose what icon type to use',
+      control: {
+        type: 'radio',
+      },
+      options: ['Native', 'Web Component'],
+      if: { arg: 'icon', eq: true },
+    },
   },
   args: {
-    placeholderText: 'Chip text',
-    icon: false,
-    iconType: 'Native',
-    iconPosition: 'Icon right',
     state: 'Default',
     size: 'Default',
+    placeholderText: 'Chip text',
+    icon: false,
+    iconPosition: 'Icon right',
+    iconType: 'Native',
   },
 };
 
-const Template = ({ icon, iconPosition, iconType, state, placeholderText, size }) => {
+const Template = ({ 
+  state,
+  size,
+  placeholderText, 
+  icon, 
+  iconPosition, 
+  iconType
+   }) => {
   const stateValue = state === 'Active' ? 'sdds-chip-active' : '';
   const sizeValue = size === 'Small' ? 'sdds-chip-sm' : '';
   const iconPositionLookup = {


### PR DESCRIPTION
**Describe pull-request**  
Standardised order of controls in Storybook for chips component. Also updated descriptions and added default values.

**Solving issue**  
Fixes: [AB#3429](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3429)

**How to test**  
_Add description how to test if possible_
1. Go to Storybook link below
2. Check in Chips -> Native
3. Inspect order of controls
4. Read control descriptions

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events