### PR TITLE
fix(textfield): standardise order of controls in Storybook

### DIFF
--- a/tegel/src/components/textfield/textfield.stories.tsx
+++ b/tegel/src/components/textfield/textfield.stories.tsx
@@ -77,7 +77,7 @@ export default {
       control: {
         type: 'radio',
       },
-      options: ['None', 'Inside', 'Outside'],
+      options: ['No label', 'Inside', 'Outside'],
       table: {
         defaultValue: { summary: 'no-label' },
       },
@@ -172,7 +172,7 @@ export default {
     type: 'Text',
     size: 'Large',
     label: 'Label',
-    labelPosition: 'None',
+    labelPosition: 'No label',
     placeholderText: 'Placeholder',
     helper: '',
     prefix: false,

--- a/tegel/src/components/textfield/textfield.stories.tsx
+++ b/tegel/src/components/textfield/textfield.stories.tsx
@@ -22,6 +22,7 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
+      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
@@ -32,7 +33,7 @@ export default {
     },
     state: {
       name: 'State',
-      description: 'Switch between success or error state',
+      description: 'Switches between success and error state.',
       control: {
         type: 'radio',
       },
@@ -48,44 +49,44 @@ export default {
     },
     size: {
       name: 'Size',
-      description: 'Switch between different sizes',
+      description: 'Switches between different sizes.',
       control: {
         type: 'radio',
         options: ['Large', 'Medium', 'Small'],
       },
     },
     label: {
-      description: 'Label text for specific textfield',
       name: 'Label text',
+      description: 'Sets the label text.',
       control: {
         type: 'text',
       },
     },
     labelPosition: {
       name: 'Label position',
+      description: 'Sets the label text position.',
       control: {
         type: 'radio',
       },
       options: ['None', 'Inside', 'Outside'],
-      description: 'Label text position',
     },
     placeholderText: {
       name: 'Placeholder',
-      description: 'Placeholder text',
+      description: 'Sets the placeholder text.',
       control: {
         type: 'text',
       },
     },
     helper: {
       name: 'Helper text',
-      description: 'Add helper text for the textfield',
+      description: 'Sets the helper text.',
       control: {
         type: 'text',
       },
     },
     prefix: {
       name: 'Prefix',
-      description: 'Add prefix symbol/text before the textfield',
+      description: 'Adds a prefix symbol or text before the textfield.',
       control: {
         type: 'boolean',
       },
@@ -95,7 +96,7 @@ export default {
     },
     prefixType: {
       name: 'Prefix type',
-      description: 'Choose icon or text for prefix.',
+      description: 'Switches between icon and text for the prefix.',
       control: {
         type: 'radio',
       },
@@ -104,7 +105,7 @@ export default {
     },
     suffix: {
       name: 'Suffix',
-      description: 'Add suffix symbol/text after the textfield',
+      description: 'Adds a suffix symbol or text after the textfield.',
       control: {
         type: 'boolean',
       },
@@ -114,7 +115,7 @@ export default {
     },
     suffixType: {
       name: 'Suffix type',
-      description: 'Choose icon or text for suffix.',
+      description: 'Swithces between icon or text for the suffix.',
       control: {
         type: 'radio',
       },
@@ -123,14 +124,14 @@ export default {
     },
     maxLength: {
       name: 'Max length',
-      description: 'Set a maximum value of how long the text can be.',
+      description: 'Sets a maximum value of how long the text can be.',
       control: {
         type: 'number',
       },
     },
     minWidth: {
       name: 'No minimum width',
-      description: 'Toggle the minimum width.',
+      description: 'Enables component to shrink below 208px which is the default width.',
       control: {
         type: 'boolean',
       },
@@ -139,14 +140,14 @@ export default {
       },
     },
     readonly: {
-      description: 'Set textfield to read only',
+      description: 'Sets the textfield to read-only state.',
       name: 'Read Only',
       control: {
         type: 'boolean',
       },
     },
     disabled: {
-      description: 'Set textfield to disabled state',
+      description: 'Disables the textfield.',
       name: 'Disabled',
       control: {
         type: 'boolean',

--- a/tegel/src/components/textfield/textfield.stories.tsx
+++ b/tegel/src/components/textfield/textfield.stories.tsx
@@ -38,13 +38,19 @@ export default {
         type: 'radio',
       },
       options: ['Default', 'Success', 'Error'],
+      table: {
+        defaultValue: { summary: 'Default' },
+      },
     },
     type: {
       name: 'Type',
       description: 'Which type of textfield',
       control: {
         type: 'radio',
-        options: ['Password', 'Text'],
+      },
+      options: ['Password', 'Text'],
+      table: {
+        defaultValue: { summary: 'Text' },
       },
     },
     size: {
@@ -52,7 +58,10 @@ export default {
       description: 'Switches between different sizes.',
       control: {
         type: 'radio',
-        options: ['Large', 'Medium', 'Small'],
+      },
+      options: ['Large', 'Medium', 'Small'],
+      table: {
+        defaultValue: { summary: 'Large' },
       },
     },
     label: {
@@ -69,6 +78,9 @@ export default {
         type: 'radio',
       },
       options: ['None', 'Inside', 'Outside'],
+      table: {
+        defaultValue: { summary: 'None' },
+      },
     },
     placeholderText: {
       name: 'Placeholder',
@@ -102,6 +114,9 @@ export default {
       },
       options: ['Icon', 'Text'],
       if: { arg: 'prefix', eq: true },
+      table: {
+        defaultValue: { summary: 'Icon' },
+      },
     },
     suffix: {
       name: 'Suffix',
@@ -121,6 +136,9 @@ export default {
       },
       options: ['Icon', 'Text'],
       if: { arg: 'suffix', eq: true },
+      table: {
+        defaultValue: { summary: 'Icon' },
+      },
     },
     maxLength: {
       name: 'Max length',
@@ -145,12 +163,18 @@ export default {
       control: {
         type: 'boolean',
       },
+      table: {
+        defaultValue: { summary: false },
+      },
     },
     disabled: {
       description: 'Disables the textfield.',
       name: 'Disabled',
       control: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
       },
     },
   },

--- a/tegel/src/components/textfield/textfield.stories.tsx
+++ b/tegel/src/components/textfield/textfield.stories.tsx
@@ -48,7 +48,7 @@ export default {
       control: {
         type: 'radio',
       },
-      options: ['Password', 'Text'],
+      options: ['Text', 'Password'],
       table: {
         defaultValue: { summary: 'text' },
       },

--- a/tegel/src/components/textfield/textfield.stories.tsx
+++ b/tegel/src/components/textfield/textfield.stories.tsx
@@ -20,21 +20,6 @@ export default {
     ],
   },
   argTypes: {
-    placeholderText: {
-      name: 'Placeholder',
-      description: 'Placeholder text',
-      control: {
-        type: 'text',
-      },
-    },
-    type: {
-      name: 'Type',
-      description: 'Which type of textfield',
-      control: {
-        type: 'radio',
-        options: ['Password', 'Text'],
-      },
-    },
     modeVariant: {
       name: 'Mode variant',
       control: {
@@ -45,36 +30,28 @@ export default {
         defaultValue: { summary: 'Inherit from parent' },
       },
     },
+    state: {
+      name: 'State',
+      description: 'Switch between success or error state',
+      control: {
+        type: 'radio',
+      },
+      options: ['Default', 'Success', 'Error'],
+    },
+    type: {
+      name: 'Type',
+      description: 'Which type of textfield',
+      control: {
+        type: 'radio',
+        options: ['Password', 'Text'],
+      },
+    },
     size: {
       name: 'Size',
       description: 'Switch between different sizes',
       control: {
         type: 'radio',
         options: ['Large', 'Medium', 'Small'],
-      },
-    },
-    minWidth: {
-      name: 'No minimum width',
-      description: 'Toggle the minimum width.',
-      control: {
-        type: 'boolean',
-      },
-      table: {
-        defaultValue: { summary: false },
-      },
-    },
-    disabled: {
-      description: 'Set textfield to disabled state',
-      name: 'Disabled',
-      control: {
-        type: 'boolean',
-      },
-    },
-    readonly: {
-      description: 'Set textfield to read only',
-      name: 'Read Only',
-      control: {
-        type: 'boolean',
       },
     },
     label: {
@@ -91,6 +68,20 @@ export default {
       },
       options: ['None', 'Inside', 'Outside'],
       description: 'Label text position',
+    },
+    placeholderText: {
+      name: 'Placeholder',
+      description: 'Placeholder text',
+      control: {
+        type: 'text',
+      },
+    },
+    helper: {
+      name: 'Helper text',
+      description: 'Add helper text for the textfield',
+      control: {
+        type: 'text',
+      },
     },
     prefix: {
       name: 'Prefix',
@@ -130,13 +121,6 @@ export default {
       options: ['Icon', 'Text'],
       if: { arg: 'suffix', eq: true },
     },
-    helper: {
-      name: 'Helper text',
-      description: 'Add helper text for the textfield',
-      control: {
-        type: 'text',
-      },
-    },
     maxLength: {
       name: 'Max length',
       description: 'Set a maximum value of how long the text can be.',
@@ -144,52 +128,68 @@ export default {
         type: 'number',
       },
     },
-    state: {
-      name: 'State',
-      description: 'Switch between success or error state',
+    minWidth: {
+      name: 'No minimum width',
+      description: 'Toggle the minimum width.',
       control: {
-        type: 'radio',
+        type: 'boolean',
       },
-      options: ['Default', 'Success', 'Error'],
+      table: {
+        defaultValue: { summary: false },
+      },
+    },
+    readonly: {
+      description: 'Set textfield to read only',
+      name: 'Read Only',
+      control: {
+        type: 'boolean',
+      },
+    },
+    disabled: {
+      description: 'Set textfield to disabled state',
+      name: 'Disabled',
+      control: {
+        type: 'boolean',
+      },
     },
   },
   args: {
-    placeholderText: 'Placeholder',
-    disabled: false,
-    readonly: false,
+    modeVariant: 'Inherit from parent',
+    state: 'Default',
+    type: 'Text',
+    size: 'Large',
     label: 'Label',
     labelPosition: 'None',
+    placeholderText: 'Placeholder',
     helper: '',
-    maxLength: 0,
-    state: 'Default',
-    suffix: false,
-    suffixType: 'Icon',
     prefix: false,
     prefixType: 'Icon',
+    suffix: false,
+    suffixType: 'Icon',
+    maxLength: 0,
     minWidth: 'Default',
-    size: 'Large',
-    type: 'Text',
-    modeVariant: 'Inherit from parent',
+    readonly: false,
+    disabled: false,
   },
 };
 
 const Template = ({
+  modeVariant,
+  state,
   type,
-  placeholderText,
   size,
-  minWidth,
-  disabled,
-  readonly,
   label,
   labelPosition,
-  state,
+  placeholderText,
   helper,
   prefix,
   prefixType,
   suffix,
   suffixType,
   maxLength,
-  modeVariant,
+  minWidth,
+  readonly,
+  disabled,
 }) => {
   const maxlength = maxLength > 0 ? `max-length="${maxLength}"` : '';
   const stateValue = state.toLowerCase();

--- a/tegel/src/components/textfield/textfield.stories.tsx
+++ b/tegel/src/components/textfield/textfield.stories.tsx
@@ -39,7 +39,7 @@ export default {
       },
       options: ['Default', 'Success', 'Error'],
       table: {
-        defaultValue: { summary: 'Default' },
+        defaultValue: { summary: 'default' },
       },
     },
     type: {
@@ -50,7 +50,7 @@ export default {
       },
       options: ['Password', 'Text'],
       table: {
-        defaultValue: { summary: 'Text' },
+        defaultValue: { summary: 'text' },
       },
     },
     size: {
@@ -61,7 +61,7 @@ export default {
       },
       options: ['Large', 'Medium', 'Small'],
       table: {
-        defaultValue: { summary: 'Large' },
+        defaultValue: { summary: 'lg' },
       },
     },
     label: {
@@ -79,7 +79,7 @@ export default {
       },
       options: ['None', 'Inside', 'Outside'],
       table: {
-        defaultValue: { summary: 'None' },
+        defaultValue: { summary: 'no-label' },
       },
     },
     placeholderText: {
@@ -102,9 +102,6 @@ export default {
       control: {
         type: 'boolean',
       },
-      table: {
-        defaultValue: { summary: false },
-      },
     },
     prefixType: {
       name: 'Prefix type',
@@ -114,18 +111,12 @@ export default {
       },
       options: ['Icon', 'Text'],
       if: { arg: 'prefix', eq: true },
-      table: {
-        defaultValue: { summary: 'Icon' },
-      },
     },
     suffix: {
       name: 'Suffix',
       description: 'Adds a suffix symbol or text after the textfield.',
       control: {
         type: 'boolean',
-      },
-      table: {
-        defaultValue: { summary: false },
       },
     },
     suffixType: {
@@ -136,9 +127,6 @@ export default {
       },
       options: ['Icon', 'Text'],
       if: { arg: 'suffix', eq: true },
-      table: {
-        defaultValue: { summary: 'Icon' },
-      },
     },
     maxLength: {
       name: 'Max length',

--- a/tegel/src/components/textfield/textfield.stories.tsx
+++ b/tegel/src/components/textfield/textfield.stories.tsx
@@ -135,7 +135,7 @@ export default {
         type: 'number',
       },
     },
-    minWidth: {
+    noMinWidth: {
       name: 'No minimum width',
       description: 'Enables component to shrink below 208px which is the default width.',
       control: {
@@ -180,7 +180,7 @@ export default {
     suffix: false,
     suffixType: 'Icon',
     maxLength: 0,
-    minWidth: 'Default',
+    noMinWidth: 'Default',
     readonly: false,
     disabled: false,
   },
@@ -200,7 +200,7 @@ const Template = ({
   suffix,
   suffixType,
   maxLength,
-  minWidth,
+  noMinWidth,
   readonly,
   disabled,
 }) => {
@@ -233,7 +233,7 @@ const Template = ({
       ${maxlength}
       ${disabled ? 'disabled' : ''}
       ${readonly ? 'read-only' : ''}
-      ${minWidth ? 'no-min-width' : ''}
+      ${noMinWidth ? 'no-min-width' : ''}
       placeholder="${placeholderText}" >
         ${
           prefix


### PR DESCRIPTION
**Describe pull-request**  
Standardised order of controls in Storybook for textfield component. Also updated descriptions, added default values and refactored noMinWidth control.

**Solving issue**  
Fixes: [DTS-868](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-868)

**How to test**  
1. Go to Storybook link below
2. Check in Textfield -> Default
3. Inspect order of controls
4. Read control descriptions

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

[DTS-868]: https://tegel.atlassian.net/browse/DTS-868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ