### PR TITLE
fix(radio button): standardise order of controls in Storybook

### DIFF
--- a/tegel/src/components/radio-button/radio-button-component.stories.tsx
+++ b/tegel/src/components/radio-button/radio-button-component.stories.tsx
@@ -60,8 +60,6 @@ const Template = ({label, disabled}) =>
     name="rb-example"
     value="option1"
     radio-id="option-1"
-    aria-labelled-by="option-1"
-    aria-describedby="option-1"
     required=false
     ${disabled ? 'disabled' : ''}
     checked="true" 
@@ -73,8 +71,6 @@ const Template = ({label, disabled}) =>
     name="rb-example"
     value="option2"
     radio-id="option-2"
-    aria-labelled-by="option-2"
-    aria-described-by="option-2"
     ${label ? `label="${label} 2"` : ''}
     required=false
     ${disabled ? 'disabled' : ''} 

--- a/tegel/src/components/radio-button/radio-button-component.stories.tsx
+++ b/tegel/src/components/radio-button/radio-button-component.stories.tsx
@@ -71,7 +71,6 @@ const Template = ({label, disabled}) =>
     name="rb-example"
     value="option2"
     radio-id="option-2"
-    ${label ? `label="${label} 2"` : ''}
     required=false
     ${disabled ? 'disabled' : ''} 
   >

--- a/tegel/src/components/radio-button/radio-button.stories.tsx
+++ b/tegel/src/components/radio-button/radio-button.stories.tsx
@@ -39,7 +39,7 @@ export default {
   },
 };
 
-const Template = (args) =>
+const Template = ({label, disabled}) =>
   formatHtmlPreview(`
   <style>
     .demo-fieldset-reset { 
@@ -49,12 +49,12 @@ const Template = (args) =>
       padding: 0; 
     }
   </style>
-  <fieldset class="demo-fieldset-reset" ${args.disabled ? 'disabled' : ''}>
+  <fieldset class="demo-fieldset-reset" ${disabled ? 'disabled' : ''}>
     <div class="sdds-radio-button-group">
       <div class="sdds-radio-item">
         <input class="sdds-form-input" type="radio" name="rb-example" id="rb-option-1" checked>
         <label class="sdds-form-label" for="rb-option-1">
-          ${args.label} 1
+          ${label} 1
         </label>
       </div>
     </div>
@@ -62,7 +62,7 @@ const Template = (args) =>
       <div class="sdds-radio-item">
         <input class="sdds-form-input" type="radio" name="rb-example" id="rb-option-2">
         <label class="sdds-form-label" for="rb-option-2">
-          ${args.label} 2
+          ${label} 2
         </label>
       </div>
     </div>

--- a/tegel/src/components/radio-button/radio-button.stories.tsx
+++ b/tegel/src/components/radio-button/radio-button.stories.tsx
@@ -31,6 +31,9 @@ export default {
       control: {
         type: 'boolean',
       },
+      table: {
+        defaultValue: { summary: 'false' },
+      },
     },
   },
   args: {

--- a/tegel/src/components/radio-button/radio-button.stories.tsx
+++ b/tegel/src/components/radio-button/radio-button.stories.tsx
@@ -21,8 +21,8 @@ export default {
     label: {
       name: 'Label',
       description: 'Sets the label for the radio button.',
-      controls: {
-        type: 'string',
+      control: {
+        type: 'text',
       },
     },
     disabled: {

--- a/tegel/src/components/radio-button/radio-button.tsx
+++ b/tegel/src/components/radio-button/radio-button.tsx
@@ -63,7 +63,7 @@ export class RadioButton {
 
         // REMEMBER TO ENABLE ARIA PROPS ONCE ALIGNMENT HAS BEEN MADE!
         // aria-labelledby={this.ariaLabelledBy} 
-        aria-describedby={this.host.getAttribute('aria-describedby')}
+        // aria-describedby={this.host.getAttribute('aria-describedby')}
         required={this.required} 
         disabled={this.disabled}
         onChange={() => {


### PR DESCRIPTION
**Describe pull-request**  
Standardised order of controls in Storybook for radio button component. Also updated deprecated control, added default values and deconstructed args for consistency between stories.

**Solving issue**  
Fixes: [AB#3439](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3439)

**How to test**  
_Add description how to test if possible_
1. Go to Storybook link below
2. Check in Radio Button -> Web Component and Native
3. Inspect order of controls
4. Read control descriptions

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events