### PR TITLE
fix(message): standardise order of controls in Storybook

### DIFF
--- a/tegel/src/components/message/message.scss
+++ b/tegel/src/components/message/message.scss
@@ -5,13 +5,12 @@
   @include sdds-box-sizing;
 
   display: block;
-  padding: 16px 32px 16px 20px;
+  padding: 16px;
   border-radius: 4px;
   position: relative;
   overflow: hidden;
   color: var(--sdds-grey-958);
   background-color: var(--sdds-message-background);
-  margin-bottom: 12px;
 
   &-single {
     font: var(--sdds-headline-07);
@@ -57,7 +56,7 @@
   /* modifiers */
 
   &-icon-active {
-    padding: 18px 32px 18px 20px;
+    padding: 18px;
 
     .sdds-message-single,
     .sdds-message-extended {

--- a/tegel/src/components/message/message.stories.tsx
+++ b/tegel/src/components/message/message.stories.tsx
@@ -111,6 +111,11 @@ const Template = ({
 
   return formatHtmlPreview(
     `
+    <style>
+      .demo-wrapper {
+        width: 380px;
+      }
+    </style>
 
     ${
       iconType === 'Native'
@@ -120,20 +125,21 @@ const Template = ({
     </style>`
         : ''
     }
-
-    <div class="sdds-message ${messageTypeClass} ${noIcon ? '' : 'sdds-message-icon-active'} ${
-      showExtendedMessage ? 'sdds-message-extended-active' : ''
-    } 
-    ${modeVariant === 'Inherit from parent' ? '' : `sdds-mode-variant-${modeVariant.toLowerCase()}`}">
-    ${noIcon ? '' : iconHtml}
-    <h4 class="sdds-message-single">
-      Single line message goes here.
-    </h4>
-    ${
-      showExtendedMessage
-        ? '<p class="sdds-message-extended">Longer message text can be placed here. Longer message text can be placed here. Longer message text can be placed here.</p>'
-        : ''
-    }
+    <div class="demo-wrapper">
+      <div class="sdds-message ${messageTypeClass} ${noIcon ? '' : 'sdds-message-icon-active'} ${
+        showExtendedMessage ? 'sdds-message-extended-active' : ''
+      } 
+      ${modeVariant === 'Inherit from parent' ? '' : `sdds-mode-variant-${modeVariant.toLowerCase()}`}">
+      ${noIcon ? '' : iconHtml}
+      <h4 class="sdds-message-single">
+        Single line message goes here.
+      </h4>
+      ${
+        showExtendedMessage
+          ? '<p class="sdds-message-extended">Longer message text can be placed here. Longer message text can be placed here.</p>'
+          : ''
+      }
+    </div>
   </div>
   `,
   );

--- a/tegel/src/components/message/message.stories.tsx
+++ b/tegel/src/components/message/message.stories.tsx
@@ -47,12 +47,12 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: { summary: false },
+        defaultValue: { summary: true },
       },
     },
-    icon: {
-      name: 'Icon',
-      description: 'Shows the icon.',
+    noIcon: {
+      name: 'No icon',
+      description: 'Hides the icon.',
       control: {
         type: 'boolean',
       },
@@ -76,8 +76,8 @@ export default {
   args: {
     modeVariant: 'Inherit from parent',
     messageType: 'Information',
-    showExtendedMessage: false,
-    icon: false,
+    showExtendedMessage: true,
+    noIcon: false,
     iconType: 'Web Component',
   },
 };
@@ -93,7 +93,7 @@ const Template = ({
   modeVariant, 
   messageType, 
   showExtendedMessage, 
-  icon, 
+  noIcon, 
   iconType 
 }) => {
   const messageTypeClass =
@@ -121,11 +121,11 @@ const Template = ({
         : ''
     }
 
-    <div class="sdds-message ${messageTypeClass} ${icon ? 'sdds-message-icon-active' : ''} ${
+    <div class="sdds-message ${messageTypeClass} ${noIcon ? '' : 'sdds-message-icon-active'} ${
       showExtendedMessage ? 'sdds-message-extended-active' : ''
     } 
     ${modeVariant === 'Inherit from parent' ? '' : `sdds-mode-variant-${modeVariant.toLowerCase()}`}">
-    ${icon ? iconHtml : ''}
+    ${noIcon ? '' : iconHtml}
     <h4 class="sdds-message-single">
       Single line message goes here.
     </h4>

--- a/tegel/src/components/message/message.stories.tsx
+++ b/tegel/src/components/message/message.stories.tsx
@@ -20,7 +20,7 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
-      description: 'The mode variant of the component',
+      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
@@ -30,30 +30,30 @@ export default {
       },
     },
     messageType: {
-      name: 'Message Type',
-      description: 'The type of the message.',
+      name: 'Message type',
+      description: 'Changes the type of the component.',
       control: {
         type: 'radio',
       },
       options: ['Information', 'Error', 'Warning', 'Success'],
     },
     showExtendedMessage: {
-      name: 'Extended Message',
-      description: 'Show an extended message',
+      name: 'Extended message',
+      description: 'Shows an extended message.',
       control: {
         type: 'boolean',
       },
     },
     icon: {
       name: 'Icon',
-      description: 'Show icon',
+      description: 'Shows the icon.',
       control: {
         type: 'boolean',
       },
     },
     iconType: {
-      name: 'Icon',
-      description: 'Switch between show a native/web component icon.',
+      name: 'Icon type',
+      description: 'Switch between showing a native or a web component icon.',
       control: {
         type: 'radio',
       },

--- a/tegel/src/components/message/message.stories.tsx
+++ b/tegel/src/components/message/message.stories.tsx
@@ -36,6 +36,9 @@ export default {
         type: 'radio',
       },
       options: ['Information', 'Error', 'Warning', 'Success'],
+      table: {
+        defaultValue: { summary: 'Information' },
+      },
     },
     showExtendedMessage: {
       name: 'Extended message',
@@ -43,12 +46,18 @@ export default {
       control: {
         type: 'boolean',
       },
+      table: {
+        defaultValue: { summary: false },
+      },
     },
     icon: {
       name: 'Icon',
       description: 'Shows the icon.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
       },
     },
     iconType: {
@@ -59,6 +68,9 @@ export default {
       },
       options: ['Native', 'Web Component'],
       if: { arg: 'icon', eq: true },
+      table: {
+        defaultValue: { summary: 'Web Component' },
+      },
     },
   },
   args: {

--- a/tegel/src/components/message/message.stories.tsx
+++ b/tegel/src/components/message/message.stories.tsx
@@ -18,14 +18,6 @@ export default {
     ],
   },
   argTypes: {
-    messageType: {
-      name: 'Message Type',
-      description: 'The type of the message.',
-      control: {
-        type: 'radio',
-      },
-      options: ['Information', 'Error', 'Warning', 'Success'],
-    },
     modeVariant: {
       name: 'Mode variant',
       description: 'The mode variant of the component',
@@ -35,6 +27,21 @@ export default {
       options: ['Inherit from parent', 'Primary', 'Secondary'],
       table: {
         defaultValue: { summary: 'Inherit from parent' },
+      },
+    },
+    messageType: {
+      name: 'Message Type',
+      description: 'The type of the message.',
+      control: {
+        type: 'radio',
+      },
+      options: ['Information', 'Error', 'Warning', 'Success'],
+    },
+    showExtendedMessage: {
+      name: 'Extended Message',
+      description: 'Show an extended message',
+      control: {
+        type: 'boolean',
       },
     },
     icon: {
@@ -53,20 +60,13 @@ export default {
       options: ['Native', 'Web Component'],
       if: { arg: 'icon', eq: true },
     },
-    showExtendedMessage: {
-      name: 'Extended Message',
-      description: 'Show an extended message',
-      control: {
-        type: 'boolean',
-      },
-    },
   },
   args: {
-    messageType: 'Information',
     modeVariant: 'Inherit from parent',
+    messageType: 'Information',
+    showExtendedMessage: false,
     icon: false,
     iconType: 'Web Component',
-    showExtendedMessage: false,
   },
 };
 
@@ -77,7 +77,13 @@ const nativeIconNameLookup = {
   Success: 'tick',
 };
 
-const Template = ({ messageType, icon, iconType, showExtendedMessage, modeVariant }) => {
+const Template = ({ 
+  modeVariant, 
+  messageType, 
+  showExtendedMessage, 
+  icon, 
+  iconType 
+}) => {
   const messageTypeClass =
     messageType === 'Information'
       ? 'sdds-message-type-informative'

--- a/tegel/src/components/message/sdds-message.stories.tsx
+++ b/tegel/src/components/message/sdds-message.stories.tsx
@@ -20,17 +20,6 @@ export default {
     ],
   },
   argTypes: {
-    messageType: {
-      name: 'Message Type',
-      description: 'The type of the message.',
-      control: {
-        type: 'radio',
-      },
-      options: ['Information', 'Error', 'Warning', 'Success'],
-      table: {
-        defaultValue: { summary: 'information' },
-      },
-    },
     modeVariant: {
       name: 'Mode variant',
       description: 'The mode variant of the component',
@@ -40,6 +29,17 @@ export default {
       options: ['Inherit from parent', 'Primary', 'Secondary'],
       table: {
         defaultValue: { summary: 'Inherit from parent' },
+      },
+    },
+    messageType: {
+      name: 'Message Type',
+      description: 'The type of the message.',
+      control: {
+        type: 'radio',
+      },
+      options: ['Information', 'Error', 'Warning', 'Success'],
+      table: {
+        defaultValue: { summary: 'information' },
       },
     },
     header: {
@@ -55,16 +55,6 @@ export default {
         type: 'text',
       },
     },
-    noIcon: {
-      name: 'No icon',
-      description: 'Hide the icon',
-      control: {
-        type: 'boolean',
-      },
-      table: {
-        defaultValue: { summary: 'false' },
-      },
-    },
     minimal: {
       name: 'Minimal',
       description: 'Minimal message styling.',
@@ -75,19 +65,35 @@ export default {
         defaultValue: { summary: 'false' },
       },
     },
+    noIcon: {
+      name: 'No icon',
+      description: 'Hide the icon',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: 'false' },
+      },
+    },
   },
   args: {
-    messageType: 'Information',
     modeVariant: 'Inherit from parent',
+    messageType: 'Information',
     header: 'Message header',
-    noIcon: false,
-    extendedMessage:
-      'Longer message text can be placed here. Longer message text can be placed here.',
+    extendedMessage: 'Longer message text can be placed here. Longer message text can be placed here.',
     minimal: false,
+    noIcon: false,
   },
 };
 
-const Template = ({ messageType, noIcon, extendedMessage, modeVariant, header, minimal }) =>
+const Template = ({ 
+  modeVariant, 
+  messageType, 
+  header, 
+  extendedMessage, 
+  minimal, 
+  noIcon
+}) =>
   formatHtmlPreview(
     `
     <style>

--- a/tegel/src/components/message/sdds-message.stories.tsx
+++ b/tegel/src/components/message/sdds-message.stories.tsx
@@ -22,7 +22,7 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
-      description: 'The mode variant of the component',
+      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
@@ -32,8 +32,8 @@ export default {
       },
     },
     messageType: {
-      name: 'Message Type',
-      description: 'The type of the message.',
+      name: 'Message type',
+      description: 'Changes the type of the component.',
       control: {
         type: 'radio',
       },
@@ -44,20 +44,21 @@ export default {
     },
     header: {
       name: 'Header',
-      description: 'Header for the message',
+      description: 'Sets the header for the message.',
       control: {
         type: 'text',
       },
     },
     extendedMessage: {
       name: 'Extended message content',
+      description: 'Sets the content of an extended message.',
       control: {
         type: 'text',
       },
     },
     minimal: {
       name: 'Minimal',
-      description: 'Minimal message styling.',
+      description: 'Applies minimal message styling.',
       control: {
         type: 'boolean',
       },
@@ -67,7 +68,7 @@ export default {
     },
     noIcon: {
       name: 'No icon',
-      description: 'Hide the icon',
+      description: 'Hides the icon.',
       control: {
         type: 'boolean',
       },


### PR DESCRIPTION
**Describe pull-request**  
Standardised order of controls in Storybook for message component. Also updated descriptions and added default values to controls.

**Solving issue**  
Fixes: [AB#3437](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3437)

**How to test**  
_Add description how to test if possible_
1. Go to Storybook link below
2. Check in Message-> Web Component and Native
3. Inspect order of controls
4. Read control descriptions

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events