### PR TITLE
fix(link): standardise order of controls in Storybook

### DIFF
--- a/tegel/src/components/link/link.stories.tsx
+++ b/tegel/src/components/link/link.stories.tsx
@@ -20,9 +20,12 @@ export default {
   argTypes: {
     underline: {
       name: 'Underline',
-      description: 'Hide underline under link text',
+      description: 'Adds an underline under the link text.',
       controls: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: true },
       },
     },
     disabled: {
@@ -30,6 +33,9 @@ export default {
       description: 'Disables the link.',
       controls: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
       },
     },
   },

--- a/tegel/src/components/link/link.stories.tsx
+++ b/tegel/src/components/link/link.stories.tsx
@@ -27,14 +27,14 @@ export default {
     },
     disabled: {
       name: 'Disabled',
-      description: 'Display link in disabled state',
+      description: 'Disables the link.',
       controls: {
         type: 'boolean',
       },
     },
   },
   args: {
-    underline: false,
+    underline: true,
     disabled: false,
   },
 };

--- a/tegel/src/components/link/link.stories.tsx
+++ b/tegel/src/components/link/link.stories.tsx
@@ -18,8 +18,8 @@ export default {
     ],
   },
   argTypes: {
-    noUnderline: {
-      name: 'No underline',
+    underline: {
+      name: 'Underline',
       description: 'Hide underline under link text',
       controls: {
         type: 'boolean',
@@ -34,16 +34,16 @@ export default {
     },
   },
   args: {
-    noUnderline: false,
+    underline: false,
     disabled: false,
   },
 };
 
-const Template = ({ noUnderline, disabled }) =>
+const Template = ({ underline, disabled }) =>
   formatHtmlPreview(
     `
       <a class="sdds-link ${disabled ? 'disabled' : ''} ${
-      noUnderline ? 'sdds-link--no-underline' : ''
+      underline ? '' : 'sdds-link--no-underline'
     }" href="#">
         This is a link.
       </a>

--- a/tegel/src/components/link/link.stories.tsx
+++ b/tegel/src/components/link/link.stories.tsx
@@ -18,13 +18,6 @@ export default {
     ],
   },
   argTypes: {
-    disabled: {
-      name: 'Disabled',
-      description: 'Display link in disabled state',
-      controls: {
-        type: 'boolean',
-      },
-    },
     noUnderline: {
       name: 'No underline',
       description: 'Hide underline under link text',
@@ -32,14 +25,21 @@ export default {
         type: 'boolean',
       },
     },
+    disabled: {
+      name: 'Disabled',
+      description: 'Display link in disabled state',
+      controls: {
+        type: 'boolean',
+      },
+    },
   },
   args: {
-    disabled: false,
     noUnderline: false,
+    disabled: false,
   },
 };
 
-const Template = ({ disabled, noUnderline }) =>
+const Template = ({ noUnderline, disabled }) =>
   formatHtmlPreview(
     `
       <a class="sdds-link ${disabled ? 'disabled' : ''} ${

--- a/tegel/src/components/link/sdds-link.stories.tsx
+++ b/tegel/src/components/link/sdds-link.stories.tsx
@@ -22,7 +22,7 @@ export default {
   argTypes: {
     underline: {
       name: 'Underline',
-      description: 'Underline under link text.',
+      description: 'Adds an underline under the link text.',
       controls: {
         type: 'boolean',
       },
@@ -32,7 +32,7 @@ export default {
     },
     target: {
       name: 'Target',
-      description: 'Where to open the linked URL.',
+      description: 'Sets where to open the linked URL.',
       control: {
         type: 'radio',
       },
@@ -43,7 +43,7 @@ export default {
     },
     disabled: {
       name: 'Disabled',
-      description: 'Display link in disabled state',
+      description: 'Disables the link.',
       controls: {
         type: 'boolean',
       },

--- a/tegel/src/components/link/sdds-link.stories.tsx
+++ b/tegel/src/components/link/sdds-link.stories.tsx
@@ -27,7 +27,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: { summary: 'true' },
+        defaultValue: { summary: true },
       },
     },
     target: {
@@ -48,7 +48,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: { summary: 'false' },
+        defaultValue: { summary: false },
       },
     },
   },

--- a/tegel/src/components/link/sdds-link.stories.tsx
+++ b/tegel/src/components/link/sdds-link.stories.tsx
@@ -20,16 +20,6 @@ export default {
     ],
   },
   argTypes: {
-    disabled: {
-      name: 'Disabled',
-      description: 'Display link in disabled state',
-      controls: {
-        type: 'boolean',
-      },
-      table: {
-        defaultValue: { summary: 'false' },
-      },
-    },
     underline: {
       name: 'Underline',
       description: 'Underline under link text.',
@@ -51,15 +41,25 @@ export default {
         defaultValue: { summary: '_self' },
       },
     },
+    disabled: {
+      name: 'Disabled',
+      description: 'Display link in disabled state',
+      controls: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: 'false' },
+      },
+    },
   },
   args: {
-    disabled: false,
     underline: true,
     target: '_self',
+    disabled: false,
   },
 };
 
-const Template = ({ disabled, underline, target }) =>
+const Template = ({ underline, target, disabled }) =>
   formatHtmlPreview(
     `
     <sdds-link


### PR DESCRIPTION
**Describe pull-request**  
Standardised order of controls in Storybook for link component. Also updated descriptions and added default values to controls.

**Solving issue**  
Fixes: [AB#3436](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3436)

**How to test**  
_Add description how to test if possible_
1. Go to Storybook link below
2. Check in Link -> Web Component and Native
3. Inspect order of controls
4. Read control descriptions

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events