### PR TITLE
fix(data table): standardise order of controls in Storybook

### DIFF
--- a/tegel/src/components/data-table/native-table.stories.tsx
+++ b/tegel/src/components/data-table/native-table.stories.tsx
@@ -14,7 +14,7 @@ export default {
         defaultValue: { summary: 'Inherit from parent' },
       },
     },
-    isCompact: {
+    compactDesign: {
       name: 'Compact design',
       description: 'Enables compact design of the table, rows with less height.',
       control: {
@@ -24,7 +24,7 @@ export default {
         defaultValue: { summary: false },
       },
     },
-    responsiveTable: {
+    responsiveDesign: {
       name: 'Responsive table',
       description: 'Enables table to take 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too. ',
       control: {
@@ -41,7 +41,7 @@ export default {
         type: 'text',
       },
     },
-    dividers: {
+    verticalDivider: {
       name: 'Vertical dividers',
       description: 'Enables vertical dividers between table columns.',
       control: {
@@ -88,10 +88,10 @@ export default {
   },
   args: {
     modeVariant: 'Inherit from parent',
-    isCompact: false,
-    responsiveTable: false,
+    compactDesign: false,
+    responsiveDesign: false,
     tableTitle: 'Native table',
-    dividers: false,
+    verticalDivider: false,
     noMinWidthArg: false,
     column1Width: '',
     column2Width: '',
@@ -101,10 +101,10 @@ export default {
 
 const Template = ({
   modeVariant,
-  isCompact,
-  responsiveTable,
+  compactDesign,
+  responsiveDesign,
   tableTitle,
-  dividers,
+  verticalDivider,
   noMinWidthArg,
   column1Width,
   column2Width,
@@ -115,10 +115,10 @@ const Template = ({
         sdds-table
         ${modeVariant === 'Primary' ? 'sdds-mode-variant-primary' : ''}
         ${modeVariant === 'Secondary' ? 'sdds-mode-variant-secondary' : ''}
-        ${isCompact ? 'sdds-table--compact' : ''}
-        ${dividers ? 'sdds-table--divider' : ''}
+        ${compactDesign ? 'sdds-table--compact' : ''}
+        ${verticalDivider ? 'sdds-table--divider' : ''}
         ${noMinWidthArg ? 'sdds-table--no-min-width' : ''}
-        ${responsiveTable ? 'sdds-table--responsive' : ''}
+        ${responsiveDesign ? 'sdds-table--responsive' : ''}
     ">
     ${tableTitle && `<caption>${tableTitle}</caption>`}
     <thead>
@@ -149,4 +149,3 @@ const Template = ({
     `);
 
 export const Default = Template.bind({});
-Default.args = {};

--- a/tegel/src/components/data-table/native-table.stories.tsx
+++ b/tegel/src/components/data-table/native-table.stories.tsx
@@ -26,7 +26,7 @@ export default {
     },
     responsiveDesign: {
       name: 'Responsive table',
-      description: 'Enables table to take 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too. ',
+      description: 'Enables table to take 100% of available width. For column values less than 192px, "No minimum width" has to be enabled too.',
       control: {
         type: 'boolean',
       },

--- a/tegel/src/components/data-table/native-table.stories.tsx
+++ b/tegel/src/components/data-table/native-table.stories.tsx
@@ -21,9 +21,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     responsiveTable: {
@@ -33,9 +31,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     tableTitle: {
@@ -43,11 +39,6 @@ export default {
       description: 'Sets text that appears in table caption area.',
       control: {
         type: 'text',
-      },
-      table: {
-        defaultValue: {
-          summary: '',
-        },
       },
     },
     dividers: {
@@ -57,9 +48,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     noMinWidthArg: {
@@ -69,9 +58,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     column1Width: {
@@ -79,11 +66,6 @@ export default {
       description:'Value of width for column 1. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
       control: {
         type: 'text',
-      },
-      table: {
-        defaultValue: {
-          summary: '192px',
-        },
       },
       if: { arg: 'noMinWidthArg', eq: true },
     },
@@ -93,11 +75,6 @@ export default {
       control: {
         type: 'text',
       },
-      table: {
-        defaultValue: {
-          summary: '192px',
-        },
-      },
       if: { arg: 'noMinWidthArg', eq: true },
     },
     column3Width: {
@@ -105,11 +82,6 @@ export default {
       description: 'Value of width for column 3. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
       control: {
         type: 'text',
-      },
-      table: {
-        defaultValue: {
-          summary: '192px',
-        },
       },
       if: { arg: 'noMinWidthArg', eq: true },
     },

--- a/tegel/src/components/data-table/native-table.stories.tsx
+++ b/tegel/src/components/data-table/native-table.stories.tsx
@@ -77,7 +77,9 @@ export default {
     column1Width: {
       name: 'Column 1 width',
       description:'Value of width for column 1. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
-      type: 'string',
+      control: {
+        type: 'text',
+      },
       table: {
         defaultValue: {
           summary: '192px',
@@ -87,9 +89,10 @@ export default {
     },
     column2Width: {
       name: 'Column 2 width',
-      description:
-        'Value of width for column 2. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
-      type: 'string',
+      description: 'Value of width for column 2. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
       table: {
         defaultValue: {
           summary: '192px',
@@ -99,9 +102,10 @@ export default {
     },
     column3Width: {
       name: 'Column 3 width',
-      description:
-        'Value of width for column 3. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
-      type: 'string',
+      description: 'Value of width for column 3. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
       table: {
         defaultValue: {
           summary: '192px',

--- a/tegel/src/components/data-table/native-table.stories.tsx
+++ b/tegel/src/components/data-table/native-table.stories.tsx
@@ -5,7 +5,7 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
-      description: 'The mode variant of the component',
+      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
@@ -28,8 +28,7 @@ export default {
     },
     responsiveTable: {
       name: 'Responsive table',
-      description:
-        'Table takes 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too. ',
+      description: 'Enables table to take 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too. ',
       control: {
         type: 'boolean',
       },
@@ -41,7 +40,7 @@ export default {
     },
     tableTitle: {
       name: 'Table title',
-      description: 'Text that appears in table caption area.',
+      description: 'Sets text that appears in table caption area.',
       control: {
         type: 'text',
       },
@@ -53,7 +52,7 @@ export default {
     },
     dividers: {
       name: 'Vertical dividers',
-      description: 'When enabled, table has vertical dividers between columns.',
+      description: 'Enables vertical dividers between table columns.',
       control: {
         type: 'boolean',
       },
@@ -65,8 +64,7 @@ export default {
     },
     noMinWidthArg: {
       name: 'No minimum width',
-      description:
-        'Resets min-width rule and enabled setting column width value less then 192px which is default one. When enabled, controls for columns width will show here.',
+      description: 'Resets min-width rule and enables setting column width value to less than 192px which is the default. When enabled, controls for column width will show here.',
       control: {
         type: 'boolean',
       },
@@ -78,8 +76,7 @@ export default {
     },
     column1Width: {
       name: 'Column 1 width',
-      description:
-        'Value of width for column 1. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit too next tot the value, eg. 200px.',
+      description:'Value of width for column 1. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
       type: 'string',
       table: {
         defaultValue: {
@@ -91,7 +88,7 @@ export default {
     column2Width: {
       name: 'Column 2 width',
       description:
-        'Value of width for column 2. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit too next tot the value, eg. 200px.',
+        'Value of width for column 2. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
       type: 'string',
       table: {
         defaultValue: {
@@ -103,7 +100,7 @@ export default {
     column3Width: {
       name: 'Column 3 width',
       description:
-        'Value of width for column 3. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit too next tot the value, eg. 200px.',
+        'Value of width for column 3. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
       type: 'string',
       table: {
         defaultValue: {

--- a/tegel/src/components/data-table/native-table.stories.tsx
+++ b/tegel/src/components/data-table/native-table.stories.tsx
@@ -51,7 +51,7 @@ export default {
         defaultValue: { summary: false },
       },
     },
-    noMinWidthArg: {
+    noMinWidth: {
       name: 'No minimum width',
       description: 'Resets min-width rule and enables setting column width value to less than 192px which is the default. When enabled, controls for column width will show here.',
       control: {
@@ -67,7 +67,7 @@ export default {
       control: {
         type: 'text',
       },
-      if: { arg: 'noMinWidthArg', eq: true },
+      if: { arg: 'noMinWidth', eq: true },
     },
     column2Width: {
       name: 'Column 2 width',
@@ -75,7 +75,7 @@ export default {
       control: {
         type: 'text',
       },
-      if: { arg: 'noMinWidthArg', eq: true },
+      if: { arg: 'noMinWidth', eq: true },
     },
     column3Width: {
       name: 'Column 3 width',
@@ -83,7 +83,7 @@ export default {
       control: {
         type: 'text',
       },
-      if: { arg: 'noMinWidthArg', eq: true },
+      if: { arg: 'noMinWidth', eq: true },
     },
   },
   args: {
@@ -92,7 +92,7 @@ export default {
     responsiveDesign: false,
     tableTitle: 'Native table',
     verticalDivider: false,
-    noMinWidthArg: false,
+    noMinWidth: false,
     column1Width: '',
     column2Width: '',
     column3Width: '',
@@ -105,7 +105,7 @@ const Template = ({
   responsiveDesign,
   tableTitle,
   verticalDivider,
-  noMinWidthArg,
+  noMinWidth,
   column1Width,
   column2Width,
   column3Width,
@@ -117,7 +117,7 @@ const Template = ({
         ${modeVariant === 'Secondary' ? 'sdds-mode-variant-secondary' : ''}
         ${compactDesign ? 'sdds-table--compact' : ''}
         ${verticalDivider ? 'sdds-table--divider' : ''}
-        ${noMinWidthArg ? 'sdds-table--no-min-width' : ''}
+        ${noMinWidth ? 'sdds-table--no-min-width' : ''}
         ${responsiveDesign ? 'sdds-table--responsive' : ''}
     ">
     ${tableTitle && `<caption>${tableTitle}</caption>`}

--- a/tegel/src/components/data-table/native-table.stories.tsx
+++ b/tegel/src/components/data-table/native-table.stories.tsx
@@ -3,16 +3,15 @@ import { formatHtmlPreview } from '../../utils/utils';
 export default {
   title: 'Components/Data Table/Native',
   argTypes: {
-    tableTitle: {
-      name: 'Table title',
-      description: 'Text that appears in table caption area.',
+    modeVariant: {
+      name: 'Mode variant',
+      description: 'The mode variant of the component',
       control: {
-        type: 'text',
+        type: 'radio',
       },
+      options: ['Inherit from parent', 'Primary', 'Secondary'],
       table: {
-        defaultValue: {
-          summary: '',
-        },
+        defaultValue: { summary: 'Inherit from parent' },
       },
     },
     isCompact: {
@@ -27,9 +26,10 @@ export default {
         },
       },
     },
-    dividers: {
-      name: 'Vertical dividers',
-      description: 'When enabled, table has vertical dividers between columns.',
+    responsiveTable: {
+      name: 'Responsive table',
+      description:
+        'Table takes 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too. ',
       control: {
         type: 'boolean',
       },
@@ -39,21 +39,21 @@ export default {
         },
       },
     },
-    modeVariant: {
-      name: 'Mode variant',
-      description: 'The mode variant of the component',
+    tableTitle: {
+      name: 'Table title',
+      description: 'Text that appears in table caption area.',
       control: {
-        type: 'radio',
+        type: 'text',
       },
-      options: ['Inherit from parent', 'Primary', 'Secondary'],
       table: {
-        defaultValue: { summary: 'Inherit from parent' },
+        defaultValue: {
+          summary: '',
+        },
       },
     },
-    responsiveTable: {
-      name: 'Responsive table',
-      description:
-        'Table takes 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too. ',
+    dividers: {
+      name: 'Vertical dividers',
+      description: 'When enabled, table has vertical dividers between columns.',
       control: {
         type: 'boolean',
       },
@@ -115,11 +115,11 @@ export default {
   },
   args: {
     modeVariant: 'Inherit from parent',
-    tableTitle: 'Native table',
     isCompact: false,
+    responsiveTable: false,
+    tableTitle: 'Native table',
     dividers: false,
     noMinWidthArg: false,
-    responsiveTable: false,
     column1Width: '',
     column2Width: '',
     column3Width: '',
@@ -128,11 +128,11 @@ export default {
 
 const Template = ({
   modeVariant,
-  tableTitle,
   isCompact,
+  responsiveTable,
+  tableTitle,
   dividers,
   noMinWidthArg,
-  responsiveTable,
   column1Width,
   column2Width,
   column3Width,

--- a/tegel/src/components/data-table/table-component-basic.stories.tsx
+++ b/tegel/src/components/data-table/table-component-basic.stories.tsx
@@ -27,7 +27,7 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
-      description: 'The mode variant of the component',
+      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
@@ -50,8 +50,7 @@ export default {
     },
     responsiveDesign: {
       name: 'Responsive table',
-      description:
-        'Table takes 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too. ',
+      description: 'Enables table to take 100% of available width. For column values less than 192px, "No minimum width" has to be enabled too.',
       control: {
         type: 'boolean',
       },
@@ -63,8 +62,7 @@ export default {
     },
     disablePadding: {
       name: 'Disable cell padding',
-      description:
-        'By default each cell comes with padding. Disabling padding rule can be useful when a users want to insert another HTML element in cell, eg. input.',
+      description: 'By default each cell comes with padding. Disabling padding rule can be useful when a users want to insert another HTML element in cell, eg. input.',
       control: {
         type: 'boolean',
       },
@@ -76,7 +74,7 @@ export default {
     },
     verticalDivider: {
       name: 'Vertical dividers',
-      description: 'When enabled, table has vertical dividers between columns.',
+      description: 'Enables vertical dividers between table columns.',
       control: {
         type: 'boolean',
       },
@@ -88,7 +86,7 @@ export default {
     },
     noMinWidth: {
       name: 'No minimum width',
-      description: 'Enable columns to shrink below width 192px.',
+      description: 'Resets min-width rule and enables setting column width value to less than 192px which is the default. When enabled, controls for column width will show here.',
       control: {
         type: 'boolean',
       },

--- a/tegel/src/components/data-table/table-component-basic.stories.tsx
+++ b/tegel/src/components/data-table/table-component-basic.stories.tsx
@@ -87,7 +87,7 @@ export default {
       },
     },
     noMinWidth: {
-      name: 'No column minimum width limitation',
+      name: 'No minimum width',
       description: 'Enable columns to shrink below width 192px.',
       control: {
         type: 'boolean',

--- a/tegel/src/components/data-table/table-component-basic.stories.tsx
+++ b/tegel/src/components/data-table/table-component-basic.stories.tsx
@@ -98,6 +98,38 @@ export default {
         },
       },
     },
+    column1Width: {
+      name: 'Column 1 width',
+      description:'Value of width for column 1. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
+    column2Width: {
+      name: 'Column 2 width',
+      description: 'Value of width for column 2. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
+    column3Width: {
+      name: 'Column 3 width',
+      description: 'Value of width for column 3. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
+    column4Width: {
+      name: 'Column 4 width',
+      description: 'Value of width for column 4. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
   },
   args: {
     modeVariant: 'Inherit from parent',
@@ -106,6 +138,10 @@ export default {
     disablePadding: false,
     verticalDivider: false,
     noMinWidth: false,
+    column1Width: '',
+    column2Width: '',
+    column3Width: '',
+    column4Width: '',
   },
 };
 
@@ -116,6 +152,10 @@ const BasicTemplate = ({
   disablePadding,
   verticalDivider,
   noMinWidth,
+  column1Width,
+  column2Width,
+  column3Width,
+  column4Width,
 }) =>
   formatHtmlPreview(`
   <sdds-table
@@ -125,10 +165,10 @@ const BasicTemplate = ({
       ${noMinWidth ? 'no-min-width' : ''}
       ${modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''}>
       <sdds-table-header>
-          <sdds-header-cell column-key='truck' column-title='Truck type'></sdds-header-cell>
-          <sdds-header-cell column-key='driver' column-title='Driver name'></sdds-header-cell>
-          <sdds-header-cell column-key='country' column-title='Country'></sdds-header-cell>
-          <sdds-header-cell column-key='mileage' column-title='Mileage' text-align='right'></sdds-header-cell>
+          <sdds-header-cell ${column1Width ? `style="width: ${column1Width};"` : ''} column-key='truck' column-title='Truck type'></sdds-header-cell>
+          <sdds-header-cell ${column2Width ? `style="width: ${column2Width};"` : ''} column-key='driver' column-title='Driver name'></sdds-header-cell>
+          <sdds-header-cell ${column3Width ? `style="width: ${column3Width};"` : ''} column-key='country' column-title='Country'></sdds-header-cell>
+          <sdds-header-cell ${column4Width ? `style="width: ${column4Width};"` : ''} column-key='mileage' column-title='Mileage' text-align='right'></sdds-header-cell>
       </sdds-table-header>
       <sdds-table-body>
           <sdds-table-body-row>

--- a/tegel/src/components/data-table/table-component-basic.stories.tsx
+++ b/tegel/src/components/data-table/table-component-basic.stories.tsx
@@ -43,9 +43,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     responsiveDesign: {
@@ -55,9 +53,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     disablePadding: {
@@ -67,9 +63,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     verticalDivider: {
@@ -79,9 +73,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     noMinWidth: {
@@ -91,9 +83,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: 'false',
-        },
+        defaultValue: { summary: false },
       },
     },
     column1Width: {

--- a/tegel/src/components/data-table/table-component-basic.stories.tsx
+++ b/tegel/src/components/data-table/table-component-basic.stories.tsx
@@ -153,10 +153,18 @@ const BasicTemplate = ({
       ${noMinWidth ? 'no-min-width' : ''}
       ${modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''}>
       <sdds-table-header>
-          <sdds-header-cell ${column1Width ? `style="width: ${column1Width};"` : ''} column-key='truck' column-title='Truck type'></sdds-header-cell>
-          <sdds-header-cell ${column2Width ? `style="width: ${column2Width};"` : ''} column-key='driver' column-title='Driver name'></sdds-header-cell>
-          <sdds-header-cell ${column3Width ? `style="width: ${column3Width};"` : ''} column-key='country' column-title='Country'></sdds-header-cell>
-          <sdds-header-cell ${column4Width ? `style="width: ${column4Width};"` : ''} column-key='mileage' column-title='Mileage' text-align='right'></sdds-header-cell>
+          <sdds-header-cell column-key='truck' column-title='Truck type' ${
+            column1Width ? `custom-width="${column1Width}"` : ''
+          }></sdds-header-cell>
+          <sdds-header-cell column-key='driver' column-title='Driver name' ${
+            column2Width ? `custom-width="${column2Width}"` : ''
+          }></sdds-header-cell>
+          <sdds-header-cell column-key='country' column-title='Country' ${
+            column3Width ? `custom-width="${column3Width}"` : ''
+          }></sdds-header-cell>
+          <sdds-header-cell column-key='mileage' column-title='Mileage' text-align='right' ${
+            column4Width ? `custom-width="${column4Width}"` : ''
+          }></sdds-header-cell>
       </sdds-table-header>
       <sdds-table-body>
           <sdds-table-body-row>

--- a/tegel/src/components/data-table/table-component-basic.stories.tsx
+++ b/tegel/src/components/data-table/table-component-basic.stories.tsx
@@ -199,4 +199,3 @@ const BasicTemplate = ({
   </sdds-table>`);
 
 export const Default = BasicTemplate.bind({});
-Default.args = {};

--- a/tegel/src/components/data-table/table-component-basic.stories.tsx
+++ b/tegel/src/components/data-table/table-component-basic.stories.tsx
@@ -25,16 +25,15 @@ export default {
     },
   },
   argTypes: {
-    verticalDivider: {
-      name: 'Vertical dividers',
-      description: 'When enabled, table has vertical dividers between columns.',
+    modeVariant: {
+      name: 'Mode variant',
+      description: 'The mode variant of the component',
       control: {
-        type: 'boolean',
+        type: 'radio',
       },
+      options: ['Inherit from parent', 'Primary', 'Secondary'],
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: 'Inherit from parent' },
       },
     },
     compactDesign: {
@@ -62,21 +61,22 @@ export default {
         },
       },
     },
-    modeVariant: {
-      name: 'Mode variant',
-      description: 'The mode variant of the component',
-      control: {
-        type: 'radio',
-      },
-      options: ['Inherit from parent', 'Primary', 'Secondary'],
-      table: {
-        defaultValue: { summary: 'Inherit from parent' },
-      },
-    },
     disablePadding: {
       name: 'Disable cell padding',
       description:
         'By default each cell comes with padding. Disabling padding rule can be useful when a users want to insert another HTML element in cell, eg. input.',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: {
+          summary: false,
+        },
+      },
+    },
+    verticalDivider: {
+      name: 'Vertical dividers',
+      description: 'When enabled, table has vertical dividers between columns.',
       control: {
         type: 'boolean',
       },
@@ -104,8 +104,8 @@ export default {
     compactDesign: false,
     responsiveDesign: false,
     disablePadding: false,
-    noMinWidth: false,
     verticalDivider: false,
+    noMinWidth: false,
   },
 };
 
@@ -114,8 +114,8 @@ const BasicTemplate = ({
   compactDesign,
   responsiveDesign,
   disablePadding,
-  noMinWidth,
   verticalDivider,
+  noMinWidth,
 }) =>
   formatHtmlPreview(`
   <sdds-table

--- a/tegel/src/components/data-table/table-component-batch-actions.stories.tsx
+++ b/tegel/src/components/data-table/table-component-batch-actions.stories.tsx
@@ -27,7 +27,7 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
-      description: 'The mode variant of the component',
+      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
@@ -43,56 +43,44 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     responsiveDesign: {
       name: 'Responsive table',
-      description:
-        'Table takes 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too. ',
+      description: 'Enables table to take 100% of available width. For column values less than 192px, "No minimum width" has to be enabled too.',
       control: {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     batchArea: {
       name: 'Batch code',
-      description: 'Code that user can inject to the toolbar area.',
+      description: 'Enables code to be injected into the toolbar area.',
       control: {
         type: 'text',
-      },
-      defaultValue: {
-        summary: '',
       },
     },
     verticalDivider: {
       name: 'Vertical dividers',
-      description: 'When enabled, table has vertical dividers between columns.',
+      description: 'Enables vertical dividers between table columns.',
       control: {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     noMinWidth: {
-      name: 'No column minimum width limitation',
-      description: 'Enable columns to shrink below width 192px.',
+      name: 'No minimum width',
+      description: 'Resets min-width rule and enables setting column width value to less than 192px which is the default. When enabled, controls for column width will show here.',
       control: {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: 'false',
-        },
+        defaultValue: { summary: false },
       },
     },
   },

--- a/tegel/src/components/data-table/table-component-batch-actions.stories.tsx
+++ b/tegel/src/components/data-table/table-component-batch-actions.stories.tsx
@@ -169,4 +169,3 @@ const BatchActionTemplate = ({
   </sdds-table>`);
 
 export const BatchAction = BatchActionTemplate.bind({});
-BatchAction.args = {};

--- a/tegel/src/components/data-table/table-component-batch-actions.stories.tsx
+++ b/tegel/src/components/data-table/table-component-batch-actions.stories.tsx
@@ -25,16 +25,15 @@ export default {
     },
   },
   argTypes: {
-    verticalDivider: {
-      name: 'Vertical dividers',
-      description: 'When enabled, table has vertical dividers between columns.',
+    modeVariant: {
+      name: 'Mode variant',
+      description: 'The mode variant of the component',
       control: {
-        type: 'boolean',
+        type: 'radio',
       },
+      options: ['Inherit from parent', 'Primary', 'Secondary'],
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: 'Inherit from parent' },
       },
     },
     compactDesign: {
@@ -49,21 +48,32 @@ export default {
         },
       },
     },
-    modeVariant: {
-      name: 'Mode variant',
-      description: 'The mode variant of the component',
-      control: {
-        type: 'radio',
-      },
-      options: ['Inherit from parent', 'Primary', 'Secondary'],
-      table: {
-        defaultValue: { summary: 'Inherit from parent' },
-      },
-    },
     responsiveDesign: {
       name: 'Responsive table',
       description:
         'Table takes 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too. ',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: {
+          summary: false,
+        },
+      },
+    },
+    batchArea: {
+      name: 'Batch code',
+      description: 'Code that user can inject to the toolbar area.',
+      control: {
+        type: 'text',
+      },
+      defaultValue: {
+        summary: '',
+      },
+    },
+    verticalDivider: {
+      name: 'Vertical dividers',
+      description: 'When enabled, table has vertical dividers between columns.',
       control: {
         type: 'boolean',
       },
@@ -85,35 +95,25 @@ export default {
         },
       },
     },
-    batchArea: {
-      name: 'Batch code',
-      description: 'Code that user can inject to the toolbar area.',
-      control: {
-        type: 'text',
-      },
-      defaultValue: {
-        summary: '',
-      },
-    },
   },
   args: {
     modeVariant: 'Inherit from parent',
     compactDesign: false,
-    verticalDivider: false,
     responsiveDesign: false,
     batchArea: formatHtmlPreview(
       '<button slot="sdds-table__actionbar" class="sdds-table__actionbar-btn"><sdds-icon class="sdds-table__actionbar-btn-icon" name="settings" size="20px"></sdds-icon> </button><sdds-button slot="sdds-table__actionbar" type="primary" size="sm" text="Download"></sdds-button>',
     ),
+    verticalDivider: false,
     noMinWidth: false,
   },
 };
 
 const BatchActionTemplate = ({
-  verticalDivider,
-  compactDesign,
   modeVariant,
-  batchArea,
+  compactDesign,
   responsiveDesign,
+  batchArea,
+  verticalDivider,
   noMinWidth,
 }) =>
   formatHtmlPreview(`

--- a/tegel/src/components/data-table/table-component-batch-actions.stories.tsx
+++ b/tegel/src/components/data-table/table-component-batch-actions.stories.tsx
@@ -83,6 +83,38 @@ export default {
         defaultValue: { summary: false },
       },
     },
+    column1Width: {
+      name: 'Column 1 width',
+      description:'Value of width for column 1. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
+    column2Width: {
+      name: 'Column 2 width',
+      description: 'Value of width for column 2. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
+    column3Width: {
+      name: 'Column 3 width',
+      description: 'Value of width for column 3. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
+    column4Width: {
+      name: 'Column 4 width',
+      description: 'Value of width for column 4. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
   },
   args: {
     modeVariant: 'Inherit from parent',
@@ -93,6 +125,10 @@ export default {
     ),
     verticalDivider: false,
     noMinWidth: false,
+    column1Width: '',
+    column2Width: '',
+    column3Width: '',
+    column4Width: '',
   },
 };
 
@@ -103,6 +139,10 @@ const BatchActionTemplate = ({
   batchArea,
   verticalDivider,
   noMinWidth,
+  column1Width,
+  column2Width,
+  column3Width,
+  column4Width,
 }) =>
   formatHtmlPreview(`
    <sdds-table
@@ -119,10 +159,10 @@ const BatchActionTemplate = ({
           ${batchArea}
         </sdds-table-toolbar>
           <sdds-table-header>
-              <sdds-header-cell column-key='truck' column-title='Truck type'></sdds-header-cell>
-              <sdds-header-cell column-key='driver' column-title='Driver name'></sdds-header-cell>
-              <sdds-header-cell column-key='country' column-title='Country'></sdds-header-cell>
-              <sdds-header-cell column-key='mileage' column-title='Mileage' text-align='right'></sdds-header-cell>
+              <sdds-header-cell ${column1Width ? `style="width: ${column1Width};"` : ''} column-key='truck' column-title='Truck type'></sdds-header-cell>
+              <sdds-header-cell ${column2Width ? `style="width: ${column2Width};"` : ''} column-key='driver' column-title='Driver name'></sdds-header-cell>
+              <sdds-header-cell ${column3Width ? `style="width: ${column3Width};"` : ''} column-key='country' column-title='Country'></sdds-header-cell>
+              <sdds-header-cell ${column4Width ? `style="width: ${column4Width};"` : ''} column-key='mileage' column-title='Mileage' text-align='right'></sdds-header-cell>
           </sdds-table-header>
           <sdds-table-body enable-dummy-data>
           </sdds-table-body>

--- a/tegel/src/components/data-table/table-component-bodydata.stories.tsx
+++ b/tegel/src/components/data-table/table-component-bodydata.stories.tsx
@@ -27,15 +27,9 @@ export default {
   argTypes: {
     bodyData: {
       name: 'Data',
-      description:
-        'An array of objects with keys matching the header cell `column-key` attributes. Can be passed as an array object, or as a stringified array.',
+      description: 'An array of objects with keys matching the header cell `column-key` attributes. Can be passed as an array object, or as a stringified array.',
       control: {
         type: 'array',
-      },
-      table: {
-        defaultValue: {
-          summary: false,
-        },
       },
     },
   },
@@ -60,4 +54,3 @@ const DataPropertyTemplate = ({ bodyData }) =>
   </sdds-table>`);
 
 export const DataProperty = DataPropertyTemplate.bind({});
-DataProperty.args = {};

--- a/tegel/src/components/data-table/table-component-custom-width.stories.tsx
+++ b/tegel/src/components/data-table/table-component-custom-width.stories.tsx
@@ -25,16 +25,15 @@ export default {
     },
   },
   argTypes: {
-    verticalDivider: {
-      name: 'Vertical dividers',
-      description: 'When enabled, table has vertical dividers between columns.',
+    modeVariant: {
+      name: 'Mode variant',
+      description: 'The mode variant of the component',
       control: {
-        type: 'boolean',
+        type: 'radio',
       },
+      options: ['Inherit from parent', 'Primary', 'Secondary'],
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: 'Inherit from parent' },
       },
     },
     compactDesign: {
@@ -49,21 +48,22 @@ export default {
         },
       },
     },
-    modeVariant: {
-      name: 'Mode variant',
-      description: 'The mode variant of the component',
-      control: {
-        type: 'radio',
-      },
-      options: ['Inherit from parent', 'Primary', 'Secondary'],
-      table: {
-        defaultValue: { summary: 'Inherit from parent' },
-      },
-    },
     responsiveDesign: {
       name: 'Responsive table',
       description:
         'Table takes 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too. ',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: {
+          summary: false,
+        },
+      },
+    },
+    verticalDivider: {
+      name: 'Vertical dividers',
+      description: 'When enabled, table has vertical dividers between columns.',
       control: {
         type: 'boolean',
       },
@@ -138,8 +138,8 @@ export default {
   args: {
     modeVariant: 'Inherit from parent',
     compactDesign: false,
-    verticalDivider: true,
     responsiveDesign: false,
+    verticalDivider: true,
     noMinWidth: true,
     column1Width: '321px',
     column2Width: '400px',
@@ -151,8 +151,8 @@ export default {
 const BasicTemplate = ({
   modeVariant,
   compactDesign,
-  verticalDivider,
   responsiveDesign,
+  verticalDivider,
   noMinWidth,
   column1Width,
   column2Width,

--- a/tegel/src/components/data-table/table-component-custom-width.stories.tsx
+++ b/tegel/src/components/data-table/table-component-custom-width.stories.tsx
@@ -43,9 +43,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     responsiveDesign: {
@@ -55,9 +53,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     verticalDivider: {
@@ -67,9 +63,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     noMinWidth: {
@@ -79,19 +73,12 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     column1Width: {
       name: 'Column 1 width',
       description: 'Value of width for column 1. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
-      type: 'string',
-      table: {
-        defaultValue: {
-          summary: '192px',
-        },
       control: {
         type: 'text',
       },
@@ -100,11 +87,6 @@ export default {
     column2Width: {
       name: 'Column 2 width',
       description: 'Value of width for column 2. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
-      type: 'string',
-      table: {
-        defaultValue: {
-          summary: '192px',
-        },
       control: {
         type: 'text',
       },
@@ -113,11 +95,6 @@ export default {
     column3Width: {
       name: 'Column 3 width',
       description: 'Value of width for column 3. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
-      type: 'string',
-      table: {
-        defaultValue: {
-          summary: '192px',
-        },
       control: {
         type: 'text',
       },
@@ -126,11 +103,6 @@ export default {
     column4Width: {
       name: 'Column 4 width',
       description: 'Value of width for column 4. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
-      type: 'string',
-      table: {
-        defaultValue: {
-          summary: '192px',
-        },
       control: {
         type: 'text',
       },

--- a/tegel/src/components/data-table/table-component-custom-width.stories.tsx
+++ b/tegel/src/components/data-table/table-component-custom-width.stories.tsx
@@ -92,6 +92,8 @@ export default {
         defaultValue: {
           summary: '192px',
         },
+      control: {
+        type: 'text',
       },
       if: { arg: 'noMinWidth', eq: true },
     },
@@ -103,6 +105,8 @@ export default {
         defaultValue: {
           summary: '192px',
         },
+      control: {
+        type: 'text',
       },
       if: { arg: 'noMinWidth', eq: true },
     },
@@ -114,6 +118,8 @@ export default {
         defaultValue: {
           summary: '192px',
         },
+      control: {
+        type: 'text',
       },
       if: { arg: 'noMinWidth', eq: true },
     },
@@ -125,6 +131,8 @@ export default {
         defaultValue: {
           summary: '192px',
         },
+      control: {
+        type: 'text',
       },
       if: { arg: 'noMinWidth', eq: true },
     },

--- a/tegel/src/components/data-table/table-component-custom-width.stories.tsx
+++ b/tegel/src/components/data-table/table-component-custom-width.stories.tsx
@@ -27,7 +27,7 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
-      description: 'The mode variant of the component',
+      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
@@ -50,8 +50,7 @@ export default {
     },
     responsiveDesign: {
       name: 'Responsive table',
-      description:
-        'Table takes 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too. ',
+      description: 'Enables table to take 100% of available width. For column values less than 192px, "No minimum width" has to be enabled too.',
       control: {
         type: 'boolean',
       },
@@ -63,7 +62,7 @@ export default {
     },
     verticalDivider: {
       name: 'Vertical dividers',
-      description: 'When enabled, table has vertical dividers between columns.',
+      description: 'Enables vertical dividers between table columns.',
       control: {
         type: 'boolean',
       },
@@ -75,8 +74,7 @@ export default {
     },
     noMinWidth: {
       name: 'No minimum width',
-      description:
-        'Resets min-width rule and enabled setting column width value less then 192px which is default one. When enabled, controls for columns width will show here.',
+      description: 'Resets min-width rule and enables setting column width value to less than 192px which is the default. When enabled, controls for column width will show here.',
       control: {
         type: 'boolean',
       },
@@ -88,8 +86,7 @@ export default {
     },
     column1Width: {
       name: 'Column 1 width',
-      description:
-        'Value of width for column 1. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit too next tot the value, eg. 200px.',
+      description: 'Value of width for column 1. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
       type: 'string',
       table: {
         defaultValue: {
@@ -100,8 +97,7 @@ export default {
     },
     column2Width: {
       name: 'Column 2 width',
-      description:
-        'Value of width for column 2. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit too next tot the value, eg. 200px.',
+      description: 'Value of width for column 2. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
       type: 'string',
       table: {
         defaultValue: {
@@ -112,8 +108,7 @@ export default {
     },
     column3Width: {
       name: 'Column 3 width',
-      description:
-        'Value of width for column 3. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit too next tot the value, eg. 200px.',
+      description: 'Value of width for column 3. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
       type: 'string',
       table: {
         defaultValue: {
@@ -124,8 +119,7 @@ export default {
     },
     column4Width: {
       name: 'Column 4 width',
-      description:
-        'Value of width for column 4. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit too next tot the value, eg. 200px.',
+      description: 'Value of width for column 4. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
       type: 'string',
       table: {
         defaultValue: {
@@ -222,4 +216,3 @@ const BasicTemplate = ({
   </sdds-table>`);
 
 export const CustomWidth = BasicTemplate.bind({});
-CustomWidth.args = {};

--- a/tegel/src/components/data-table/table-component-event-listeners.stories.tsx
+++ b/tegel/src/components/data-table/table-component-event-listeners.stories.tsx
@@ -27,7 +27,7 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
-      description: 'The mode variant of the component',
+      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
@@ -50,8 +50,7 @@ export default {
     },
     responsiveDesign: {
       name: 'Responsive table',
-      description:
-        'Table takes 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too. ',
+      description: 'Enables table to take 100% of available width. For column values less than 192px, "No minimum width" has to be enabled too.',
       control: {
         type: 'boolean',
       },
@@ -63,7 +62,7 @@ export default {
     },
     verticalDivider: {
       name: 'Vertical dividers',
-      description: 'When enabled, table has vertical dividers between columns.',
+      description: 'Enables vertical dividers between table columns.',
       control: {
         type: 'boolean',
       },
@@ -74,8 +73,8 @@ export default {
       },
     },
     noMinWidth: {
-      name: 'No column minimum width limitation',
-      description: 'Enable columns to shrink below width 192px.',
+      name: 'No minimum width',
+      description: 'Resets min-width rule and enables setting column width value to less than 192px which is the default. When enabled, controls for column width will show here.',
       control: {
         type: 'boolean',
       },

--- a/tegel/src/components/data-table/table-component-event-listeners.stories.tsx
+++ b/tegel/src/components/data-table/table-component-event-listeners.stories.tsx
@@ -25,16 +25,15 @@ export default {
     },
   },
   argTypes: {
-    verticalDivider: {
-      name: 'Vertical dividers',
-      description: 'When enabled, table has vertical dividers between columns.',
+    modeVariant: {
+      name: 'Mode variant',
+      description: 'The mode variant of the component',
       control: {
-        type: 'boolean',
+        type: 'radio',
       },
+      options: ['Inherit from parent', 'Primary', 'Secondary'],
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: 'Inherit from parent' },
       },
     },
     compactDesign: {
@@ -49,21 +48,22 @@ export default {
         },
       },
     },
-    modeVariant: {
-      name: 'Mode variant',
-      description: 'The mode variant of the component',
-      control: {
-        type: 'radio',
-      },
-      options: ['Inherit from parent', 'Primary', 'Secondary'],
-      table: {
-        defaultValue: { summary: 'Inherit from parent' },
-      },
-    },
     responsiveDesign: {
       name: 'Responsive table',
       description:
         'Table takes 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too. ',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: {
+          summary: false,
+        },
+      },
+    },
+    verticalDivider: {
+      name: 'Vertical dividers',
+      description: 'When enabled, table has vertical dividers between columns.',
       control: {
         type: 'boolean',
       },
@@ -89,17 +89,17 @@ export default {
   args: {
     modeVariant: 'Inherit from parent',
     compactDesign: false,
-    verticalDivider: false,
     responsiveDesign: false,
+    verticalDivider: false,
     noMinWidth: false,
   },
 };
 
 const EventListenersTemplate = ({
-  verticalDivider,
-  compactDesign,
   modeVariant,
+  compactDesign,
   responsiveDesign,
+  verticalDivider,
   noMinWidth,
 }) =>
   formatHtmlPreview(`
@@ -159,4 +159,3 @@ const EventListenersTemplate = ({
   </div>`);
 
 export const EventListeners = EventListenersTemplate.bind({});
-EventListeners.args = {};

--- a/tegel/src/components/data-table/table-component-event-listeners.stories.tsx
+++ b/tegel/src/components/data-table/table-component-event-listeners.stories.tsx
@@ -84,6 +84,38 @@ export default {
         },
       },
     },
+    column1Width: {
+      name: 'Column 1 width',
+      description:'Value of width for column 1. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
+    column2Width: {
+      name: 'Column 2 width',
+      description: 'Value of width for column 2. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
+    column3Width: {
+      name: 'Column 3 width',
+      description: 'Value of width for column 3. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
+    column4Width: {
+      name: 'Column 4 width',
+      description: 'Value of width for column 4. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
   },
   args: {
     modeVariant: 'Inherit from parent',
@@ -91,6 +123,10 @@ export default {
     responsiveDesign: false,
     verticalDivider: false,
     noMinWidth: false,
+    column1Width: '',
+    column2Width: '',
+    column3Width: '',
+    column4Width: '',
   },
 };
 
@@ -100,6 +136,10 @@ const EventListenersTemplate = ({
   responsiveDesign,
   verticalDivider,
   noMinWidth,
+  column1Width,
+  column2Width,
+  column3Width,
+  column4Width,
 }) =>
   formatHtmlPreview(`
     <script>
@@ -129,10 +169,18 @@ const EventListenersTemplate = ({
    >
           <sdds-table-toolbar table-title="Disabled filtering, pagination and sorting - left to the user to listen to events" enable-filtering></sdds-table-toolbar>
           <sdds-table-header>
-              <sdds-header-cell column-key='truck' column-title='Truck type' sortable></sdds-header-cell>
-              <sdds-header-cell column-key='driver' column-title='Driver name' sortable></sdds-header-cell>
-              <sdds-header-cell column-key='country' column-title='Country' sortable></sdds-header-cell>
-              <sdds-header-cell column-key='mileage' column-title='Mileage' sortable text-align='right'></sdds-header-cell>
+              <sdds-header-cell column-key='truck' column-title='Truck type' sortable ${
+                column1Width ? `custom-width="${column1Width}"` : ''
+              }></sdds-header-cell>
+              <sdds-header-cell column-key='driver' column-title='Driver name' sortable ${
+                column2Width ? `custom-width="${column2Width}"` : ''
+              }></sdds-header-cell>
+              <sdds-header-cell column-key='country' column-title='Country' sortable ${
+                column3Width ? `custom-width="${column3Width}"` : ''
+              }></sdds-header-cell>
+              <sdds-header-cell column-key='mileage' column-title='Mileage' sortable text-align='right' ${
+                column4Width ? `custom-width="${column4Width}"` : ''
+              }></sdds-header-cell>
           </sdds-table-header>
           <sdds-table-body disable-pagination-function disable-filtering-function disable-sorting-function enable-dummy-data>
               <sdds-table-body-row>

--- a/tegel/src/components/data-table/table-component-event-listeners.stories.tsx
+++ b/tegel/src/components/data-table/table-component-event-listeners.stories.tsx
@@ -43,9 +43,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     responsiveDesign: {
@@ -55,9 +53,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     verticalDivider: {
@@ -67,9 +63,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     noMinWidth: {
@@ -79,9 +73,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: 'false',
-        },
+        defaultValue: { summary: false },
       },
     },
     column1Width: {

--- a/tegel/src/components/data-table/table-component-expandable-rows.stories.tsx
+++ b/tegel/src/components/data-table/table-component-expandable-rows.stories.tsx
@@ -27,7 +27,7 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
-      description: 'The mode variant of the component',
+      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
@@ -43,46 +43,37 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     responsiveDesign: {
       name: 'Responsive table',
-      description:
-        'Table takes 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too. ',
+      description: 'Enables table to take 100% of available width. For column values less than 192px, "No minimum width" has to be enabled too.',
       control: {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     verticalDivider: {
       name: 'Vertical dividers',
-      description: 'When enabled, table has vertical dividers between columns.',
+      description: 'Enables vertical dividers between table columns.',
       control: {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     noMinWidth: {
-      name: 'No column minimum width limitation',
-      description: 'Enable columns to shrink below width 192px.',
+      name: 'No minimum width',
+      description: 'Resets min-width rule and enables setting column width value to less than 192px which is the default. When enabled, controls for column width will show here.',
       control: {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: 'false',
-        },
+        defaultValue: { summary: false },
       },
     },
   },

--- a/tegel/src/components/data-table/table-component-expandable-rows.stories.tsx
+++ b/tegel/src/components/data-table/table-component-expandable-rows.stories.tsx
@@ -25,16 +25,15 @@ export default {
     },
   },
   argTypes: {
-    verticalDivider: {
-      name: 'Vertical dividers',
-      description: 'When enabled, table has vertical dividers between columns.',
+    modeVariant: {
+      name: 'Mode variant',
+      description: 'The mode variant of the component',
       control: {
-        type: 'boolean',
+        type: 'radio',
       },
+      options: ['Inherit from parent', 'Primary', 'Secondary'],
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: 'Inherit from parent' },
       },
     },
     compactDesign: {
@@ -49,21 +48,22 @@ export default {
         },
       },
     },
-    modeVariant: {
-      name: 'Mode variant',
-      description: 'The mode variant of the component',
-      control: {
-        type: 'radio',
-      },
-      options: ['Inherit from parent', 'Primary', 'Secondary'],
-      table: {
-        defaultValue: { summary: 'Inherit from parent' },
-      },
-    },
     responsiveDesign: {
       name: 'Responsive table',
       description:
         'Table takes 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too. ',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: {
+          summary: false,
+        },
+      },
+    },
+    verticalDivider: {
+      name: 'Vertical dividers',
+      description: 'When enabled, table has vertical dividers between columns.',
       control: {
         type: 'boolean',
       },
@@ -89,17 +89,17 @@ export default {
   args: {
     modeVariant: 'Inherit from parent',
     compactDesign: false,
-    verticalDivider: false,
     responsiveDesign: false,
+    verticalDivider: false,
     noMinWidth: false,
   },
 };
 
 const ExpandableRowTemplate = ({
-  verticalDivider,
-  compactDesign,
   modeVariant,
+  compactDesign,
   responsiveDesign,
+  verticalDivider,
   noMinWidth,
 }) =>
   formatHtmlPreview(`

--- a/tegel/src/components/data-table/table-component-expandable-rows.stories.tsx
+++ b/tegel/src/components/data-table/table-component-expandable-rows.stories.tsx
@@ -182,4 +182,3 @@ const ExpandableRowTemplate = ({
   </sdds-table>`);
 
 export const ExpandableRows = ExpandableRowTemplate.bind({});
-ExpandableRows.args = {};

--- a/tegel/src/components/data-table/table-component-expandable-rows.stories.tsx
+++ b/tegel/src/components/data-table/table-component-expandable-rows.stories.tsx
@@ -76,6 +76,38 @@ export default {
         defaultValue: { summary: false },
       },
     },
+    column1Width: {
+      name: 'Column 1 width',
+      description:'Value of width for column 1. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
+    column2Width: {
+      name: 'Column 2 width',
+      description: 'Value of width for column 2. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
+    column3Width: {
+      name: 'Column 3 width',
+      description: 'Value of width for column 3. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
+    column4Width: {
+      name: 'Column 4 width',
+      description: 'Value of width for column 4. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
   },
   args: {
     modeVariant: 'Inherit from parent',
@@ -83,6 +115,10 @@ export default {
     responsiveDesign: false,
     verticalDivider: false,
     noMinWidth: false,
+    column1Width: '',
+    column2Width: '',
+    column3Width: '',
+    column4Width: '',
   },
 };
 
@@ -92,6 +128,10 @@ const ExpandableRowTemplate = ({
   responsiveDesign,
   verticalDivider,
   noMinWidth,
+  column1Width,
+  column2Width,
+  column3Width,
+  column4Width,
 }) =>
   formatHtmlPreview(`
   <sdds-table
@@ -103,10 +143,18 @@ const ExpandableRowTemplate = ({
     ${modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''}
     >
       <sdds-table-header>
-          <sdds-header-cell column-key='truck' column-title='Truck type'></sdds-header-cell>
-          <sdds-header-cell column-key='driver' column-title='Driver name'></sdds-header-cell>
-          <sdds-header-cell column-key='country' column-title='Country'></sdds-header-cell>
-          <sdds-header-cell column-key='mileage' column-title='Mileage'  text-align='right'></sdds-header-cell>
+          <sdds-header-cell column-key='truck' column-title='Truck type' ${
+            column1Width ? `custom-width="${column1Width}"` : ''
+          }></sdds-header-cell>
+          <sdds-header-cell column-key='driver' column-title='Driver name' ${
+            column2Width ? `custom-width="${column2Width}"` : ''
+          }></sdds-header-cell>
+          <sdds-header-cell column-key='country' column-title='Country' ${
+            column3Width ? `custom-width="${column3Width}"` : ''
+          }></sdds-header-cell>
+          <sdds-header-cell column-key='mileage' column-title='Mileage' text-align='right' ${
+            column4Width ? `custom-width="${column4Width}"` : ''
+          }></sdds-header-cell>
       </sdds-table-header>
       <sdds-table-body>
         <sdds-table-body-row-expandable>

--- a/tegel/src/components/data-table/table-component-filtering.stories.tsx
+++ b/tegel/src/components/data-table/table-component-filtering.stories.tsx
@@ -191,4 +191,3 @@ const FilteringTemplate = ({
   </sdds-table>`);
 
 export const Filtering = FilteringTemplate.bind({});
-Filtering.args = {};

--- a/tegel/src/components/data-table/table-component-filtering.stories.tsx
+++ b/tegel/src/components/data-table/table-component-filtering.stories.tsx
@@ -28,7 +28,7 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
-      description: 'The mode variant of the component',
+      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
@@ -44,58 +44,47 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     responsiveDesign: {
       name: 'Responsive table',
-      description:
-        'Table takes 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too. ',
+      description: 'Enables table to take 100% of available width. For column values less than 192px, "No minimum width" has to be enabled too.',
       control: {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     useDataProp: {
       name: 'Use data prop',
-      description: 'Load table data from property',
+      description: 'Loads table data from property.',
       control: {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: 'n/a',
-        },
+        defaultValue: { summary: true },
       },
     },
     verticalDivider: {
       name: 'Vertical dividers',
-      description: 'When enabled, table has vertical dividers between columns.',
+      description: 'Enables vertical dividers between table columns.',
       control: {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     noMinWidth: {
-      name: 'No column minimum width limitation',
-      description: 'Enable columns to shrink below width 192px.',
+      name: 'No minimum width',
+      description: 'Resets min-width rule and enables setting column width value to less than 192px which is the default. When enabled, controls for column width will show here.',
       control: {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: 'false',
-        },
+        defaultValue: { summary: false },
       },
     },
   },

--- a/tegel/src/components/data-table/table-component-filtering.stories.tsx
+++ b/tegel/src/components/data-table/table-component-filtering.stories.tsx
@@ -26,16 +26,15 @@ export default {
     },
   },
   argTypes: {
-    verticalDivider: {
-      name: 'Vertical dividers',
-      description: 'When enabled, table has vertical dividers between columns.',
+    modeVariant: {
+      name: 'Mode variant',
+      description: 'The mode variant of the component',
       control: {
-        type: 'boolean',
+        type: 'radio',
       },
+      options: ['Inherit from parent', 'Primary', 'Secondary'],
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: 'Inherit from parent' },
       },
     },
     compactDesign: {
@@ -50,21 +49,34 @@ export default {
         },
       },
     },
-    modeVariant: {
-      name: 'Mode variant',
-      description: 'The mode variant of the component',
-      control: {
-        type: 'radio',
-      },
-      options: ['Inherit from parent', 'Primary', 'Secondary'],
-      table: {
-        defaultValue: { summary: 'Inherit from parent' },
-      },
-    },
     responsiveDesign: {
       name: 'Responsive table',
       description:
         'Table takes 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too. ',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: {
+          summary: false,
+        },
+      },
+    },
+    useDataProp: {
+      name: 'Use data prop',
+      description: 'Load table data from property',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: {
+          summary: 'n/a',
+        },
+      },
+    },
+    verticalDivider: {
+      name: 'Vertical dividers',
+      description: 'When enabled, table has vertical dividers between columns.',
       control: {
         type: 'boolean',
       },
@@ -86,35 +98,23 @@ export default {
         },
       },
     },
-    useDataProp: {
-      name: 'Use data prop',
-      description: 'Load table data from property',
-      control: {
-        type: 'boolean',
-      },
-      table: {
-        defaultValue: {
-          summary: 'n/a',
-        },
-      },
-    },
   },
   args: {
     modeVariant: 'Inherit from parent',
     compactDesign: false,
-    verticalDivider: false,
     responsiveDesign: true,
     useDataProp: true,
+    verticalDivider: false,
     noMinWidth: true,
   },
 };
 
 const FilteringTemplate = ({
-  verticalDivider,
-  compactDesign,
   modeVariant,
+  compactDesign,
   responsiveDesign,
   useDataProp,
+  verticalDivider,
   noMinWidth,
 }) =>
   formatHtmlPreview(`

--- a/tegel/src/components/data-table/table-component-filtering.stories.tsx
+++ b/tegel/src/components/data-table/table-component-filtering.stories.tsx
@@ -87,6 +87,38 @@ export default {
         defaultValue: { summary: false },
       },
     },
+    column1Width: {
+      name: 'Column 1 width',
+      description:'Value of width for column 1. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
+    column2Width: {
+      name: 'Column 2 width',
+      description: 'Value of width for column 2. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
+    column3Width: {
+      name: 'Column 3 width',
+      description: 'Value of width for column 3. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
+    column4Width: {
+      name: 'Column 4 width',
+      description: 'Value of width for column 4. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
   },
   args: {
     modeVariant: 'Inherit from parent',
@@ -94,7 +126,11 @@ export default {
     responsiveDesign: true,
     useDataProp: true,
     verticalDivider: false,
-    noMinWidth: true,
+    noMinWidth: false,
+    column1Width: '',
+    column2Width: '',
+    column3Width: '',
+    column4Width: '',
   },
 };
 
@@ -105,6 +141,10 @@ const FilteringTemplate = ({
   useDataProp,
   verticalDivider,
   noMinWidth,
+  column1Width,
+  column2Width,
+  column3Width,
+  column4Width,
 }) =>
   formatHtmlPreview(`
    <sdds-table
@@ -116,10 +156,18 @@ const FilteringTemplate = ({
   >
           <sdds-table-toolbar table-title="Filter" enable-filtering></sdds-table-toolbar>
           <sdds-table-header>
-              <sdds-header-cell column-key='truck' column-title='Truck type'></sdds-header-cell>
-              <sdds-header-cell column-key='driver' column-title='Driver name'></sdds-header-cell>
-              <sdds-header-cell column-key='country' column-title='Country' ></sdds-header-cell>
-              <sdds-header-cell column-key='mileage' column-title='Mileage' text-align='right'></sdds-header-cell>
+              <sdds-header-cell column-key='truck' column-title='Truck type' ${
+                column1Width ? `custom-width="${column1Width}"` : ''
+              }></sdds-header-cell>
+              <sdds-header-cell column-key='driver' column-title='Driver name' ${
+                column2Width ? `custom-width="${column2Width}"` : ''
+              }></sdds-header-cell>
+              <sdds-header-cell column-key='country' column-title='Country' ${
+                column3Width ? `custom-width="${column3Width}"` : ''
+              }></sdds-header-cell>
+              <sdds-header-cell column-key='mileage' column-title='Mileage' text-align='right' ${
+                column4Width ? `custom-width="${column4Width}"` : ''
+              }></sdds-header-cell>
           </sdds-table-header>
           <sdds-table-body ${useDataProp ? `body-data='${JSON.stringify(dummyData)}'` : ''}>
             ${

--- a/tegel/src/components/data-table/table-component-multiselect.stories.tsx
+++ b/tegel/src/components/data-table/table-component-multiselect.stories.tsx
@@ -25,6 +25,42 @@ export default {
     },
   },
   argTypes: {
+    modeVariant: {
+      name: 'Mode variant',
+      description: 'The mode variant of the component',
+      control: {
+        type: 'radio',
+      },
+      options: ['Inherit from parent', 'Primary', 'Secondary'],
+      table: {
+        defaultValue: { summary: 'Inherit from parent' },
+      },
+    },
+    compactDesign: {
+      name: 'Compact design',
+      description: 'Enables compact design of the table, rows with less height.',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: {
+          summary: false,
+        },
+      },
+    },
+    responsiveDesign: {
+      name: 'Responsive table',
+      description:
+        'Table takes 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too. ',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: {
+          summary: false,
+        },
+      },
+    },
     enableMultiselect: {
       name: 'Enable multiselect',
       description: 'Enable row selection.',
@@ -40,42 +76,6 @@ export default {
     verticalDivider: {
       name: 'Vertical dividers',
       description: 'When enabled, table has vertical dividers between columns.',
-      control: {
-        type: 'boolean',
-      },
-      table: {
-        defaultValue: {
-          summary: false,
-        },
-      },
-    },
-    compactDesign: {
-      name: 'Compact design',
-      description: 'Enables compact design of the table, rows with less height.',
-      control: {
-        type: 'boolean',
-      },
-      table: {
-        defaultValue: {
-          summary: false,
-        },
-      },
-    },
-    modeVariant: {
-      name: 'Mode variant',
-      description: 'The mode variant of the component',
-      control: {
-        type: 'radio',
-      },
-      options: ['Inherit from parent', 'Primary', 'Secondary'],
-      table: {
-        defaultValue: { summary: 'Inherit from parent' },
-      },
-    },
-    responsiveDesign: {
-      name: 'Responsive table',
-      description:
-        'Table takes 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too. ',
       control: {
         type: 'boolean',
       },
@@ -101,19 +101,19 @@ export default {
   args: {
     modeVariant: 'Inherit from parent',
     compactDesign: false,
-    verticalDivider: false,
     responsiveDesign: false,
-    noMinWidth: false,
     enableMultiselect: true,
+    verticalDivider: false,
+    noMinWidth: false,
   },
 };
 
 const MultiselectTemplate = ({
-  verticalDivider,
-  compactDesign,
   modeVariant,
+  compactDesign,
   responsiveDesign,
   enableMultiselect,
+  verticalDivider,
   noMinWidth,
 }) =>
   formatHtmlPreview(`

--- a/tegel/src/components/data-table/table-component-multiselect.stories.tsx
+++ b/tegel/src/components/data-table/table-component-multiselect.stories.tsx
@@ -86,6 +86,38 @@ export default {
         defaultValue: { summary: false },
       },
     },
+    column1Width: {
+      name: 'Column 1 width',
+      description:'Value of width for column 1. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
+    column2Width: {
+      name: 'Column 2 width',
+      description: 'Value of width for column 2. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
+    column3Width: {
+      name: 'Column 3 width',
+      description: 'Value of width for column 3. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
+    column4Width: {
+      name: 'Column 4 width',
+      description: 'Value of width for column 4. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
   },
   args: {
     modeVariant: 'Inherit from parent',
@@ -94,6 +126,10 @@ export default {
     enableMultiselect: true,
     verticalDivider: false,
     noMinWidth: false,
+    column1Width: '',
+    column2Width: '',
+    column3Width: '',
+    column4Width: '',
   },
 };
 
@@ -104,6 +140,10 @@ const MultiselectTemplate = ({
   enableMultiselect,
   verticalDivider,
   noMinWidth,
+  column1Width,
+  column2Width,
+  column3Width,
+  column4Width,
 }) =>
   formatHtmlPreview(`
 <script>
@@ -140,10 +180,18 @@ const MultiselectTemplate = ({
         }
     >
           <sdds-table-header>
-              <sdds-header-cell column-key='truck' column-title='Truck type'></sdds-header-cell>
-              <sdds-header-cell column-key='driver' column-title='Driver name'></sdds-header-cell>
-              <sdds-header-cell column-key='country' column-title='Country'></sdds-header-cell>
-              <sdds-header-cell column-key='mileage' column-title='Mileage' text-align='right'></sdds-header-cell>
+              <sdds-header-cell column-key='truck' column-title='Truck type' ${
+                column1Width ? `custom-width="${column1Width}"` : ''
+              }></sdds-header-cell>
+              <sdds-header-cell column-key='driver' column-title='Driver name' ${
+                column2Width ? `custom-width="${column2Width}"` : ''
+              }></sdds-header-cell>
+              <sdds-header-cell column-key='country' column-title='Country' ${
+                column3Width ? `custom-width="${column3Width}"` : ''
+              }></sdds-header-cell>
+              <sdds-header-cell column-key='mileage' column-title='Mileage' text-align='right' ${
+                column4Width ? `custom-width="${column4Width}"` : ''
+              }></sdds-header-cell>
           </sdds-table-header>
           <sdds-table-body enable-dummy-data>
           </sdds-table-body>

--- a/tegel/src/components/data-table/table-component-multiselect.stories.tsx
+++ b/tegel/src/components/data-table/table-component-multiselect.stories.tsx
@@ -27,7 +27,7 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
-      description: 'The mode variant of the component',
+      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
@@ -43,58 +43,47 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     responsiveDesign: {
       name: 'Responsive table',
-      description:
-        'Table takes 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too. ',
+      description: 'Enables table to take 100% of available width. For column values less than 192px, "No minimum width" has to be enabled too.',
       control: {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     enableMultiselect: {
       name: 'Enable multiselect',
-      description: 'Enable row selection.',
+      description: 'Enables row selection.',
       control: {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: true,
-        },
+        defaultValue: { summary: true },
       },
     },
     verticalDivider: {
       name: 'Vertical dividers',
-      description: 'When enabled, table has vertical dividers between columns.',
+      description: 'Enables vertical dividers between table columns.',
       control: {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     noMinWidth: {
-      name: 'No column minimum width limitation',
-      description: 'Enable columns to shrink below width 192px.',
+      name: 'No minimum width',
+      description: 'Resets min-width rule and enables setting column width value to less than 192px which is the default. When enabled, controls for column width will show here.',
       control: {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: 'false',
-        },
+        defaultValue: { summary: false },
       },
     },
   },

--- a/tegel/src/components/data-table/table-component-multiselect.stories.tsx
+++ b/tegel/src/components/data-table/table-component-multiselect.stories.tsx
@@ -206,4 +206,3 @@ const MultiselectTemplate = ({
   </div>`);
 
 export const Multiselect = MultiselectTemplate.bind({});
-Multiselect.args = {};

--- a/tegel/src/components/data-table/table-component-pagination.stories.tsx
+++ b/tegel/src/components/data-table/table-component-pagination.stories.tsx
@@ -27,7 +27,7 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
-      description: 'The mode variant of the component',
+      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
@@ -43,58 +43,47 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     responsiveDesign: {
       name: 'Responsive table',
-      description:
-        'Table takes 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too. ',
+      description: 'Enables table to take 100% of available width. For column values less than 192px, "No minimum width" has to be enabled too.',
       control: {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     rowsPerPageControl: {
       name: 'Rows per page',
-      description: 'Specify how many rows per page user would like to see',
+      description: 'Specifies how many rows are shown per page.',
       control: {
         type: 'number',
       },
       table: {
-        defaultValue: {
-          summary: 4,
-        },
+        defaultValue: { summary: 4 },
       },
     },
     verticalDivider: {
       name: 'Vertical dividers',
-      description: 'When enabled, table has vertical dividers between columns.',
+      description: 'Enables vertical dividers between table columns.',
       control: {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: false },
       },
     },
     noMinWidth: {
-      name: 'No column minimum width limitation',
-      description: 'Enable columns to shrink below width 192px.',
+      name: 'No minimum width',
+      description: 'Resets min-width rule and enables setting column width value to less than 192px which is the default. When enabled, controls for column width will show here.',
       control: {
         type: 'boolean',
       },
       table: {
-        defaultValue: {
-          summary: 'false',
-        },
+        defaultValue: { summary: false },
       },
     },
   },

--- a/tegel/src/components/data-table/table-component-pagination.stories.tsx
+++ b/tegel/src/components/data-table/table-component-pagination.stories.tsx
@@ -86,6 +86,38 @@ export default {
         defaultValue: { summary: false },
       },
     },
+    column1Width: {
+      name: 'Column 1 width',
+      description:'Value of width for column 1. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
+    column2Width: {
+      name: 'Column 2 width',
+      description: 'Value of width for column 2. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
+    column3Width: {
+      name: 'Column 3 width',
+      description: 'Value of width for column 3. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
+    column4Width: {
+      name: 'Column 4 width',
+      description: 'Value of width for column 4. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
   },
   args: {
     modeVariant: 'Inherit from parent',
@@ -94,6 +126,10 @@ export default {
     rowsPerPageControl: 4,
     verticalDivider: false,
     noMinWidth: false,
+    column1Width: '',
+    column2Width: '',
+    column3Width: '',
+    column4Width: '',
   },
 };
 
@@ -104,6 +140,10 @@ const PaginationTemplate = ({
   rowsPerPageControl,
   verticalDivider,
   noMinWidth,
+  column1Width,
+  column2Width,
+  column3Width,
+  column4Width,
 }) =>
   formatHtmlPreview(`
     <sdds-table
@@ -114,10 +154,18 @@ const PaginationTemplate = ({
       ${modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''}
       >
           <sdds-table-header>
-              <sdds-header-cell column-key='truck' column-title='Truck type'></sdds-header-cell>
-              <sdds-header-cell column-key='driver' column-title='Driver name'></sdds-header-cell>
-              <sdds-header-cell column-key='country' column-title='Country'></sdds-header-cell>
-              <sdds-header-cell column-key='mileage' column-title='Mileage' text-align='right'></sdds-header-cell>
+              <sdds-header-cell column-key='truck' column-title='Truck type' ${
+                column1Width ? `custom-width="${column1Width}"` : ''
+              }></sdds-header-cell>
+              <sdds-header-cell column-key='driver' column-title='Driver name' ${
+                column2Width ? `custom-width="${column2Width}"` : ''
+              }></sdds-header-cell>
+              <sdds-header-cell column-key='country' column-title='Country' ${
+                column3Width ? `custom-width="${column3Width}"` : ''
+              }></sdds-header-cell>
+              <sdds-header-cell column-key='mileage' column-title='Mileage' text-align='right' ${
+                column4Width ? `custom-width="${column4Width}"` : ''
+              }></sdds-header-cell>
           </sdds-table-header>
           <sdds-table-body enable-dummy-data>
           </sdds-table-body>

--- a/tegel/src/components/data-table/table-component-pagination.stories.tsx
+++ b/tegel/src/components/data-table/table-component-pagination.stories.tsx
@@ -173,4 +173,3 @@ const PaginationTemplate = ({
   </sdds-table>`);
 
 export const Pagination = PaginationTemplate.bind({});
-Pagination.args = {};

--- a/tegel/src/components/data-table/table-component-pagination.stories.tsx
+++ b/tegel/src/components/data-table/table-component-pagination.stories.tsx
@@ -25,16 +25,15 @@ export default {
     },
   },
   argTypes: {
-    verticalDivider: {
-      name: 'Vertical dividers',
-      description: 'When enabled, table has vertical dividers between columns.',
+    modeVariant: {
+      name: 'Mode variant',
+      description: 'The mode variant of the component',
       control: {
-        type: 'boolean',
+        type: 'radio',
       },
+      options: ['Inherit from parent', 'Primary', 'Secondary'],
       table: {
-        defaultValue: {
-          summary: false,
-        },
+        defaultValue: { summary: 'Inherit from parent' },
       },
     },
     compactDesign: {
@@ -49,21 +48,34 @@ export default {
         },
       },
     },
-    modeVariant: {
-      name: 'Mode variant',
-      description: 'The mode variant of the component',
-      control: {
-        type: 'radio',
-      },
-      options: ['Inherit from parent', 'Primary', 'Secondary'],
-      table: {
-        defaultValue: { summary: 'Inherit from parent' },
-      },
-    },
     responsiveDesign: {
       name: 'Responsive table',
       description:
         'Table takes 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too. ',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: {
+          summary: false,
+        },
+      },
+    },
+    rowsPerPageControl: {
+      name: 'Rows per page',
+      description: 'Specify how many rows per page user would like to see',
+      control: {
+        type: 'number',
+      },
+      table: {
+        defaultValue: {
+          summary: 4,
+        },
+      },
+    },
+    verticalDivider: {
+      name: 'Vertical dividers',
+      description: 'When enabled, table has vertical dividers between columns.',
       control: {
         type: 'boolean',
       },
@@ -85,35 +97,23 @@ export default {
         },
       },
     },
-    rowsPerPageControl: {
-      name: 'Rows per page',
-      description: 'Specify how many rows per page user would like to see',
-      control: {
-        type: 'number',
-      },
-      table: {
-        defaultValue: {
-          summary: 4,
-        },
-      },
-    },
   },
   args: {
     modeVariant: 'Inherit from parent',
     compactDesign: false,
-    verticalDivider: false,
     responsiveDesign: false,
     rowsPerPageControl: 4,
+    verticalDivider: false,
     noMinWidth: false,
   },
 };
 
 const PaginationTemplate = ({
-  verticalDivider,
-  compactDesign,
   modeVariant,
-  rowsPerPageControl,
+  compactDesign,
   responsiveDesign,
+  rowsPerPageControl,
+  verticalDivider,
   noMinWidth,
 }) =>
   formatHtmlPreview(`

--- a/tegel/src/components/data-table/table-component-sorting.stories.tsx
+++ b/tegel/src/components/data-table/table-component-sorting.stories.tsx
@@ -62,18 +62,12 @@ export default {
       control: {
         type: 'boolean',
       },
-      table: {
-        defaultValue: { summary: true },
-      },
     },
     column2sortable: {
       name: 'Column 2 is sortable',
       description: 'Enables column 2 to be sorted alphabetically.',
       control: {
         type: 'boolean',
-      },
-      table: {
-        defaultValue: { summary: true },
       },
     },
     column3sortable: {
@@ -82,18 +76,12 @@ export default {
       control: {
         type: 'boolean',
       },
-      table: {
-        defaultValue: { summary: true },
-      },
     },
     column4sortable: {
       name: 'Column 4 is sortable',
       description: 'Enables column 4 to be sorted alphabetically.',
       control: {
         type: 'boolean',
-      },
-      table: {
-        defaultValue: { summary: true },
       },
     },
     verticalDivider: {

--- a/tegel/src/components/data-table/table-component-sorting.stories.tsx
+++ b/tegel/src/components/data-table/table-component-sorting.stories.tsx
@@ -27,7 +27,7 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
-      description: 'The mode variant of the component',
+      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
@@ -45,50 +45,49 @@ export default {
     },
     responsiveDesign: {
       name: 'Responsive design',
-      description:
-        'Table takes 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too.',
+      description: 'Enables table to take 100% of available width. For column values less than 192px, "No minimum width" has to be enabled too.',
       control: {
         type: 'boolean',
       },
     },
     column1sortable: {
       name: 'Column 1 is sortable',
-      description: 'Enabling column 1 to be sorted alphabetically.',
+      description: 'Enables column 1 to be sorted alphabetically.',
       control: {
         type: 'boolean',
       },
     },
     column2sortable: {
       name: 'Column 2 is sortable',
-      description: 'Enabling column 2 to be sorted alphabetically.',
+      description: 'Enables column 2 to be sorted alphabetically.',
       control: {
         type: 'boolean',
       },
     },
     column3sortable: {
       name: 'Column 3 is sortable',
-      description: 'Enabling column 3 to be sorted alphabetically.',
+      description: 'Enables column 3 to be sorted alphabetically.',
       control: {
         type: 'boolean',
       },
     },
     column4sortable: {
       name: 'Column 4 is sortable',
-      description: 'Enabling column 4 to be sorted alphabetically.',
+      description: 'Enables column 4 to be sorted alphabetically.',
       control: {
         type: 'boolean',
       },
     },
     verticalDivider: {
       name: 'Vertical dividers',
-      description: 'When enabled, table has vertical dividers between columns.',
+      description: 'Enables vertical dividers between table columns.',
       control: {
         type: 'boolean',
       },
     },
     noMinWidth: {
-      name: 'No column minimum width limitation',
-      description: 'Enable columns to shrink below width 192px.',
+      name: 'No minimum width',
+      description: 'Resets min-width rule and enables setting column width value to less than 192px which is the default. When enabled, controls for column width will show here.',
       control: {
         type: 'boolean',
       },

--- a/tegel/src/components/data-table/table-component-sorting.stories.tsx
+++ b/tegel/src/components/data-table/table-component-sorting.stories.tsx
@@ -209,4 +209,3 @@ const SortingTemplate = ({
   </sdds-table>`);
 
 export const Sorting = SortingTemplate.bind({});
-Sorting.args = {};

--- a/tegel/src/components/data-table/table-component-sorting.stories.tsx
+++ b/tegel/src/components/data-table/table-component-sorting.stories.tsx
@@ -116,6 +116,38 @@ export default {
         defaultValue: { summary: false },
       },
     },
+    column1Width: {
+      name: 'Column 1 width',
+      description:'Value of width for column 1. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
+    column2Width: {
+      name: 'Column 2 width',
+      description: 'Value of width for column 2. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
+    column3Width: {
+      name: 'Column 3 width',
+      description: 'Value of width for column 3. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
+    column4Width: {
+      name: 'Column 4 width',
+      description: 'Value of width for column 4. In order to work correctly "No minimum width" has to be enabled too. When editing please provide a unit next to the value, eg. 200px.',
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'noMinWidth', eq: true },
+    },
   },
   args: {
     modeVariant: 'Inherit from parent',
@@ -127,6 +159,10 @@ export default {
     column4sortable: true,
     verticalDivider: false,
     noMinWidth: false,
+    column1Width: '',
+    column2Width: '',
+    column3Width: '',
+    column4Width: '',
   },
 };
 
@@ -140,6 +176,10 @@ const SortingTemplate = ({
   column4sortable,
   verticalDivider,
   noMinWidth,
+  column1Width,
+  column2Width,
+  column3Width,
+  column4Width,
 }) =>
   formatHtmlPreview(`
     <sdds-table
@@ -151,10 +191,18 @@ const SortingTemplate = ({
     >
       <sdds-table-toolbar table-title="Sorting"></sdds-table-toolbar>
           <sdds-table-header>
-              <sdds-header-cell column-key='truck' column-title='Truck type' sortable="${column1sortable}"></sdds-header-cell>
-              <sdds-header-cell column-key='driver' column-title='Driver name' sortable="${column2sortable}"></sdds-header-cell>
-              <sdds-header-cell column-key='country' column-title='Country' sortable="${column3sortable}"></sdds-header-cell>
-              <sdds-header-cell column-key='mileage' column-title='Mileage' sortable="${column4sortable}" text-align='right'></sdds-header-cell>
+              <sdds-header-cell column-key='truck' column-title='Truck type' sortable="${column1sortable}" ${
+                column1Width ? `custom-width="${column1Width}"` : ''
+              }></sdds-header-cell>
+              <sdds-header-cell column-key='driver' column-title='Driver name' sortable="${column2sortable}" ${
+                column2Width ? `custom-width="${column2Width}"` : ''
+              }></sdds-header-cell>
+              <sdds-header-cell column-key='country' column-title='Country' sortable="${column3sortable}" ${
+                column3Width ? `custom-width="${column3Width}"` : ''
+              }></sdds-header-cell>
+              <sdds-header-cell column-key='mileage' column-title='Mileage' sortable="${column4sortable}" text-align='right' ${
+                column4Width ? `custom-width="${column4Width}"` : ''
+              }></sdds-header-cell>
           </sdds-table-header>
           <sdds-table-body enable-dummy-data>
           </sdds-table-body>

--- a/tegel/src/components/data-table/table-component-sorting.stories.tsx
+++ b/tegel/src/components/data-table/table-component-sorting.stories.tsx
@@ -42,12 +42,18 @@ export default {
       control: {
         type: 'boolean',
       },
+      table: {
+        defaultValue: { summary: false },
+      },
     },
     responsiveDesign: {
       name: 'Responsive design',
       description: 'Enables table to take 100% of available width. For column values less than 192px, "No minimum width" has to be enabled too.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
       },
     },
     column1sortable: {
@@ -56,12 +62,18 @@ export default {
       control: {
         type: 'boolean',
       },
+      table: {
+        defaultValue: { summary: true },
+      },
     },
     column2sortable: {
       name: 'Column 2 is sortable',
       description: 'Enables column 2 to be sorted alphabetically.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: true },
       },
     },
     column3sortable: {
@@ -70,12 +82,18 @@ export default {
       control: {
         type: 'boolean',
       },
+      table: {
+        defaultValue: { summary: true },
+      },
     },
     column4sortable: {
       name: 'Column 4 is sortable',
       description: 'Enables column 4 to be sorted alphabetically.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: true },
       },
     },
     verticalDivider: {
@@ -84,12 +102,18 @@ export default {
       control: {
         type: 'boolean',
       },
+      table: {
+        defaultValue: { summary: false },
+      },
     },
     noMinWidth: {
       name: 'No minimum width',
       description: 'Resets min-width rule and enables setting column width value to less than 192px which is the default. When enabled, controls for column width will show here.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
       },
     },
   },

--- a/tegel/src/components/data-table/table-component-sorting.stories.tsx
+++ b/tegel/src/components/data-table/table-component-sorting.stories.tsx
@@ -25,20 +25,6 @@ export default {
     },
   },
   argTypes: {
-    verticalDivider: {
-      name: 'Vertical dividers',
-      description: 'When enabled, table has vertical dividers between columns.',
-      control: {
-        type: 'boolean',
-      },
-    },
-    compactDesign: {
-      name: 'Compact Design',
-      description: 'Enables compact design of the table, rows with less height.',
-      control: {
-        type: 'boolean',
-      },
-    },
     modeVariant: {
       name: 'Mode variant',
       description: 'The mode variant of the component',
@@ -50,17 +36,17 @@ export default {
         defaultValue: { summary: 'Inherit from parent' },
       },
     },
-    responsiveDesign: {
-      name: 'Responsive design',
-      description:
-        'Table takes 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too.',
+    compactDesign: {
+      name: 'Compact Design',
+      description: 'Enables compact design of the table, rows with less height.',
       control: {
         type: 'boolean',
       },
     },
-    noMinWidth: {
-      name: 'No column minimum width limitation',
-      description: 'Enable columns to shrink below width 192px.',
+    responsiveDesign: {
+      name: 'Responsive design',
+      description:
+        'Table takes 100% of available width. For column values less then 192px, "No minimum width" has to be enabled too.',
       control: {
         type: 'boolean',
       },
@@ -93,29 +79,43 @@ export default {
         type: 'boolean',
       },
     },
+    verticalDivider: {
+      name: 'Vertical dividers',
+      description: 'When enabled, table has vertical dividers between columns.',
+      control: {
+        type: 'boolean',
+      },
+    },
+    noMinWidth: {
+      name: 'No column minimum width limitation',
+      description: 'Enable columns to shrink below width 192px.',
+      control: {
+        type: 'boolean',
+      },
+    },
   },
   args: {
     modeVariant: 'Inherit from parent',
-    verticalDivider: false,
     compactDesign: false,
     responsiveDesign: false,
     column1sortable: true,
     column2sortable: true,
     column3sortable: true,
     column4sortable: true,
+    verticalDivider: false,
     noMinWidth: false,
   },
 };
 
 const SortingTemplate = ({
-  verticalDivider,
-  compactDesign,
   modeVariant,
+  compactDesign,
   responsiveDesign,
   column1sortable,
   column2sortable,
   column3sortable,
   column4sortable,
+  verticalDivider,
   noMinWidth,
 }) =>
   formatHtmlPreview(`


### PR DESCRIPTION
**Describe pull-request**  
Standardised order of controls in Storybook for data table component. Also updated descriptions, refactored deprecated controls and introduced noMinWidth controls with custom width input to all sub-stories.

**Solving issue**  
Fixes: [AB#DTS-708](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-708)

**How to test**  
_Add description how to test if possible_
1. Go to Storybook link below
2. Check in Data Table -> All sub stories
3. Inspect order of controls
4. Read control descriptions

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events