### PR TITLE
fix(footer): standardise order of controls in Storybook

### DIFF
--- a/tegel/src/components/footer/footer.stories.tsx
+++ b/tegel/src/components/footer/footer.stories.tsx
@@ -22,23 +22,23 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
+      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
       options: ['Inherit from parent', 'Primary', 'Secondary'],
-      description: 'Footer mode variant',
       table: {
         defaultValue: { summary: 'Inherit from parent' },
       },
     },
     topPart: {
       name: 'Top part',
-      description: 'Adds top part of the footer with more links',
-      table: {
-        defaultValue: { summary: false },
-      },
+      description: 'Adds the top part of the footer with more links.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
       },
     },
   },

--- a/tegel/src/components/footer/webcomponent/sdds-footer.stories.tsx
+++ b/tegel/src/components/footer/webcomponent/sdds-footer.stories.tsx
@@ -40,13 +40,13 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: { summary: true },
+        defaultValue: { summary: false },
       },
     },
   },
   args: {
     modeVariant: 'Inherit from parent',
-    topPart: true,
+    topPart: false,
   },
 };
 

--- a/tegel/src/components/footer/webcomponent/sdds-footer.stories.tsx
+++ b/tegel/src/components/footer/webcomponent/sdds-footer.stories.tsx
@@ -24,20 +24,23 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
+      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
       options: ['Inherit from parent', 'Primary', 'Secondary'],
-      description: 'Footer mode variant',
       table: {
         defaultValue: { summary: 'Inherit from parent' },
       },
     },
     topPart: {
       name: 'Top part',
-      description: 'Adds the top part of the footer',
+      description: 'Adds the top part of the footer with more links.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: true },
       },
     },
   },


### PR DESCRIPTION
**Describe pull-request**  
Updated control descriptions in footer Storybook file.

**Solving issue**  
Fixes: [AB#3434](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3434)

**How to test**  
_Add description how to test if possible_
1. Go to Storybook link below
2. Check in Footer -> Web Component and Native
3. inspect order of controls
4. Read control descriptions 

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events