### PR TITLE
fix(dropdown): correct color in disabled state

### DIFF
--- a/tegel/src/components/dropdown/dropdown-vars.scss
+++ b/tegel/src/components/dropdown/dropdown-vars.scss
@@ -9,7 +9,7 @@
   --sdds-dropdown-background: var(--sdds-grey-50);
   --sdds-dropdown-background-hover: var(--sdds-grey-100);
   --sdds-dropdown-background-disabled: var(--sdds-white);
-  --sdds-dropdown-disabled: var(--sdds-grey-800);
+  --sdds-dropdown-disabled: var(--sdds-grey-400);
   --sdds-dropdown-border: var(--sdds-grey-100);
   --sdds-dropdown-label-inside: var(--sdds-grey-700);
   --sdds-dropdown-label-outside: var(--sdds-grey-958);

--- a/tegel/src/components/dropdown/dropdown-vars.scss
+++ b/tegel/src/components/dropdown/dropdown-vars.scss
@@ -9,7 +9,7 @@
   --sdds-dropdown-background: var(--sdds-grey-50);
   --sdds-dropdown-background-hover: var(--sdds-grey-100);
   --sdds-dropdown-background-disabled: var(--sdds-white);
-  --sdds-dropdown-disabled: var(--sdds-grey-400);
+  --sdds-dropdown-disabled: var(--sdds-grey-800);
   --sdds-dropdown-border: var(--sdds-grey-100);
   --sdds-dropdown-label-inside: var(--sdds-grey-700);
   --sdds-dropdown-label-outside: var(--sdds-grey-958);

--- a/tegel/src/components/dropdown/dropdown.scss
+++ b/tegel/src/components/dropdown/dropdown.scss
@@ -1,6 +1,5 @@
 @import '../../mixins/z-index';
 @import './dropdown-core';
-@import './dropdown-vars.scss';
 @import '../../global/scania-fonts-vars.scss';
 
 @import '../checkbox/checkbox.scss';
@@ -32,11 +31,11 @@
     cursor: not-allowed;
     caret-color: transparent;
     pointer-events: none;
-    color: var(--sdds-grey-400);
+    color: var(--sdds-grey-800);
     border: none;
 
     &::placeholder {
-      color: var(--sdds-grey-400);
+      color: var(--sdds-grey-800);
     }
   }
 }

--- a/tegel/src/components/dropdown/dropdown.scss
+++ b/tegel/src/components/dropdown/dropdown.scss
@@ -31,11 +31,11 @@
     cursor: not-allowed;
     caret-color: transparent;
     pointer-events: none;
-    color: var(--sdds-grey-800);
+    color: var(--sdds-dropdown-disabled);
     border: none;
 
     &::placeholder {
-      color: var(--sdds-grey-800);
+      color: var(--sdds-dropdown-disabled);
     }
   }
 }

--- a/tegel/src/global/global.scss
+++ b/tegel/src/global/global.scss
@@ -56,6 +56,7 @@
 @import 'src/components/banner/banner-vars';
 @import 'src/components/datetime/datetime-vars';
 @import 'src/components/data-table/data-table-vars';
+@import 'src/components/dropdown/dropdown-vars';
 @import 'src/components/popover-canvas/popover-canvas-vars';
 @import 'src/components/popover-menu/popover-menu-vars';
 @import 'src/components/popover-menu/popover-menu-item';


### PR DESCRIPTION
**Describe pull-request**  
Now uses the correct color when dropdown is disabled, also moves the inclusion of vars file to global css

**Solving issue**  
Fixes: [DTS-712](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-712)


**How to test**  
Go to storybook link below.
2. Check in Components -> Dropdown, Web Component, toggle disabled state and check that var(--sdds-grey-800) is being used.


**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Dark/light mode and variants 


[DTS-712]: https://tegel.atlassian.net/browse/DTS-712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ