### PR TITLE
fix: align default values to props

### DIFF
--- a/tegel/src/components/accordion/accordion.stories.tsx
+++ b/tegel/src/components/accordion/accordion.stories.tsx
@@ -34,7 +34,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: { summary: 'false' },
+        defaultValue: { summary: false },
       },
     },
     disabled: {
@@ -44,7 +44,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: { summary: 'false' },
+        defaultValue: { summary: false },
       },
     },
   },

--- a/tegel/src/components/badge/badge.stories.tsx
+++ b/tegel/src/components/badge/badge.stories.tsx
@@ -41,9 +41,6 @@ export default {
         type: 'number',
       },
       if: { arg: 'size', neq: 'sm' },
-      table: {
-        defaultValue: { summary: null },
-      },
     },
     hidden: {
       name: 'Hidden',

--- a/tegel/src/components/banner/sdds-banner.stories.tsx
+++ b/tegel/src/components/banner/sdds-banner.stories.tsx
@@ -31,7 +31,7 @@ export default {
         type: 'radio',
       },
       table: {
-        defaultValue: { summary: 'default' },
+        defaultValue: { summary: 'none' },
       },
     },
     header: {
@@ -80,9 +80,6 @@ export default {
         type: 'select',
       },
       options: [...iconsNames, 'none'],
-      table: {
-        defaultValue: { summary: 'none' },
-      },
       if: { arg: 'type', eq: 'Default' },
     },
     persistent: {
@@ -92,7 +89,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: { summary: 'false' },
+        defaultValue: { summary: false },
       },
     },
   },

--- a/tegel/src/components/button/button-webcomponent.stories.tsx
+++ b/tegel/src/components/button/button-webcomponent.stories.tsx
@@ -96,9 +96,6 @@ export default {
         type: 'select',
       },
       options: ['none', ...iconsNames],
-      table: {
-        defaultValue: { summary: 'none' },
-      },
       if: { arg: 'size', neq: 'Extra small' },
     },
     iconType: {
@@ -108,9 +105,6 @@ export default {
         type: 'radio',
       },
       options: ['Native', 'Web Component'],
-      table: {
-        defaultValue: { summary: 'Web Component' },
-      },
       if: { arg: 'size', neq: 'Extra small' },
     },
     disabled: {

--- a/tegel/src/components/card/sdds-card.stories.tsx
+++ b/tegel/src/components/card/sdds-card.stories.tsx
@@ -52,9 +52,6 @@ export default {
       control: {
         type: 'boolean',
       },
-      table: {
-        defaultValue: { summary: true },
-      },
     },
     headerPlacement: {
       name: 'Header placement',
@@ -73,9 +70,6 @@ export default {
       control: {
         type: 'boolean',
       },
-      table: {
-        defaultValue: { summary: false },
-      },
       if: { arg: 'bodyDivider', eq: false },
     },
     bodyContent: {
@@ -91,10 +85,10 @@ export default {
       control: {
         type: 'boolean',
       },
+      if: { arg: 'bodyImg', eq: false },
       table: {
         defaultValue: { summary: false },
       },
-      if: { arg: 'bodyImg', eq: false },
     },
     cardBottom: {
       name: 'Content of the bottom of the card',

--- a/tegel/src/components/card/sdds-card.stories.tsx
+++ b/tegel/src/components/card/sdds-card.stories.tsx
@@ -29,7 +29,7 @@ export default {
       },
       options: ['Inherit from parent', 'Primary', 'Secondary'],
       table: {
-        defaultValue: { summary: 'primary' },
+        defaultValue: { summary: 'Inherit from parent' },
       },
     },
     header: {

--- a/tegel/src/components/data-table/table-component-basic.stories.tsx
+++ b/tegel/src/components/data-table/table-component-basic.stories.tsx
@@ -82,9 +82,6 @@ export default {
       control: {
         type: 'boolean',
       },
-      table: {
-        defaultValue: { summary: false },
-      },
     },
     column1Width: {
       name: 'Column 1 width',

--- a/tegel/src/components/data-table/table-component-batch-actions.stories.tsx
+++ b/tegel/src/components/data-table/table-component-batch-actions.stories.tsx
@@ -79,9 +79,6 @@ export default {
       control: {
         type: 'boolean',
       },
-      table: {
-        defaultValue: { summary: false },
-      },
     },
     column1Width: {
       name: 'Column 1 width',

--- a/tegel/src/components/data-table/table-component-custom-width.stories.tsx
+++ b/tegel/src/components/data-table/table-component-custom-width.stories.tsx
@@ -72,9 +72,6 @@ export default {
       control: {
         type: 'boolean',
       },
-      table: {
-        defaultValue: { summary: false },
-      },
     },
     column1Width: {
       name: 'Column 1 width',

--- a/tegel/src/components/data-table/table-component-event-listeners.stories.tsx
+++ b/tegel/src/components/data-table/table-component-event-listeners.stories.tsx
@@ -72,9 +72,6 @@ export default {
       control: {
         type: 'boolean',
       },
-      table: {
-        defaultValue: { summary: false },
-      },
     },
     column1Width: {
       name: 'Column 1 width',

--- a/tegel/src/components/data-table/table-component-expandable-rows.stories.tsx
+++ b/tegel/src/components/data-table/table-component-expandable-rows.stories.tsx
@@ -72,9 +72,6 @@ export default {
       control: {
         type: 'boolean',
       },
-      table: {
-        defaultValue: { summary: false },
-      },
     },
     column1Width: {
       name: 'Column 1 width',

--- a/tegel/src/components/data-table/table-component-filtering.stories.tsx
+++ b/tegel/src/components/data-table/table-component-filtering.stories.tsx
@@ -63,9 +63,6 @@ export default {
       control: {
         type: 'boolean',
       },
-      table: {
-        defaultValue: { summary: true },
-      },
     },
     verticalDivider: {
       name: 'Vertical dividers',
@@ -82,9 +79,6 @@ export default {
       description: 'Resets min-width rule and enables setting column width value to less than 192px which is the default. When enabled, controls for column width will show here.',
       control: {
         type: 'boolean',
-      },
-      table: {
-        defaultValue: { summary: false },
       },
     },
     column1Width: {

--- a/tegel/src/components/data-table/table-component-multiselect.stories.tsx
+++ b/tegel/src/components/data-table/table-component-multiselect.stories.tsx
@@ -63,7 +63,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: { summary: true },
+        defaultValue: { summary: false },
       },
     },
     verticalDivider: {
@@ -81,9 +81,6 @@ export default {
       description: 'Resets min-width rule and enables setting column width value to less than 192px which is the default. When enabled, controls for column width will show here.',
       control: {
         type: 'boolean',
-      },
-      table: {
-        defaultValue: { summary: false },
       },
     },
     column1Width: {

--- a/tegel/src/components/data-table/table-component-pagination.stories.tsx
+++ b/tegel/src/components/data-table/table-component-pagination.stories.tsx
@@ -63,7 +63,7 @@ export default {
         type: 'number',
       },
       table: {
-        defaultValue: { summary: 4 },
+        defaultValue: { summary: 5 },
       },
     },
     verticalDivider: {
@@ -81,9 +81,6 @@ export default {
       description: 'Resets min-width rule and enables setting column width value to less than 192px which is the default. When enabled, controls for column width will show here.',
       control: {
         type: 'boolean',
-      },
-      table: {
-        defaultValue: { summary: false },
       },
     },
     column1Width: {

--- a/tegel/src/components/data-table/table-component-sorting.stories.tsx
+++ b/tegel/src/components/data-table/table-component-sorting.stories.tsx
@@ -62,12 +62,18 @@ export default {
       control: {
         type: 'boolean',
       },
+      table: {
+        defaultValue: { summary: false },
+      },
     },
     column2sortable: {
       name: 'Column 2 is sortable',
       description: 'Enables column 2 to be sorted alphabetically.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
       },
     },
     column3sortable: {
@@ -76,12 +82,18 @@ export default {
       control: {
         type: 'boolean',
       },
+      table: {
+        defaultValue: { summary: false },
+      },
     },
     column4sortable: {
       name: 'Column 4 is sortable',
       description: 'Enables column 4 to be sorted alphabetically.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: false },
       },
     },
     verticalDivider: {
@@ -99,9 +111,6 @@ export default {
       description: 'Resets min-width rule and enables setting column width value to less than 192px which is the default. When enabled, controls for column width will show here.',
       control: {
         type: 'boolean',
-      },
-      table: {
-        defaultValue: { summary: false },
       },
     },
     column1Width: {

--- a/tegel/src/components/datetime/datetime.stories.tsx
+++ b/tegel/src/components/datetime/datetime.stories.tsx
@@ -38,9 +38,6 @@ export default {
         type: 'radio',
       },
       options: ['None', 'Success', 'Error'],
-      table: {
-        defaultValue: { summary: 'none' },
-      },
     },
     type: {
       name: 'Type',

--- a/tegel/src/components/footer/webcomponent/sdds-footer.stories.tsx
+++ b/tegel/src/components/footer/webcomponent/sdds-footer.stories.tsx
@@ -39,9 +39,6 @@ export default {
       control: {
         type: 'boolean',
       },
-      table: {
-        defaultValue: { summary: false },
-      },
     },
   },
   args: {

--- a/tegel/src/components/message/sdds-message.stories.tsx
+++ b/tegel/src/components/message/sdds-message.stories.tsx
@@ -63,7 +63,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: { summary: 'false' },
+        defaultValue: { summary: false },
       },
     },
     noIcon: {
@@ -73,7 +73,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: { summary: 'false' },
+        defaultValue: { summary: false },
       },
     },
   },

--- a/tegel/src/components/modal/modal-webcomponent.stories.tsx
+++ b/tegel/src/components/modal/modal-webcomponent.stories.tsx
@@ -28,7 +28,7 @@ export default {
       },
       options: ['Sticky', 'Static'],
       table: {
-        defaultValue: { summary: 'Static' },
+        defaultValue: { summary: 'static' },
       },
     },
     size: {
@@ -39,7 +39,7 @@ export default {
       },
       options: ['Large', 'Medium', 'Small', 'Extra small'],
       table: {
-        defaultValue: { summary: 'lg' },
+        defaultValue: { summary: 'md' },
       },
     },
     headline: {
@@ -61,9 +61,6 @@ export default {
       description: 'Toggles if the modal is displayed.',
       control: {
         type: 'boolean',
-      },
-      table: {
-        defaultValue: { summary: true },
       },
     },
   },

--- a/tegel/src/components/popover-canvas/popover-canvas.stories.tsx
+++ b/tegel/src/components/popover-canvas/popover-canvas.stories.tsx
@@ -30,7 +30,7 @@ export default {
         'Auto',
       ],
       table: {
-        defaultValue: { summary: 'Auto' },
+        defaultValue: { summary: 'auto' },
       },
     },
   },

--- a/tegel/src/components/popover-menu/popover-menu-icons.stories.tsx
+++ b/tegel/src/components/popover-menu/popover-menu-icons.stories.tsx
@@ -42,7 +42,7 @@ export default {
         'Auto',
       ],
       table: {
-        defaultValue: { summary: 'Auto' },
+        defaultValue: { summary: 'auto' },
       },
     },
   },

--- a/tegel/src/components/popover-menu/popover-menu.stories.tsx
+++ b/tegel/src/components/popover-menu/popover-menu.stories.tsx
@@ -42,7 +42,7 @@ export default {
         'Auto',
       ],
       table: {
-        defaultValue: { summary: 'Auto' },
+        defaultValue: { summary: 'auto' },
       },
     },
   },

--- a/tegel/src/components/radio-button/radio-button-component.stories.tsx
+++ b/tegel/src/components/radio-button/radio-button-component.stories.tsx
@@ -34,7 +34,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: { summary: 'false' },
+        defaultValue: { summary: false },
       },
     },
   },

--- a/tegel/src/components/slider/readme.md
+++ b/tegel/src/components/slider/readme.md
@@ -9,21 +9,21 @@
 
 | Property          | Attribute           | Description                                                                      | Type         | Default               |
 | ----------------- | ------------------- | -------------------------------------------------------------------------------- | ------------ | --------------------- |
-| `controls`        | `controls`          | Decide to show the controls or not                                               | `boolean`    | `null`                |
-| `disabled`        | `disabled`          | Sets the disabled state for the whole component                                  | `boolean`    | `null`                |
-| `input`           | `input`             | Decide to show the input field or not                                            | `boolean`    | `null`                |
+| `controls`        | `controls`          | Decide to show the controls or not                                               | `boolean`    | `false`               |
+| `disabled`        | `disabled`          | Sets the disabled state for the whole component                                  | `boolean`    | `false`               |
+| `input`           | `input`             | Decide to show the input field or not                                            | `boolean`    | `false`               |
 | `label`           | `label`             | Text for label                                                                   | `string`     | `''`                  |
 | `max`             | `max`               | Maximum value                                                                    | `string`     | `'100'`               |
 | `min`             | `min`               | Minimum value                                                                    | `string`     | `'0'`                 |
 | `name`            | `name`              | Name property (will be inherited by the native slider component)                 | `string`     | `''`                  |
-| `readOnly`        | `read-only`         | Sets the read only state for the whole component                                 | `boolean`    | `null`                |
+| `readOnly`        | `read-only`         | Sets the read only state for the whole component                                 | `boolean`    | `false`               |
 | `showTickNumbers` | `show-tick-numbers` | Decide to show numbers above the tick markers or not                             | `boolean`    | `false`               |
 | `size`            | `size`              | Sets the size of the scrubber                                                    | `"" \| "sm"` | `''`                  |
 | `sliderId`        | `slider-id`         | Id for the sliders input element, randomly generated if not specified.           | `string`     | `crypto.randomUUID()` |
-| `snap`            | `snap`              | Snap to the ticks grid                                                           | `boolean`    | `null`                |
+| `snap`            | `snap`              | Snap to the ticks grid                                                           | `boolean`    | `false`               |
 | `step`            | `step`              | Defines how much to increment/decrement the value when using controls            | `string`     | `'1'`                 |
 | `ticks`           | `ticks`             | Number of tick markers (tick for min- and max-value will be added automatically) | `string`     | `'0'`                 |
-| `tooltip`         | `tooltip`           | Decide to show the tooltip or not                                                | `boolean`    | `null`                |
+| `tooltip`         | `tooltip`           | Decide to show the tooltip or not                                                | `boolean`    | `false`               |
 | `value`           | `value`             | Initial value                                                                    | `string`     | `'0'`                 |
 
 

--- a/tegel/src/components/slider/slider.stories.tsx
+++ b/tegel/src/components/slider/slider.stories.tsx
@@ -40,9 +40,6 @@ export default {
       control: {
         type: 'boolean',
       },
-      table: {
-        defaultValue: { summary: false },
-      },
     },
     labelText: {
       name: 'Label text',
@@ -58,9 +55,6 @@ export default {
       control: {
         type: 'boolean',
       },
-      table: {
-        defaultValue: { summary: false },
-      },
     },
     numTicks: {
       name: 'Number of ticks',
@@ -69,6 +63,10 @@ export default {
         type: 'number',
       },
       if: { arg: 'showTicks', eq: true },
+      
+      table: {
+        defaultValue: { summary: 0 },
+      },
     },
     showTickNumbers: {
       name: 'Show tick numbers',
@@ -78,7 +76,7 @@ export default {
       },
       if: { arg: 'showTicks', eq: true },
       table: {
-        defaultValue: { summary: 3 },
+        defaultValue: { summary: false },
       },
     },
     snapToTicks: {
@@ -99,7 +97,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: { summary: true },
+        defaultValue: { summary: false },
       },
     },
     showControls: {

--- a/tegel/src/components/slider/slider.tsx
+++ b/tegel/src/components/slider/slider.tsx
@@ -25,19 +25,19 @@ export class Slider {
   @Prop() showTickNumbers: boolean = false;
 
   /** Decide to show the tooltip or not */
-  @Prop() tooltip: boolean = null;
+  @Prop() tooltip: boolean = false;
 
   /** Sets the disabled state for the whole component  */
-  @Prop() disabled: boolean = null;
+  @Prop() disabled: boolean = false;
 
   /** Sets the read only state for the whole component  */
-  @Prop() readOnly: boolean = null;
+  @Prop() readOnly: boolean = false;
 
   /** Decide to show the controls or not */
-  @Prop() controls: boolean = null;
+  @Prop() controls: boolean = false;
 
   /** Decide to show the input field or not */
-  @Prop() input: boolean = null;
+  @Prop() input: boolean = false;
 
   /** Defines how much to increment/decrement the value when using controls */
   @Prop() step: string = '1';
@@ -49,7 +49,7 @@ export class Slider {
   @Prop() size: 'sm' | '' = '';
 
   /** Snap to the ticks grid */
-  @Prop() snap: boolean = null;
+  @Prop() snap: boolean = false;
 
   /** Id for the sliders input element, randomly generated if not specified. */
   @Prop() sliderId: string = crypto.randomUUID();

--- a/tegel/src/components/spinner/spinner.stories.tsx
+++ b/tegel/src/components/spinner/spinner.stories.tsx
@@ -28,7 +28,7 @@ export default {
       },
       options: ['Standard', 'Inverted'],
       table: {
-        defaultValue: { summary: 'Standard' },
+        defaultValue: { summary: 'standard' },
       },
     },
     size: {
@@ -39,7 +39,7 @@ export default {
       },
       options: ['Large', 'Medium', 'Small', 'Extra small'],
       table: {
-        defaultValue: { summary: 'Large' },
+        defaultValue: { summary: 'lg' },
       },
     },
   },


### PR DESCRIPTION
**Describe pull-request**  
Aligned all default values in Storybook with the corresponding props for web components. The few components that are not included in this PR either didn't need alignment or will be handled in their own standardisation on controls PR.

**Solving issue**  
Fixes: [DTS-1023](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-1023)

**How to test**  
1. Go to Storybook link below
2. Check that the default values of the controls are the same as the default values in the notes in Storybook*

*If the default value in the notes is "null" or "undefined" (except for modeVariant which should always be "Inherit from parent") the control default value should be empty.

[DTS-1023]: https://tegel.atlassian.net/browse/DTS-1023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ