### PR TITLE
fix(stepper): standardise order of controls in Storybook

### DIFF
--- a/tegel/src/components/stepper/sdds-stepper.stories.ts
+++ b/tegel/src/components/stepper/sdds-stepper.stories.ts
@@ -27,10 +27,10 @@ export default {
       control: {
         type: 'radio',
       },
+      options: ['Large', 'Small'],
       table: {
         defaultValue: { summary: 'lg' },
       },
-      options: ['Large', 'Small'],
     },
     direction: {
       name: 'Direction',
@@ -38,10 +38,10 @@ export default {
       control: {
         type: 'radio',
       },
+      options: ['Horizontal', 'Vertical'],
       table: {
         defaultValue: { summary: 'horizontal' },
       },
-      options: ['Horizontal', 'Vertical'],
     },
     labelPosition: {
       name: 'Text position',
@@ -49,11 +49,11 @@ export default {
       control: {
         type: 'radio',
       },
+      options: ['Below', 'Aside'],
+      if: { arg: 'direction', neq: 'Vertical' },
       table: {
         defaultValue: { summary: 'below' },
       },
-      options: ['Below', 'Aside'],
-      if: { arg: 'direction', neq: 'Vertical' },
     },
     hideLabels: {
       name: 'Hide labels',
@@ -62,7 +62,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: { summary: 'false' },
+        defaultValue: { summary: false },
       },
     },
   },

--- a/tegel/src/components/stepper/sdds-stepper.stories.ts
+++ b/tegel/src/components/stepper/sdds-stepper.stories.ts
@@ -23,7 +23,7 @@ export default {
   argTypes: {
     size: {
       name: 'Size',
-      description: 'The size of the stepper.',
+      description: 'Sets the size of the stepper.',
       control: {
         type: 'radio',
       },
@@ -34,7 +34,7 @@ export default {
     },
     direction: {
       name: 'Direction',
-      description: 'The direction which the stepper is displayed.',
+      description: 'Sets the direction which the stepper is displayed.',
       control: {
         type: 'radio',
       },
@@ -45,7 +45,7 @@ export default {
     },
     labelPosition: {
       name: 'Text position',
-      description: 'The position of the text, only available when the direction is horizontal.',
+      description: 'Sets the position of the text, only available when the direction is horizontal.',
       control: {
         type: 'radio',
       },

--- a/tegel/src/components/stepper/sdds-stepper.stories.ts
+++ b/tegel/src/components/stepper/sdds-stepper.stories.ts
@@ -21,6 +21,17 @@ export default {
     notes: { 'Stepper': readmeStepper, 'Stepper Item': readmeStepperItem },
   },
   argTypes: {
+    size: {
+      name: 'Size',
+      description: 'The size of the stepper.',
+      control: {
+        type: 'radio',
+      },
+      table: {
+        defaultValue: { summary: 'lg' },
+      },
+      options: ['Large', 'Small'],
+    },
     direction: {
       name: 'Direction',
       description: 'The direction which the stepper is displayed.',
@@ -44,17 +55,6 @@ export default {
       options: ['Below', 'Aside'],
       if: { arg: 'direction', neq: 'Vertical' },
     },
-    size: {
-      name: 'Size',
-      description: 'The size of the stepper.',
-      control: {
-        type: 'radio',
-      },
-      table: {
-        defaultValue: { summary: 'lg' },
-      },
-      options: ['Large', 'Small'],
-    },
     hideLabels: {
       name: 'Hide labels',
       description: 'Hides the labels for all stepper items.',
@@ -67,10 +67,10 @@ export default {
     },
   },
   args: {
+    size: 'Large',
     direction: 'Horizontal',
     labelPosition: 'Below',
     hideLabels: false,
-    size: 'Large',
   },
 };
 
@@ -78,7 +78,12 @@ const sizeLookUp = {
   Large: 'lg',
   Small: 'sm',
 };
-const Template = ({ size, hideLabels, labelPosition, direction }) =>
+const Template = ({ 
+  size, 
+  direction, 
+  labelPosition, 
+  hideLabels, 
+}) =>
   formatHtmlPreview(
     `<sdds-stepper ${hideLabels ? 'hide-labels' : ''} size="${sizeLookUp[size]}" ${
       direction === 'Horizontal' ? `label-position="${labelPosition?.toLowerCase()}"` : ''

--- a/tegel/src/components/stepper/stepper.stories.tsx
+++ b/tegel/src/components/stepper/stepper.stories.tsx
@@ -34,13 +34,6 @@ export default {
       },
       options: ['Default', 'Text on side', 'Vertical'],
     },
-    showLabel: {
-      name: 'Show label text',
-      description: 'Show or hide the label text',
-      control: {
-        type: 'boolean',
-      },
-    },
     iconType: {
       name: 'Icon type',
       description: 'Native/Web Component',
@@ -49,16 +42,28 @@ export default {
       },
       options: ['Native', 'Web Component'],
     },
+    hideLabels: {
+      name: 'Hide labels',
+      description: 'Show or hide the label text',
+      control: {
+        type: 'boolean',
+      },
+    },
   },
   args: {
     size: 'Default',
     style: 'Default',
-    showLabel: true,
     iconType: 'Native',
+    hideLabels: false,
   },
 };
 
-const Template = ({ size, style, showLabel, iconType }) => {
+const Template = ({ 
+  size, 
+  style, 
+  iconType, 
+  hideLabels 
+}) => {
   const sizeClass = size === 'Small' ? 'sdds-stepper-sm' : '';
 
   const styleLookup = {
@@ -84,7 +89,7 @@ const Template = ({ size, style, showLabel, iconType }) => {
         <div class="sdds-stepper__step-icon">
           <span class="sdds-stepper__step-icon-value">1</span>
         </div>
-        ${showLabel ? '<label class="sdds-stepper__step_label">Step value</label>' : ''}
+        ${hideLabels ? '' : '<label class="sdds-stepper__step_label">Step value</label>'}
       </div>
 
       <div class="sdds-stepper__step sdds-stepper__step--warning">
@@ -96,7 +101,7 @@ const Template = ({ size, style, showLabel, iconType }) => {
             : `<sdds-icon name="warning" size="${size === 'Small' ? '16px' : '18px'}"></sdds-icon> `
         }
         </div>
-        ${showLabel ? '<label class="sdds-stepper__step_label">Step warning</label>' : ''}
+        ${hideLabels ? '' : '<label class="sdds-stepper__step_label">Step warning</label>'}
       </div>
 
       <div class="sdds-stepper__step sdds-stepper__step--inactive">
@@ -104,7 +109,7 @@ const Template = ({ size, style, showLabel, iconType }) => {
           <span class="sdds-stepper__step-icon-value">3</span>
         </div>
         ${
-          showLabel ? '<label class="sdds-stepper__step_label">Step inactive with text</label>' : ''
+          hideLabels ? '' : '<label class="sdds-stepper__step_label">Step inactive with text</label>'
         }
       </div>
 
@@ -119,7 +124,7 @@ const Template = ({ size, style, showLabel, iconType }) => {
         </div>`
         }
         </div>
-        ${showLabel ? '<label class="sdds-stepper__step_label">Step success</label>' : ''}
+        ${hideLabels ? '' : '<label class="sdds-stepper__step_label">Step success</label>'}
       </div>
 
     </div>

--- a/tegel/src/components/stepper/stepper.stories.tsx
+++ b/tegel/src/components/stepper/stepper.stories.tsx
@@ -24,7 +24,10 @@ export default {
       control: {
         type: 'radio',
       },
-      options: ['Default', 'Small'],
+      options: ['Large', 'Small'],
+      table: {
+        defaultValue: { summary: 'Large' },
+      },
     },
     style: {
       name: 'Style',
@@ -33,6 +36,9 @@ export default {
         type: 'radio',
       },
       options: ['Default', 'Text on side', 'Vertical'],
+      table: {
+        defaultValue: { summary: 'Default' },
+      },
     },
     iconType: {
       name: 'Icon type',
@@ -41,6 +47,9 @@ export default {
         type: 'radio',
       },
       options: ['Native', 'Web Component'],
+      table: {
+        defaultValue: { summary: 'Native' },
+      },
     },
     hideLabels: {
       name: 'Hide labels',
@@ -48,10 +57,13 @@ export default {
       control: {
         type: 'boolean',
       },
+      table: {
+        defaultValue: { summary: false },
+      },
     },
   },
   args: {
-    size: 'Default',
+    size: 'Large',
     style: 'Default',
     iconType: 'Native',
     hideLabels: false,

--- a/tegel/src/components/stepper/stepper.stories.tsx
+++ b/tegel/src/components/stepper/stepper.stories.tsx
@@ -20,7 +20,7 @@ export default {
   argTypes: {
     size: {
       name: 'Size',
-      description: 'Size of the stepper',
+      description: 'Sets the size of the stepper.',
       control: {
         type: 'radio',
       },
@@ -28,7 +28,7 @@ export default {
     },
     style: {
       name: 'Style',
-      description: 'Style of the stepper',
+      description: 'Sets the style of the stepper.',
       control: {
         type: 'radio',
       },
@@ -36,7 +36,7 @@ export default {
     },
     iconType: {
       name: 'Icon type',
-      description: 'Native/Web Component',
+      description: 'Switch between showing a native or a web component icon.',
       control: {
         type: 'radio',
       },
@@ -44,7 +44,7 @@ export default {
     },
     hideLabels: {
       name: 'Hide labels',
-      description: 'Show or hide the label text',
+      description: 'Hides the labels for all stepper items.',
       control: {
         type: 'boolean',
       },


### PR DESCRIPTION
**Describe pull-request**  
Standardised order of controls in Storybook for stepper component. Also updated descriptions, added default values and refactored showLabel control in native component to match the web component structure.

**Solving issue**  
Fixes: [AB#DTS-865](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-865)

**How to test**  
1. Go to Storybook link below
2. Check in Stepper -> Native, Web Component and Web Component With Error
3. Inspect order of controls
4. Read control descriptions

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events