### PR TITLE
fix(tabs): standardise order of controls in Storybook

### DIFF
--- a/tegel/src/components/tabs/inline-tabs-default/inline-tabs.stories.tsx
+++ b/tegel/src/components/tabs/inline-tabs-default/inline-tabs.stories.tsx
@@ -23,6 +23,7 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
+      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
@@ -33,7 +34,7 @@ export default {
     },
     autoHeight: {
       name: 'Same height',
-      description: 'Make all tab panels as tall as the tallest tab panel',
+      description: 'Makes all tab panels as tall as the tallest tab panel.',
       control: {
         type: 'boolean',
       },

--- a/tegel/src/components/tabs/inline-tabs-default/inline-tabs.stories.tsx
+++ b/tegel/src/components/tabs/inline-tabs-default/inline-tabs.stories.tsx
@@ -38,6 +38,9 @@ export default {
       control: {
         type: 'boolean',
       },
+      table: {
+        defaultValue: { summary: false },
+      },
     },
   },
   args: {

--- a/tegel/src/components/tabs/inline-tabs-default/inline-tabs.stories.tsx
+++ b/tegel/src/components/tabs/inline-tabs-default/inline-tabs.stories.tsx
@@ -21,13 +21,6 @@ export default {
     ],
   },
   argTypes: {
-    autoHeight: {
-      name: 'Same height',
-      description: 'Make all tab panels as tall as the tallest tab panel',
-      control: {
-        type: 'boolean',
-      },
-    },
     modeVariant: {
       name: 'Mode variant',
       control: {
@@ -38,15 +31,17 @@ export default {
         defaultValue: { summary: 'Inherit from parent' },
       },
     },
-    backgrounds: {
-      table: {
-        disable: true,
+    autoHeight: {
+      name: 'Same height',
+      description: 'Make all tab panels as tall as the tallest tab panel',
+      control: {
+        type: 'boolean',
       },
     },
   },
   args: {
-    autoHeight: false,
     modeVariant: 'Inherit from parent',
+    autoHeight: false,
   },
 };
 // eslint-disable-next-line arrow-body-style

--- a/tegel/src/components/tabs/inline-tabs-default/inline-tabs.stories.tsx
+++ b/tegel/src/components/tabs/inline-tabs-default/inline-tabs.stories.tsx
@@ -71,4 +71,3 @@ const Template = ({ autoHeight = false, modeVariant }) => {
 };
 
 export const InlineTabs = Template.bind({});
-InlineTabs.args = {};

--- a/tegel/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.stories.tsx
+++ b/tegel/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.stories.tsx
@@ -48,4 +48,3 @@ const Template = ({ modeVariant }) =>
 `);
 
 export const InlineTabsFullbleed = Template.bind({});
-InlineTabsFullbleed.args = {};

--- a/tegel/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.stories.tsx
+++ b/tegel/src/components/tabs/inline-tabs-fullbleed/inline-tabs-fullbleed.stories.tsx
@@ -21,6 +21,7 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
+      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },

--- a/tegel/src/components/tabs/navigation-tabs/navigation-tabs.stories.tsx
+++ b/tegel/src/components/tabs/navigation-tabs/navigation-tabs.stories.tsx
@@ -33,4 +33,3 @@ const Template = () =>
     `);
 
 export const NavigationTabs = Template.bind({});
-NavigationTabs.args = {};


### PR DESCRIPTION
**Describe pull-request**  
Standardised order of controls in Storybook for tabs component. Also updated descriptions and added default values.

**Solving issue**  
Fixes: [DTS-866](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-866)

**How to test**  
1. Go to Storybook link below
2. Check in Tabs -> Inline Tabs and Inline Tabs Fullbleed
3. Inspect order of controls
4. Read control descriptions

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

[DTS-866]: https://tegel.atlassian.net/browse/DTS-866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ