### PR TITLE
fix(spinner): standardise order of controls in Storybook

### DIFF
--- a/tegel/src/components/spinner/spinner.stories.tsx
+++ b/tegel/src/components/spinner/spinner.stories.tsx
@@ -22,19 +22,25 @@ export default {
   argTypes: {
     variant: {
       name: 'Variant',
+      description: 'Switches the variant of the spinner.',
       control: {
         type: 'radio',
       },
       options: ['Standard', 'Inverted'],
-      description: 'Switches the variant of the spinner.',
+      table: {
+        defaultValue: { summary: 'Standard' },
+      },
     },
     size: {
       name: 'Size',
+      description: 'Sets the size of the spinner.',
       control: {
         type: 'radio',
       },
       options: ['Large', 'Medium', 'Small', 'Extra small'],
-      description: 'Sets the size of the spinner.',
+      table: {
+        defaultValue: { summary: 'Large' },
+      },
     },
   },
   args: {

--- a/tegel/src/components/spinner/spinner.stories.tsx
+++ b/tegel/src/components/spinner/spinner.stories.tsx
@@ -26,7 +26,7 @@ export default {
         type: 'radio',
       },
       options: ['Standard', 'Inverted'],
-      description: 'Variant of the spinner',
+      description: 'Switches the variant of the spinner.',
     },
     size: {
       name: 'Size',
@@ -34,7 +34,7 @@ export default {
         type: 'radio',
       },
       options: ['Large', 'Medium', 'Small', 'Extra small'],
-      description: 'Size of the spinner',
+      description: 'Sets the size of the spinner.',
     },
   },
   args: {


### PR DESCRIPTION
**Describe pull-request**  
Updated descriptions and added default values to controls for the spinner component.

**Solving issue**
Fixes: [AB#3442](https://dev.azure.com/scaniadigitaldesignsystem/3d9eb9c6-0045-473d-bc1d-e842dd779200/_workitems/edit/3442)

**How to test**  
1. Go to Storybook link below
2. Check in Spinner-> Default and Inverted
3. Read control descriptions

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events