### PR TITLE
fix(slider): standardise order of controls in Storybook

### DIFF
--- a/tegel/src/components/slider/slider.stories.tsx
+++ b/tegel/src/components/slider/slider.stories.tsx
@@ -10,12 +10,18 @@ export default {
       control: {
         type: 'number',
       },
+      table: {
+        defaultValue: { summary: 0 },
+      },
     },
     max: {
       name: 'Max. value',
       description: 'Sets the maximum value for the slider.',
       control: {
         type: 'number',
+      },
+      table: {
+        defaultValue: { summary: 100 },
       },
     },
     initialValue: {
@@ -24,12 +30,18 @@ export default {
       control: {
         type: 'number',
       },
+      table: {
+        defaultValue: { summary: 50 },
+      },
     },
     showLabel: {
       name: 'Show label',
       description: 'Toggles if the lable should be shown or hidden.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
       },
     },
     labelText: {
@@ -45,6 +57,9 @@ export default {
       description: 'Toggles if ticks should be shown or hidden.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
       },
     },
     numTicks: {
@@ -62,6 +77,9 @@ export default {
         type: 'boolean',
       },
       if: { arg: 'showTicks', eq: true },
+      table: {
+        defaultValue: { summary: 3 },
+      },
     },
     snapToTicks: {
       name: 'Snap to ticks',
@@ -70,6 +88,9 @@ export default {
         type: 'boolean',
       },
       if: { arg: 'showTicks', eq: true },
+      table: {
+        defaultValue: { summary: false },
+      },
     },
     showTooltip: {
       name: 'Show tooltip',
@@ -77,12 +98,18 @@ export default {
       control: {
         type: 'boolean',
       },
+      table: {
+        defaultValue: { summary: true },
+      },
     },
     showControls: {
       name: 'Show controls (not compatible with input field)',
       description: 'Toggles if controls should be shown or hidden.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
       },
     },
     step: {
@@ -92,6 +119,9 @@ export default {
         type: 'number',
       },
       if: { arg: 'showControls', eq: true },
+      table: {
+        defaultValue: { summary: 1 },
+      },
     },
     showInput: {
       name: 'Show value input field (not compatible with controls)',
@@ -100,12 +130,18 @@ export default {
         type: 'boolean',
       },
       if: { arg: 'showControls', eq: false },
+      table: {
+        defaultValue: { summary: false },
+      },
     },
     small: {
       name: 'Small',
       description: 'Toggles if the small variant of the scrubber should be used.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
       },
     },
     readonly: {
@@ -114,12 +150,18 @@ export default {
       control: {
         type: 'boolean',
       },
+      table: {
+        defaultValue: { summary: false },
+      },
     },
     disabled: {
       name: 'Disabled',
       description: 'Disables the slider.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
       },
     },
   },

--- a/tegel/src/components/slider/slider.stories.tsx
+++ b/tegel/src/components/slider/slider.stories.tsx
@@ -6,35 +6,35 @@ export default {
   argTypes: {
     min: {
       name: 'Min. value',
-      description: 'Minimum value',
+      description: 'Sets the minimum value for the slider.',
       control: {
         type: 'text',
       },
     },
     max: {
       name: 'Max. value',
-      description: 'Maximum value',
+      description: 'Sets the maximum value for the slider.',
       control: {
         type: 'text',
       },
     },
     initialValue: {
       name: 'Initial value',
-      description: 'Initial value for slider',
+      description: 'Sets the initial value for the slider.',
       control: {
         type: 'text',
       },
     },
     showLabel: {
       name: 'Show label',
-      description: 'Show or hide label',
+      description: 'Toggles if the lable should be shown or hidden.',
       control: {
         type: 'boolean',
       },
     },
     labelText: {
       name: 'Label text',
-      description: 'Text for label',
+      description: 'Sets the text for the label.',
       control: {
         type: 'text',
       },
@@ -45,14 +45,14 @@ export default {
     },
     showTicks: {
       name: 'Show ticks',
-      description: 'Show or hide ticks',
+      description: 'Toggles if ticks should be shown or hidden.',
       control: {
         type: 'boolean',
       },
     },
     numTicks: {
       name: 'Number of ticks',
-      description: 'Set the number of ticks to display',
+      description: 'Sets the number of ticks to be displayed.',
       control: {
         type: 'text',
       },
@@ -63,7 +63,7 @@ export default {
     },
     showTickNumbers: {
       name: 'Show tick numbers',
-      description: 'Show or hide tick numbers',
+      description: 'Toggles if tick numbers should be shown or hidden.',
       control: {
         type: 'boolean',
       },
@@ -74,7 +74,7 @@ export default {
     },
     snapToTicks: {
       name: 'Snap to ticks',
-      description: 'Snap the scrubber to the closest tick when dragging',
+      description: 'Snaps the scrubber to the closest tick when dragging.',
       control: {
         type: 'boolean',
       },
@@ -85,21 +85,21 @@ export default {
     },
     showTooltip: {
       name: 'Show tooltip',
-      description: 'Show or hide tooltip',
+      description: 'Toggles if the tooltip should be shown or hidden.',
       control: {
         type: 'boolean',
       },
     },
     showControls: {
       name: 'Show controls (not compatible with input field)',
-      description: 'Show or hide controls',
+      description: 'Toggles if controls should be shown or hidden.',
       control: {
         type: 'boolean',
       },
     },
     step: {
       name: 'Step value',
-      description: 'Value to increment/decrease when using controls',
+      description: 'Sets the value to increment/decrement with when using controls.',
       control: {
         type: 'text',
       },
@@ -110,7 +110,7 @@ export default {
     },
     showInput: {
       name: 'Show value input field (not compatible with controls)',
-      description: 'Show or hide value input field',
+      description: 'Toggles if the values input field should be shown or hidden.',
       control: {
         type: 'boolean',
       },
@@ -121,21 +121,21 @@ export default {
     },
     small: {
       name: 'Small',
-      description: 'Use small variant',
+      description: 'Toggles if the small variant of the scrubber should be used.',
       control: {
         type: 'boolean',
       },
     },
     readonly: {
       name: 'Read Only',
-      description: 'Put control in read-only state',
+      description: 'Puts the control in a read-only state.',
       control: {
         type: 'boolean',
       },
     },
     disabled: {
       name: 'Disabled',
-      description: 'Put control in disabled state',
+      description: 'Disables the slider.',
       control: {
         type: 'boolean',
       },

--- a/tegel/src/components/slider/slider.stories.tsx
+++ b/tegel/src/components/slider/slider.stories.tsx
@@ -4,13 +4,6 @@ import readme from './readme.md';
 export default {
   title: 'Components/Slider',
   argTypes: {
-    initialValue: {
-      name: 'Initial value',
-      description: 'Initial value for slider',
-      control: {
-        type: 'text',
-      },
-    },
     min: {
       name: 'Min. value',
       description: 'Minimum value',
@@ -21,6 +14,13 @@ export default {
     max: {
       name: 'Max. value',
       description: 'Maximum value',
+      control: {
+        type: 'text',
+      },
+    },
+    initialValue: {
+      name: 'Initial value',
+      description: 'Initial value for slider',
       control: {
         type: 'text',
       },
@@ -43,13 +43,6 @@ export default {
         truthy: true,
       },
     },
-    showTooltip: {
-      name: 'Show tooltip',
-      description: 'Show or hide tooltip',
-      control: {
-        type: 'boolean',
-      },
-    },
     showTicks: {
       name: 'Show ticks',
       description: 'Show or hide ticks',
@@ -68,6 +61,17 @@ export default {
         truthy: true,
       },
     },
+    showTickNumbers: {
+      name: 'Show tick numbers',
+      description: 'Show or hide tick numbers',
+      control: {
+        type: 'boolean',
+      },
+      if: {
+        arg: 'showTicks',
+        truthy: true,
+      },
+    },
     snapToTicks: {
       name: 'Snap to ticks',
       description: 'Snap the scrubber to the closest tick when dragging',
@@ -79,15 +83,11 @@ export default {
         truthy: true,
       },
     },
-    showTickNumbers: {
-      name: 'Show tick numbers',
-      description: 'Show or hide tick numbers',
+    showTooltip: {
+      name: 'Show tooltip',
+      description: 'Show or hide tooltip',
       control: {
         type: 'boolean',
-      },
-      if: {
-        arg: 'showTicks',
-        truthy: true,
       },
     },
     showControls: {
@@ -119,9 +119,9 @@ export default {
         truthy: false,
       },
     },
-    disabled: {
-      name: 'Disabled',
-      description: 'Put control in disabled state',
+    small: {
+      name: 'Small',
+      description: 'Use small variant',
       control: {
         type: 'boolean',
       },
@@ -133,9 +133,9 @@ export default {
         type: 'boolean',
       },
     },
-    small: {
-      name: 'Small',
-      description: 'Use small variant',
+    disabled: {
+      name: 'Disabled',
+      description: 'Put control in disabled state',
       control: {
         type: 'boolean',
       },
@@ -157,41 +157,41 @@ export default {
     ],
   },
   args: {
+    min: '0',
+    max: '100',
     initialValue: '50',
     showLabel: false,
     labelText: 'Label',
-    showTooltip: true,
     showTicks: false,
     numTicks: '3',
     showTickNumbers: false,
-    showControls: false,
-    showInput: false,
-    min: '0',
-    max: '100',
-    step: '1',
-    disabled: false,
-    small: false,
     snapToTicks: false,
+    showTooltip: true,
+    showControls: false,
+    step: '1',
+    showInput: false,
+    small: false,
     readonly: false,
+    disabled: false,
   },
 };
 const Template = ({
-  initialValue,
   min,
   max,
+  initialValue,
   showLabel,
   labelText,
-  showTooltip,
   showTicks,
   numTicks,
   showTickNumbers,
   snapToTicks,
+  showTooltip,
   showControls,
   step,
   showInput,
-  disabled,
-  readonly,
   small,
+  readonly,
+  disabled,
 }) =>
   formatHtmlPreview(`
     <sdds-slider id="sdds-slider"

--- a/tegel/src/components/slider/slider.stories.tsx
+++ b/tegel/src/components/slider/slider.stories.tsx
@@ -8,21 +8,21 @@ export default {
       name: 'Min. value',
       description: 'Sets the minimum value for the slider.',
       control: {
-        type: 'text',
+        type: 'number',
       },
     },
     max: {
       name: 'Max. value',
       description: 'Sets the maximum value for the slider.',
       control: {
-        type: 'text',
+        type: 'number',
       },
     },
     initialValue: {
       name: 'Initial value',
       description: 'Sets the initial value for the slider.',
       control: {
-        type: 'text',
+        type: 'number',
       },
     },
     showLabel: {
@@ -38,10 +38,7 @@ export default {
       control: {
         type: 'text',
       },
-      if: {
-        arg: 'showLabel',
-        truthy: true,
-      },
+      if: { arg: 'showLabel', eq: true },
     },
     showTicks: {
       name: 'Show ticks',
@@ -54,12 +51,9 @@ export default {
       name: 'Number of ticks',
       description: 'Sets the number of ticks to be displayed.',
       control: {
-        type: 'text',
+        type: 'number',
       },
-      if: {
-        arg: 'showTicks',
-        truthy: true,
-      },
+      if: { arg: 'showTicks', eq: true },
     },
     showTickNumbers: {
       name: 'Show tick numbers',
@@ -67,10 +61,7 @@ export default {
       control: {
         type: 'boolean',
       },
-      if: {
-        arg: 'showTicks',
-        truthy: true,
-      },
+      if: { arg: 'showTicks', eq: true },
     },
     snapToTicks: {
       name: 'Snap to ticks',
@@ -78,10 +69,7 @@ export default {
       control: {
         type: 'boolean',
       },
-      if: {
-        arg: 'showTicks',
-        truthy: true,
-      },
+      if: { arg: 'showTicks', eq: true },
     },
     showTooltip: {
       name: 'Show tooltip',
@@ -101,12 +89,9 @@ export default {
       name: 'Step value',
       description: 'Sets the value to increment/decrement with when using controls.',
       control: {
-        type: 'text',
+        type: 'number',
       },
-      if: {
-        arg: 'showControls',
-        truthy: true,
-      },
+      if: { arg: 'showControls', eq: true },
     },
     showInput: {
       name: 'Show value input field (not compatible with controls)',
@@ -114,10 +99,7 @@ export default {
       control: {
         type: 'boolean',
       },
-      if: {
-        arg: 'showControls',
-        truthy: false,
-      },
+      if: { arg: 'showControls', eq: false },
     },
     small: {
       name: 'Small',

--- a/tegel/src/components/slider/slider.stories.tsx
+++ b/tegel/src/components/slider/slider.stories.tsx
@@ -31,7 +31,7 @@ export default {
         type: 'number',
       },
       table: {
-        defaultValue: { summary: 50 },
+        defaultValue: { summary: 0 },
       },
     },
     showLabel: {


### PR DESCRIPTION
**Describe pull-request**  
Standardised order of controls in Storybook for slider component. Also updated descriptions, added default values to controls and refactored deprecated conditional controls.

**Solving issue**  
Fixes: [AB#3441](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3441)

**How to test**  
1. Go to Storybook link below
2. Check in Slider -> Default
3. Inspect order of controls
4. Read control descriptions

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events