### PR TITLE
fix(textarea): standardise order of controls in Storybook

### DIFF
--- a/tegel/src/components/textarea/textarea.stories.tsx
+++ b/tegel/src/components/textarea/textarea.stories.tsx
@@ -38,6 +38,9 @@ export default {
         type: 'radio',
       },
       options: ['Default', 'Success', 'Error'],
+      table: {
+        defaultValue: { summary: 'Default' },
+      },
     },
     label: {
       name: 'Label text',
@@ -53,6 +56,9 @@ export default {
         type: 'radio',
       },
       options: ['None', 'Inside', 'Outside'],
+      table: {
+        defaultValue: { summary: 'None' },
+      },
     },
     placeholder: {
       name: 'Placeholder',

--- a/tegel/src/components/textarea/textarea.stories.tsx
+++ b/tegel/src/components/textarea/textarea.stories.tsx
@@ -20,13 +20,6 @@ export default {
     ],
   },
   argTypes: {
-    placeholder: {
-      name: 'Placeholder',
-      description: 'Placeholder text',
-      control: {
-        type: 'text',
-      },
-    },
     modeVariant: {
       name: 'Mode variant',
       description: 'Change the components mode variant',
@@ -38,9 +31,60 @@ export default {
         defaultValue: { summary: 'Inherit from parent' },
       },
     },
-    disabled: {
-      description: 'Set textfield to disabled state',
-      name: 'Disabled',
+    state: {
+      name: 'State',
+      description: 'Switch between success or error state',
+      control: {
+        type: 'radio',
+      },
+      options: ['Default', 'Success', 'Error'],
+    },
+    label: {
+      description: 'Label text for specific textfield',
+      name: 'Label text',
+      control: {
+        type: 'text',
+      },
+    },
+    labelPosition: {
+      name: 'Label position',
+      control: {
+        type: 'radio',
+      },
+      options: ['None', 'Inside', 'Outside'],
+      description: 'Label text position',
+    },
+    placeholder: {
+      name: 'Placeholder',
+      description: 'Placeholder text',
+      control: {
+        type: 'text',
+      },
+    },
+    helper: {
+      name: 'Helper text',
+      description: 'Add helper text for the textfield',
+      control: {
+        type: 'text',
+      },
+    },
+    rows: {
+      name: 'Rows',
+      description: 'Set the number of rows',
+      control: {
+        type: 'number',
+      },
+    },
+    maxLength: {
+      name: 'Max length',
+      description: 'Set a maximum value of how long the text can be.',
+      control: {
+        type: 'number',
+      },
+    },
+    minWidth: {
+      name: 'No minimum width',
+      description: 'Toggle the minimum width.',
       control: {
         type: 'boolean',
       },
@@ -58,45 +102,9 @@ export default {
         defaultValue: { summary: false },
       },
     },
-    label: {
-      description: 'Label text for specific textfield',
-      name: 'Label text',
-      control: {
-        type: 'text',
-      },
-    },
-    labelPosition: {
-      name: 'Label position',
-      control: {
-        type: 'radio',
-      },
-      options: ['None', 'Inside', 'Outside'],
-      description: 'Label text position',
-    },
-    helper: {
-      name: 'Helper text',
-      description: 'Add helper text for the textfield',
-      control: {
-        type: 'text',
-      },
-    },
-    maxLength: {
-      name: 'Max length',
-      description: 'Set a maximum value of how long the text can be.',
-      control: {
-        type: 'number',
-      },
-    },
-    rows: {
-      name: 'Rows',
-      description: 'Set the number of rows',
-      control: {
-        type: 'number',
-      },
-    },
-    minWidth: {
-      name: 'No minimum width',
-      description: 'Toggle the minimum width.',
+    disabled: {
+      description: 'Set textfield to disabled state',
+      name: 'Disabled',
       control: {
         type: 'boolean',
       },
@@ -104,42 +112,34 @@ export default {
         defaultValue: { summary: false },
       },
     },
-    state: {
-      name: 'State',
-      description: 'Switch between success or error state',
-      control: {
-        type: 'radio',
-      },
-      options: ['Default', 'Success', 'Error'],
-    },
   },
   args: {
-    placeholder: 'Placeholder',
-    disabled: false,
-    readonly: false,
+    modeVariant: 'Inherit from parent',
+    state: 'Default',
     label: 'Label',
     labelPosition: 'None',
+    placeholder: 'Placeholder',
     helper: '',
-    maxLength: 0,
     rows: 5,
-    state: 'Default',
-    modeVariant: 'Inherit from parent',
+    maxLength: 0,
     minWidth: false,
+    readonly: false,
+    disabled: false,
   },
 };
 
 const Template = ({
-  placeholder,
-  disabled,
-  readonly,
+  modeVariant,
+  state,
   label,
   labelPosition,
-  state,
+  placeholder,
   helper,
-  maxLength,
-  modeVariant,
-  minWidth,
   rows,
+  maxLength,
+  minWidth,
+  readonly,
+  disabled,
 }) => {
   const maxlength = maxLength > 0 ? `max-length="${maxLength}"` : '';
   const stateValue = state.toLowerCase();

--- a/tegel/src/components/textarea/textarea.stories.tsx
+++ b/tegel/src/components/textarea/textarea.stories.tsx
@@ -88,7 +88,7 @@ export default {
         type: 'number',
       },
     },
-    minWidth: {
+    noMinWidth: {
       name: 'No minimum width',
       description: 'Enables component to shrink below 208px which is the default width.',
       control: {
@@ -128,7 +128,7 @@ export default {
     helper: '',
     rows: 5,
     maxLength: 0,
-    minWidth: false,
+    noMinWidth: false,
     readonly: false,
     disabled: false,
   },
@@ -143,7 +143,7 @@ const Template = ({
   helper,
   rows,
   maxLength,
-  minWidth,
+  noMinWidth,
   readonly,
   disabled,
 }) => {
@@ -176,7 +176,7 @@ const Template = ({
           label-position="${labelPosLookup[labelPosition]}"
           ${disabled ? 'disabled' : ''}
           ${readonly ? 'read-only' : ''}
-          ${minWidth ? 'no-min-width' : ''}
+          ${noMinWidth ? 'no-min-width' : ''}
           placeholder="${placeholder}"
           ${maxlength}>
         </sdds-textarea>

--- a/tegel/src/components/textarea/textarea.stories.tsx
+++ b/tegel/src/components/textarea/textarea.stories.tsx
@@ -50,12 +50,12 @@ export default {
       },
     },
     labelPosition: {
-      name: 'Label position.',
+      name: 'Label position',
       description: 'Sets the label text position.',
       control: {
         type: 'radio',
       },
-      options: ['None', 'Inside', 'Outside'],
+      options: ['No label', 'Inside', 'Outside'],
       table: {
         defaultValue: { summary: 'no-label' },
       },
@@ -123,7 +123,7 @@ export default {
     modeVariant: 'Inherit from parent',
     state: 'Default',
     label: 'Label',
-    labelPosition: 'None',
+    labelPosition: 'No label',
     placeholder: 'Placeholder',
     helper: '',
     rows: 5,
@@ -150,9 +150,9 @@ const Template = ({
   const maxlength = maxLength > 0 ? `max-length="${maxLength}"` : '';
   const stateValue = state.toLowerCase();
   const labelPosLookup = {
-    None: 'no-label',
-    Inside: 'inside',
-    Outside: 'outside',
+    'No label': 'no-label',
+    'Inside': 'inside',
+    'Outside': 'outside',
   };
   return formatHtmlPreview(`
   <style>

--- a/tegel/src/components/textarea/textarea.stories.tsx
+++ b/tegel/src/components/textarea/textarea.stories.tsx
@@ -22,7 +22,7 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
-      description: 'Change the components mode variant',
+      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
@@ -33,58 +33,58 @@ export default {
     },
     state: {
       name: 'State',
-      description: 'Switch between success or error state',
+      description: 'Switches between success and error state.',
       control: {
         type: 'radio',
       },
       options: ['Default', 'Success', 'Error'],
     },
     label: {
-      description: 'Label text for specific textfield',
       name: 'Label text',
+      description: 'Sets the label text.',
       control: {
         type: 'text',
       },
     },
     labelPosition: {
-      name: 'Label position',
+      name: 'Label position.',
+      description: 'Sets the label text position.',
       control: {
         type: 'radio',
       },
       options: ['None', 'Inside', 'Outside'],
-      description: 'Label text position',
     },
     placeholder: {
       name: 'Placeholder',
-      description: 'Placeholder text',
+      description: 'Sets the placeholder text.',
       control: {
         type: 'text',
       },
     },
     helper: {
       name: 'Helper text',
-      description: 'Add helper text for the textfield',
+      description: 'Sets the helper text.',
       control: {
         type: 'text',
       },
     },
     rows: {
       name: 'Rows',
-      description: 'Set the number of rows',
+      description: 'Sets the number of rows.',
       control: {
         type: 'number',
       },
     },
     maxLength: {
       name: 'Max length',
-      description: 'Set a maximum value of how long the text can be.',
+      description: 'Sets a maximum value of how long the text can be.',
       control: {
         type: 'number',
       },
     },
     minWidth: {
       name: 'No minimum width',
-      description: 'Toggle the minimum width.',
+      description: 'Enables component to shrink below 208px which is the default width.',
       control: {
         type: 'boolean',
       },
@@ -93,8 +93,8 @@ export default {
       },
     },
     readonly: {
-      description: 'Set textfield to read-only state',
       name: 'Read only',
+      description: 'Sets the textarea to read-only state.',
       control: {
         type: 'boolean',
       },
@@ -103,8 +103,8 @@ export default {
       },
     },
     disabled: {
-      description: 'Set textfield to disabled state',
       name: 'Disabled',
+      description: 'Disables the textarea.',
       control: {
         type: 'boolean',
       },

--- a/tegel/src/components/textarea/textarea.stories.tsx
+++ b/tegel/src/components/textarea/textarea.stories.tsx
@@ -39,7 +39,7 @@ export default {
       },
       options: ['Default', 'Success', 'Error'],
       table: {
-        defaultValue: { summary: 'Default' },
+        defaultValue: { summary: 'default' },
       },
     },
     label: {
@@ -57,7 +57,7 @@ export default {
       },
       options: ['None', 'Inside', 'Outside'],
       table: {
-        defaultValue: { summary: 'None' },
+        defaultValue: { summary: 'no-label' },
       },
     },
     placeholder: {


### PR DESCRIPTION
**Describe pull-request**  
Standardised order of controls in Storybook for textarea component. Also updated descriptions, added default values and refactored noMinWidth control.

**Solving issue**  
Fixes: [DTS-867](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-867)

**How to test**  
1. Go to Storybook link below
2. Check in Textarea -> Default
3. Inspect order of controls
4. Read control descriptions

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

[DTS-867]: https://tegel.atlassian.net/browse/DTS-867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ