### PR TITLE
fix(slider): refactor control for scrubber size

### DIFF
--- a/tegel/src/components/slider/readme.md
+++ b/tegel/src/components/slider/readme.md
@@ -7,24 +7,24 @@
 
 ## Properties
 
-| Property          | Attribute           | Description                                                                      | Type         | Default               |
-| ----------------- | ------------------- | -------------------------------------------------------------------------------- | ------------ | --------------------- |
-| `controls`        | `controls`          | Decide to show the controls or not                                               | `boolean`    | `false`               |
-| `disabled`        | `disabled`          | Sets the disabled state for the whole component                                  | `boolean`    | `false`               |
-| `input`           | `input`             | Decide to show the input field or not                                            | `boolean`    | `false`               |
-| `label`           | `label`             | Text for label                                                                   | `string`     | `''`                  |
-| `max`             | `max`               | Maximum value                                                                    | `string`     | `'100'`               |
-| `min`             | `min`               | Minimum value                                                                    | `string`     | `'0'`                 |
-| `name`            | `name`              | Name property (will be inherited by the native slider component)                 | `string`     | `''`                  |
-| `readOnly`        | `read-only`         | Sets the read only state for the whole component                                 | `boolean`    | `false`               |
-| `showTickNumbers` | `show-tick-numbers` | Decide to show numbers above the tick markers or not                             | `boolean`    | `false`               |
-| `size`            | `size`              | Sets the size of the scrubber                                                    | `"" \| "sm"` | `''`                  |
-| `sliderId`        | `slider-id`         | Id for the sliders input element, randomly generated if not specified.           | `string`     | `crypto.randomUUID()` |
-| `snap`            | `snap`              | Snap to the ticks grid                                                           | `boolean`    | `false`               |
-| `step`            | `step`              | Defines how much to increment/decrement the value when using controls            | `string`     | `'1'`                 |
-| `ticks`           | `ticks`             | Number of tick markers (tick for min- and max-value will be added automatically) | `string`     | `'0'`                 |
-| `tooltip`         | `tooltip`           | Decide to show the tooltip or not                                                | `boolean`    | `false`               |
-| `value`           | `value`             | Initial value                                                                    | `string`     | `'0'`                 |
+| Property          | Attribute           | Description                                                                      | Type           | Default               |
+| ----------------- | ------------------- | -------------------------------------------------------------------------------- | -------------- | --------------------- |
+| `controls`        | `controls`          | Decide to show the controls or not                                               | `boolean`      | `false`               |
+| `disabled`        | `disabled`          | Sets the disabled state for the whole component                                  | `boolean`      | `false`               |
+| `input`           | `input`             | Decide to show the input field or not                                            | `boolean`      | `false`               |
+| `label`           | `label`             | Text for label                                                                   | `string`       | `''`                  |
+| `max`             | `max`               | Maximum value                                                                    | `string`       | `'100'`               |
+| `min`             | `min`               | Minimum value                                                                    | `string`       | `'0'`                 |
+| `name`            | `name`              | Name property (will be inherited by the native slider component)                 | `string`       | `''`                  |
+| `readOnly`        | `read-only`         | Sets the read only state for the whole component                                 | `boolean`      | `false`               |
+| `showTickNumbers` | `show-tick-numbers` | Decide to show numbers above the tick markers or not                             | `boolean`      | `false`               |
+| `size`            | `size`              | Sets the size of the scrubber                                                    | `"lg" \| "sm"` | `'lg'`                |
+| `sliderId`        | `slider-id`         | Id for the sliders input element, randomly generated if not specified.           | `string`       | `crypto.randomUUID()` |
+| `snap`            | `snap`              | Snap to the ticks grid                                                           | `boolean`      | `false`               |
+| `step`            | `step`              | Defines how much to increment/decrement the value when using controls            | `string`       | `'1'`                 |
+| `ticks`           | `ticks`             | Number of tick markers (tick for min- and max-value will be added automatically) | `string`       | `'0'`                 |
+| `tooltip`         | `tooltip`           | Decide to show the tooltip or not                                                | `boolean`      | `false`               |
+| `value`           | `value`             | Initial value                                                                    | `string`       | `'0'`                 |
 
 
 ## Events

--- a/tegel/src/components/slider/readme.md
+++ b/tegel/src/components/slider/readme.md
@@ -17,8 +17,8 @@
 | `min`             | `min`               | Minimum value                                                                    | `string`       | `'0'`                 |
 | `name`            | `name`              | Name property (will be inherited by the native slider component)                 | `string`       | `''`                  |
 | `readOnly`        | `read-only`         | Sets the read only state for the whole component                                 | `boolean`      | `false`               |
+| `scrubberSize`    | `scrubber-size`     | Sets the size of the scrubber                                                    | `"lg" \| "sm"` | `'lg'`                |
 | `showTickNumbers` | `show-tick-numbers` | Decide to show numbers above the tick markers or not                             | `boolean`      | `false`               |
-| `size`            | `size`              | Sets the size of the scrubber                                                    | `"lg" \| "sm"` | `'lg'`                |
 | `sliderId`        | `slider-id`         | Id for the sliders input element, randomly generated if not specified.           | `string`       | `crypto.randomUUID()` |
 | `snap`            | `snap`              | Snap to the ticks grid                                                           | `boolean`      | `false`               |
 | `step`            | `step`              | Defines how much to increment/decrement the value when using controls            | `string`       | `'1'`                 |

--- a/tegel/src/components/slider/slider.stories.tsx
+++ b/tegel/src/components/slider/slider.stories.tsx
@@ -236,7 +236,7 @@ const Template = ({
       ${showControls ? 'controls' : ''} 
       ${showInput ? 'input' : ''} 
       ${disabled ? 'disabled' : ''} 
-      size="${sizeLookUp[scrubberSize]}"
+      scrubber-size="${sizeLookUp[scrubberSize]}"
       ${readonly ? 'read-only' : ''} 
       >
 

--- a/tegel/src/components/slider/slider.stories.tsx
+++ b/tegel/src/components/slider/slider.stories.tsx
@@ -132,14 +132,15 @@ export default {
         defaultValue: { summary: false },
       },
     },
-    small: {
-      name: 'Small',
-      description: 'Toggles if the small variant of the scrubber should be used.',
+    scrubberSize: {
+      name: 'Scrubber size',
+      description: 'Switches between the large and small version of the scrubber.',
       control: {
-        type: 'boolean',
+        type: 'radio',
       },
+      options: ['Large', 'Small'],
       table: {
-        defaultValue: { summary: false },
+        defaultValue: { summary: 'lg' },
       },
     },
     readonly: {
@@ -192,11 +193,17 @@ export default {
     showControls: false,
     step: '1',
     showInput: false,
-    small: false,
+    scrubberSize: 'Large',
     readonly: false,
     disabled: false,
   },
 };
+
+const sizeLookUp = {
+  'Large': 'lg',
+  'Small': 'sm',
+};
+
 const Template = ({
   min,
   max,
@@ -211,7 +218,7 @@ const Template = ({
   showControls,
   step,
   showInput,
-  small,
+  scrubberSize,
   readonly,
   disabled,
 }) =>
@@ -229,7 +236,7 @@ const Template = ({
       ${showControls ? 'controls' : ''} 
       ${showInput ? 'input' : ''} 
       ${disabled ? 'disabled' : ''} 
-      ${small ? 'size="sm"' : ''}
+      size="${sizeLookUp[scrubberSize]}"
       ${readonly ? 'read-only' : ''} 
       >
 

--- a/tegel/src/components/slider/slider.tsx
+++ b/tegel/src/components/slider/slider.tsx
@@ -46,7 +46,7 @@ export class Slider {
   @Prop() name: string = '';
 
   /** Sets the size of the scrubber */
-  @Prop() size: 'sm' | 'lg' = 'lg';
+  @Prop() scrubberSize: 'sm' | 'lg' = 'lg';
 
   /** Snap to the ticks grid */
   @Prop() snap: boolean = false;
@@ -452,7 +452,7 @@ export class Slider {
 
     this.useSmall = false;
 
-    if (this.size === 'sm') {
+    if (this.scrubberSize === 'sm') {
       this.useSmall = true;
     }
 

--- a/tegel/src/components/slider/slider.tsx
+++ b/tegel/src/components/slider/slider.tsx
@@ -46,7 +46,7 @@ export class Slider {
   @Prop() name: string = '';
 
   /** Sets the size of the scrubber */
-  @Prop() size: 'sm' | '' = '';
+  @Prop() size: 'sm' | 'lg' = 'lg';
 
   /** Snap to the ticks grid */
   @Prop() snap: boolean = false;


### PR DESCRIPTION
**Describe pull-request**  
Refactored control for scrubber size in slider component to better align with the corresponding prop.

**Solving issue**  
Fixes: [DTS-1082](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-1082)

**How to test**  
1. Go to Storybook link below
2. Check in Slider -> Default
3. Check that the "Scrubber size" control changes the size of the scrubber
4. Check the "scrubberSize" default value in the Notes tab

[DTS-1082]: https://tegel.atlassian.net/browse/DTS-1082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ