### PR TITLE
fix(banner): correct color on close button in light mode

### DIFF
--- a/tegel/src/components/banner/sdds-banner.scss
+++ b/tegel/src/components/banner/sdds-banner.scss
@@ -71,6 +71,7 @@
       padding-top: 14px;
       background-color: transparent;
       border: none;
+      color: var(--sdds-banner-x-color);
 
       &:hover {
         cursor: pointer;

--- a/tegel/src/global/global.scss
+++ b/tegel/src/global/global.scss
@@ -53,6 +53,7 @@
 //Web component theme variables
 @import 'src/components/accordion/accordion-vars';
 @import 'src/components/button/button-vars';
+@import 'src/components/banner/banner-vars';
 @import 'src/components/datetime/datetime-vars';
 @import 'src/components/data-table/data-table-vars';
 @import 'src/components/popover-canvas/popover-canvas-vars';


### PR DESCRIPTION
**Describe pull-request**  
Add color var to button also to enable ligh/dark switch, and added vars to global.scss

**Solving issue**  
Fixes: [AB#DTS-711](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-711)

**How to test**  
_Add description how to test if possible_
1. Go to storybook link below.
2. Check in Components -> Banner, Web Component, see that the close button changes to white in light mode. 

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Dark/light mode and variants 
