### PR TITLE
fix(button): double text prop in story

### DIFF
--- a/tegel/src/components/button/button-webcomponent.stories.tsx
+++ b/tegel/src/components/button/button-webcomponent.stories.tsx
@@ -26,7 +26,8 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
-      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
+      description:
+        'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
@@ -37,7 +38,8 @@ export default {
     },
     btnType: {
       name: 'Type',
-      description: 'Four different button types to help the user to distinguish the level of importance of the task they represent.',
+      description:
+        'Four different button types to help the user to distinguish the level of importance of the task they represent.',
       control: {
         type: 'radio',
       },
@@ -185,7 +187,6 @@ const WebComponentTemplate = ({
       disabled ? 'disabled' : ''
     } ${fullbleed ? 'fullbleed' : ''}
     ${!onlyIcon ? `text="${text}"` : ''}
-    text="${onlyIcon ? '' : text}" 
     ${
       modeVariant !== 'Inherit from parent'
         ? `mode-variant="${modeVariantLookup[modeVariant]}"`


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Seems we had double declaration of text prop in story

**Solving issue**  
Fixes: No ticket, fixed bug on the fly.

**How to test**  
1. Go to Storybook Link below
2. Make sure that no combination of props shows a double "text" attribute in the story demo code.


