### PR TITLE
fix(chip): removed class from sdds-icon

### DIFF
--- a/tegel/src/components/chips/chips.scss
+++ b/tegel/src/components/chips/chips.scss
@@ -76,6 +76,11 @@ button.sdds-chip {
 
     .sdds-chip-icon {
       right: 8px;
+
+      sdds-icon {
+        display: flex;
+        align-items: center;
+      }
     }
   }
 }

--- a/tegel/src/components/chips/chips.scss
+++ b/tegel/src/components/chips/chips.scss
@@ -67,6 +67,11 @@ button.sdds-chip {
 
     .sdds-chip-icon {
       left: 8px;
+
+      sdds-icon {
+        display: flex;
+        align-items: center;
+      }
     }
   }
 

--- a/tegel/src/components/chips/chips.stories.tsx
+++ b/tegel/src/components/chips/chips.stories.tsx
@@ -91,14 +91,7 @@ export default {
   },
 };
 
-const Template = ({ 
-  active,
-  size,
-  placeholderText, 
-  icon, 
-  iconPosition, 
-  iconType
-   }) => {
+const Template = ({ active, size, placeholderText, icon, iconPosition, iconType }) => {
   const activeValue = active === true ? 'sdds-chip-active' : '';
   const sizeValue = size === 'Small' ? 'sdds-chip-sm' : '';
   const iconPositionLookup = {
@@ -110,8 +103,8 @@ const Template = ({
   const iconSvg = `
     ${
       iconType === 'Native'
-        ? '<i class="sdds-chip-icon sdds-icon notification"></i>'
-        : '<sdds-icon class="sdds-chip-icon" name="notification" size="16px"></sdds-icon>'
+        ? '<i class=" sdds-icon notification"></i>'
+        : '<sdds-icon name="notification" size="16px"></sdds-icon>'
     }
     `;
 
@@ -130,7 +123,15 @@ const Template = ({
     <button class="sdds-chip ${
       icon ? iconPositionLookup[iconPosition] : ''
     } ${activeValue} ${sizeValue}">
-      ${icon ? iconSvg : ''}<span class="sdds-chip-text">${placeholderText}</span>
+      ${
+        icon
+          ? `
+      <div class="sdds-chip-icon">
+        ${iconSvg}
+      </div>
+      `
+          : ''
+      }<span class="sdds-chip-text">${placeholderText}</span>
     </button>
     `);
 };


### PR DESCRIPTION
**Describe pull-request**  
This is to increase the interoperability with react. Web component should not need to have classes on them. From what I could find this was the only place where we were adding a class to a <sdds-icon> komponent.

**Solving issue**  
Fixes: -

**How to test**  
Check that the component still behaves as expected.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
