### PR TITLE
fix(modal): standardise order of controls in Storybook

### DIFF
--- a/tegel/src/components/modal/modal-native.stories.tsx
+++ b/tegel/src/components/modal/modal-native.stories.tsx
@@ -18,21 +18,6 @@ export default {
     ],
   },
   argTypes: {
-    size: {
-      name: 'Size',
-      description: 'Size of modal',
-      control: {
-        type: 'radio',
-      },
-      options: ['Large', 'Medium', 'Small', 'Extra small'],
-    },
-    showModal: {
-      name: 'Show modal',
-      description: 'Toggle if the modal is displayed',
-      control: {
-        type: 'boolean',
-      },
-    },
     actions: {
       name: 'Actions',
       description: 'Behaviour of modal actions',
@@ -40,6 +25,14 @@ export default {
         type: 'radio',
       },
       options: ['Sticky', 'Static'],
+    },
+    size: {
+      name: 'Size',
+      description: 'Size of modal',
+      control: {
+        type: 'radio',
+      },
+      options: ['Large', 'Medium', 'Small', 'Extra small'],
     },
     headline: {
       name: 'Modal headline',
@@ -55,13 +48,19 @@ export default {
         type: 'text',
       },
     },
+    showModal: {
+      name: 'Show modal',
+      description: 'Toggle if the modal is displayed',
+      control: {
+        type: 'boolean',
+      },
+    },
   },
   args: {
-    headline: 'The buttons for the modal only works in the canvas tab',
-    bodyText:
-      'The steps fell lightly and oddly, with a certain swing, for all they went so slowly; it was different indeed from the heavy creaking tread of Henry Jekyll. Utterson sighed. “Is there never anything else?” he asked.',
     actions: 'Static',
     size: 'Large',
+    headline: 'The buttons for the modal only works in the canvas tab',
+    bodyText: 'The steps fell lightly and oddly, with a certain swing, for all they went so slowly; it was different indeed from the heavy creaking tread of Henry Jekyll. Utterson sighed. “Is there never anything else?” he asked.',
     showModal: true,
   },
 };
@@ -73,7 +72,13 @@ const sizeLookUp = {
   'Extra small': 'xs',
 };
 
-const Template = ({ headline, bodyText, size, actions, showModal }) =>
+const Template = ({ 
+  actions, 
+  size, 
+  headline, 
+  bodyText, 
+  showModal 
+}) =>
   formatHtmlPreview(
     `    <style>
   /* demo-wrapper and demo-styles is for demonstration purposes only*/

--- a/tegel/src/components/modal/modal-native.stories.tsx
+++ b/tegel/src/components/modal/modal-native.stories.tsx
@@ -150,5 +150,3 @@ const Template = ({
   );
 
 export const Native = Template.bind({});
-
-Native.args = {};

--- a/tegel/src/components/modal/modal-native.stories.tsx
+++ b/tegel/src/components/modal/modal-native.stories.tsx
@@ -25,6 +25,9 @@ export default {
         type: 'radio',
       },
       options: ['Sticky', 'Static'],
+      table: {
+        defaultValue: { summary: 'Static' },
+      },
     },
     size: {
       name: 'Size',
@@ -33,6 +36,9 @@ export default {
         type: 'radio',
       },
       options: ['Large', 'Medium', 'Small', 'Extra small'],
+      table: {
+        defaultValue: { summary: 'Large' },
+      },
     },
     headline: {
       name: 'Modal headline',
@@ -53,6 +59,9 @@ export default {
       description: 'Toggles if the modal is displayed.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: true },
       },
     },
   },

--- a/tegel/src/components/modal/modal-native.stories.tsx
+++ b/tegel/src/components/modal/modal-native.stories.tsx
@@ -20,7 +20,7 @@ export default {
   argTypes: {
     actions: {
       name: 'Actions',
-      description: 'Behaviour of modal actions',
+      description: 'Defines the behaviour of modal.',
       control: {
         type: 'radio',
       },
@@ -28,7 +28,7 @@ export default {
     },
     size: {
       name: 'Size',
-      description: 'Size of modal',
+      description: 'Sets the size of modal.',
       control: {
         type: 'radio',
       },
@@ -36,21 +36,21 @@ export default {
     },
     headline: {
       name: 'Modal headline',
-      description: 'Customize headline',
+      description: 'Sets the headline of the modal.',
       control: {
         type: 'text',
       },
     },
     bodyText: {
       name: 'Modal body text',
-      description: 'Customize body text',
+      description: 'Sets the body text of the modal.',
       control: {
         type: 'text',
       },
     },
     showModal: {
       name: 'Show modal',
-      description: 'Toggle if the modal is displayed',
+      description: 'Toggles if the modal is displayed.',
       control: {
         type: 'boolean',
       },

--- a/tegel/src/components/modal/modal-webcomponent.stories.tsx
+++ b/tegel/src/components/modal/modal-webcomponent.stories.tsx
@@ -56,12 +56,23 @@ export default {
         type: 'text',
       },
     },
+    showModal: {
+      name: 'Show modal',
+      description: 'Toggles if the modal is displayed.',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: true },
+      },
+    },
   },
   args: {
     actions: 'Static',
     size: 'Large',
     headline: 'The buttons for the modal only works in the canvas tab',
     bodyText:'The steps fell lightly and oddly, with a certain swing, for all they went so slowly; it was different indeed from the heavy creaking tread of Henry Jekyll. Utterson sighed. “Is there never anything else?” he asked.',
+    showModal: true,
   },
 };
 
@@ -76,13 +87,14 @@ const ModalTemplate = ({
   actions, 
   size, 
   headline, 
-  bodyText 
+  bodyText,
+  showModal 
 }) =>
   formatHtmlPreview(
     `
   <button id="my-modal-button" class="sdds-btn sdds-btn-primary">Open modal</button>
 
-  <sdds-modal open id="my-modal" size="${sizeLookUp[size]}" actions="${actions.toLowerCase()}">
+  <sdds-modal ${showModal ? 'open' : ''} id="my-modal" size="${sizeLookUp[size]}" actions="${actions.toLowerCase()}">
       <h5 class="sdds-modal-headline" slot="sdds-modal-headline">${headline}</h5>
       <span slot="sdds-modal-body">
           ${bodyText}

--- a/tegel/src/components/modal/modal-webcomponent.stories.tsx
+++ b/tegel/src/components/modal/modal-webcomponent.stories.tsx
@@ -22,7 +22,7 @@ export default {
   argTypes: {
     actions: {
       name: 'Actions',
-      description: 'Behaviour of modal actions',
+      description: 'Defines the behaviour of modal.',
       control: {
         type: 'radio',
       },
@@ -30,7 +30,7 @@ export default {
     },
     size: {
       name: 'Size',
-      description: 'Size of modal',
+      description: 'Sets the size of modal.',
       control: {
         type: 'radio',
       },
@@ -38,14 +38,14 @@ export default {
     },
     headline: {
       name: 'Modal headline',
-      description: 'Customize headline',
+      description: 'Sets the headline of the modal.',
       control: {
         type: 'text',
       },
     },
     bodyText: {
       name: 'Modal body text',
-      description: 'Customize body text',
+      description: 'Sets the body text of the modal.',
       control: {
         type: 'text',
       },

--- a/tegel/src/components/modal/modal-webcomponent.stories.tsx
+++ b/tegel/src/components/modal/modal-webcomponent.stories.tsx
@@ -20,14 +20,6 @@ export default {
     ],
   },
   argTypes: {
-    size: {
-      name: 'Size',
-      description: 'Size of modal',
-      control: {
-        type: 'radio',
-      },
-      options: ['Large', 'Medium', 'Small', 'Extra small'],
-    },
     actions: {
       name: 'Actions',
       description: 'Behaviour of modal actions',
@@ -35,6 +27,14 @@ export default {
         type: 'radio',
       },
       options: ['Sticky', 'Static'],
+    },
+    size: {
+      name: 'Size',
+      description: 'Size of modal',
+      control: {
+        type: 'radio',
+      },
+      options: ['Large', 'Medium', 'Small', 'Extra small'],
     },
     headline: {
       name: 'Modal headline',
@@ -52,11 +52,10 @@ export default {
     },
   },
   args: {
-    headline: 'The buttons for the modal only works in the canvas tab',
-    bodyText:
-      'The steps fell lightly and oddly, with a certain swing, for all they went so slowly; it was different indeed from the heavy creaking tread of Henry Jekyll. Utterson sighed. “Is there never anything else?” he asked.',
     actions: 'Static',
     size: 'Large',
+    headline: 'The buttons for the modal only works in the canvas tab',
+    bodyText:'The steps fell lightly and oddly, with a certain swing, for all they went so slowly; it was different indeed from the heavy creaking tread of Henry Jekyll. Utterson sighed. “Is there never anything else?” he asked.',
   },
 };
 
@@ -67,7 +66,12 @@ const sizeLookUp = {
   'Extra small': 'xs',
 };
 
-const ModalTemplate = ({ size, headline, bodyText, actions }) =>
+const ModalTemplate = ({ 
+  actions, 
+  size, 
+  headline, 
+  bodyText 
+}) =>
   formatHtmlPreview(
     `
   <button id="my-modal-button" class="sdds-btn sdds-btn-primary">Open modal</button>

--- a/tegel/src/components/modal/modal-webcomponent.stories.tsx
+++ b/tegel/src/components/modal/modal-webcomponent.stories.tsx
@@ -101,5 +101,3 @@ const ModalTemplate = ({
   );
 
 export const WebComponent = ModalTemplate.bind({});
-
-WebComponent.args = {};

--- a/tegel/src/components/modal/modal-webcomponent.stories.tsx
+++ b/tegel/src/components/modal/modal-webcomponent.stories.tsx
@@ -27,6 +27,9 @@ export default {
         type: 'radio',
       },
       options: ['Sticky', 'Static'],
+      table: {
+        defaultValue: { summary: 'Static' },
+      },
     },
     size: {
       name: 'Size',
@@ -35,6 +38,9 @@ export default {
         type: 'radio',
       },
       options: ['Large', 'Medium', 'Small', 'Extra small'],
+      table: {
+        defaultValue: { summary: 'lg' },
+      },
     },
     headline: {
       name: 'Modal headline',


### PR DESCRIPTION
**Describe pull-request**  
Standardised order of controls in Storybook for modal component. Also updated descriptions and added default values to controls.

**Solving issue**  
Fixes: [AB#3438](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3438)

**How to test**  
_Add description how to test if possible_
1. Go to Storybook link below
2. Check in Modal-> Web Component and Native
3. Inspect order of controls
4. Read control descriptions

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events