### PR TITLE
fix(popover): update default values in Storybook

### DIFF
--- a/tegel/src/components/popover-canvas/popover-canvas.stories.tsx
+++ b/tegel/src/components/popover-canvas/popover-canvas.stories.tsx
@@ -29,7 +29,9 @@ export default {
         'Right end',
         'Auto',
       ],
-      defaultValue: { summary: 'Bottom' },
+      table: {
+        defaultValue: { summary: 'Bottom' },
+      },
     },
   },
   args: {

--- a/tegel/src/components/popover-canvas/popover-canvas.stories.tsx
+++ b/tegel/src/components/popover-canvas/popover-canvas.stories.tsx
@@ -30,12 +30,12 @@ export default {
         'Auto',
       ],
       table: {
-        defaultValue: { summary: 'Bottom' },
+        defaultValue: { summary: 'Auto' },
       },
     },
   },
   args: {
-    canvasPosition: 'Bottom',
+    canvasPosition: 'Auto',
   },
 };
 

--- a/tegel/src/components/popover-canvas/popover-canvas.stories.tsx
+++ b/tegel/src/components/popover-canvas/popover-canvas.stories.tsx
@@ -94,4 +94,3 @@ const ComponentPopoverCanvas = ({ canvasPosition }) => {
   );
 };
 export const Default = ComponentPopoverCanvas.bind({});
-Default.args = {};

--- a/tegel/src/components/popover-canvas/popover-canvas.stories.tsx
+++ b/tegel/src/components/popover-canvas/popover-canvas.stories.tsx
@@ -10,8 +10,7 @@ export default {
   argTypes: {
     canvasPosition: {
       name: 'Canvas position',
-      description: 'Position of the PopoverCanvas',
-      type: { summary: 'string' },
+      description: 'Sets the position of the popover canvas.',
       control: {
         type: 'select',
       },

--- a/tegel/src/components/popover-canvas/popover-canvas.stories.tsx
+++ b/tegel/src/components/popover-canvas/popover-canvas.stories.tsx
@@ -29,7 +29,7 @@ export default {
         'Right end',
         'Auto',
       ],
-      defaultValue: { summary: 'Auto' },
+      defaultValue: { summary: 'Bottom' },
     },
   },
   args: {

--- a/tegel/src/components/popover-menu/popover-menu-icons.stories.tsx
+++ b/tegel/src/components/popover-menu/popover-menu-icons.stories.tsx
@@ -39,14 +39,15 @@ export default {
         'Right',
         'Right start',
         'Right end',
+        'Auto',
       ],
       table: {
-        defaultValue: { summary: 'Bottom' },
+        defaultValue: { summary: 'Auto' },
       },
     },
   },
   args: {
-    menuPosition: 'Bottom',
+    menuPosition: 'Auto',
   },
 };
 
@@ -64,6 +65,7 @@ const Template = ({ menuPosition }) => {
     'Right': 'right',
     'Right start': 'right-start',
     'Right end': 'right-end',
+    'Auto': 'auto',
   };
 
   return formatHtmlPreview(

--- a/tegel/src/components/popover-menu/popover-menu-icons.stories.tsx
+++ b/tegel/src/components/popover-menu/popover-menu-icons.stories.tsx
@@ -40,10 +40,13 @@ export default {
         'Right start',
         'Right end',
       ],
+      table: {
+        defaultValue: { summary: 'Bottom' },
+      },
     },
   },
   args: {
-    menuPosition: 'Bottom start',
+    menuPosition: 'Bottom',
   },
 };
 

--- a/tegel/src/components/popover-menu/popover-menu-icons.stories.tsx
+++ b/tegel/src/components/popover-menu/popover-menu-icons.stories.tsx
@@ -22,7 +22,7 @@ export default {
   argTypes: {
     menuPosition: {
       name: 'Menu position',
-      description: 'Position of the Popover menu',
+      description: 'Sets the position of the popover menu.',
       control: {
         type: 'select',
       },

--- a/tegel/src/components/popover-menu/popover-menu-icons.stories.tsx
+++ b/tegel/src/components/popover-menu/popover-menu-icons.stories.tsx
@@ -127,4 +127,3 @@ const Template = ({ menuPosition }) => {
 };
 
 export const WithIcons = Template.bind({});
-WithIcons.args = {};

--- a/tegel/src/components/popover-menu/popover-menu.stories.tsx
+++ b/tegel/src/components/popover-menu/popover-menu.stories.tsx
@@ -39,14 +39,15 @@ export default {
         'Right',
         'Right start',
         'Right end',
+        'Auto',
       ],
       table: {
-        defaultValue: { summary: 'Bottom' },
+        defaultValue: { summary: 'Auto' },
       },
     },
   },
   args: {
-    menuPosition: 'Bottom',
+    menuPosition: 'Auto',
   },
 };
 
@@ -64,6 +65,7 @@ const Template = ({ menuPosition }) => {
     'Right': 'right',
     'Right start': 'right-start',
     'Right end': 'right-end',
+    'Auto': 'auto',
   };
 
   return formatHtmlPreview(

--- a/tegel/src/components/popover-menu/popover-menu.stories.tsx
+++ b/tegel/src/components/popover-menu/popover-menu.stories.tsx
@@ -40,10 +40,13 @@ export default {
         'Right start',
         'Right end',
       ],
+      table: {
+        defaultValue: { summary: 'Bottom' },
+      },
     },
   },
   args: {
-    menuPosition: 'Bottom start',
+    menuPosition: 'Bottom',
   },
 };
 

--- a/tegel/src/components/popover-menu/popover-menu.stories.tsx
+++ b/tegel/src/components/popover-menu/popover-menu.stories.tsx
@@ -22,7 +22,7 @@ export default {
   argTypes: {
     menuPosition: {
       name: 'Menu position',
-      description: 'Position of the Popover menu',
+      description: 'Sets the position of the popover menu.',
       control: {
         type: 'select',
       },

--- a/tegel/src/components/popover-menu/popover-menu.stories.tsx
+++ b/tegel/src/components/popover-menu/popover-menu.stories.tsx
@@ -120,4 +120,3 @@ const Template = ({ menuPosition }) => {
 };
 
 export const Default = Template.bind({});
-Default.args = {};


### PR DESCRIPTION
**Describe pull-request**  
Updated default values and descriptions in both popover canvas and popover menu components.

**How to test**  
_Add description how to test if possible_
1. Go to Storybook link below
2. Check in Popover Canvas -> Default
3. Check in Popover Menu -> Default and With Icons
4. Read control descriptions

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events