### PR TITLE
fix(accordion): remove unused divider prop

### DIFF
--- a/tegel/src/components/accordion/accordion.tsx
+++ b/tegel/src/components/accordion/accordion.tsx
@@ -6,16 +6,13 @@ import { Component, h, Host, Prop } from '@stencil/core';
   shadow: true,
 })
 export class Accordion {
-  /** Enable or disable divider lines between items */
-  @Prop() divider: boolean = true;
-
   /** Set the variant of the the accordion. */
   @Prop() modeVariant: 'primary' | 'secondary' = null;
 
   render() {
     return (
       <Host
-        class={`sdds-accordion ${this.divider ? 'sdds-accordion-divider' : ''} ${this.modeVariant !== null ? `sdds-mode-variant-${this.modeVariant}`: ''}`}
+        class={`sdds-accordion ${this.modeVariant !== null ? `sdds-mode-variant-${this.modeVariant}`: ''}`}
       >
         <slot></slot>
       </Host>

--- a/tegel/src/components/accordion/readme.md
+++ b/tegel/src/components/accordion/readme.md
@@ -6,10 +6,9 @@
 
 ## Properties
 
-| Property      | Attribute      | Description                                   | Type                       | Default |
-| ------------- | -------------- | --------------------------------------------- | -------------------------- | ------- |
-| `divider`     | `divider`      | Enable or disable divider lines between items | `boolean`                  | `true`  |
-| `modeVariant` | `mode-variant` | Set the variant of the the accordion.         | `"primary" \| "secondary"` | `null`  |
+| Property      | Attribute      | Description                           | Type                       | Default |
+| ------------- | -------------- | ------------------------------------- | -------------------------- | ------- |
+| `modeVariant` | `mode-variant` | Set the variant of the the accordion. | `"primary" \| "secondary"` | `null`  |
 
 
 ----------------------------------------------


### PR DESCRIPTION
**Describe pull-request**  
Removed unused divider prop.

**Solving issue**  
Fixes: [DTS-1043](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-1043)

**How to test**  
1. Go to Storybook link below
2. Check in Accordion -> Default
3. Check that 'divider' is not present in Notes tab

[DTS-1043]: https://tegel.atlassian.net/browse/DTS-1043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ