### PR TITLE
fix(divider): standardise order of controls in Storybook

### DIFF
--- a/tegel/src/components/divider/divider.stories.tsx
+++ b/tegel/src/components/divider/divider.stories.tsx
@@ -25,9 +25,6 @@ export default {
         type: 'radio',
       },
       options: ['Horizontal', 'Vertical'],
-      table: {
-        defaultValue: { summary: 'Horizontal' },
-      },
     },
     direction: {
       name: 'Direction',

--- a/tegel/src/components/divider/divider.stories.tsx
+++ b/tegel/src/components/divider/divider.stories.tsx
@@ -20,7 +20,7 @@ export default {
   argTypes: {
     type: {
       name: 'Type',
-      description: 'Choose divider type.',
+      description: 'Sets the divider type.',
       control: {
         type: 'radio',
       },
@@ -31,7 +31,7 @@ export default {
     },
     direction: {
       name: 'Direction',
-      description: 'Set the direction of the divider',
+      description: 'Sets the direction of the divider.',
       control: {
         type: 'select',
       },
@@ -39,7 +39,7 @@ export default {
     },
     width: {
       name: 'Width',
-      description: 'Choose divider width.',
+      description: 'Sets the divider width.',
       control: {
         type: 'number',
       },
@@ -47,7 +47,7 @@ export default {
     },
     height: {
       name: 'Height',
-      description: 'Choose divider height.',
+      description: 'Sets the divider height.',
       control: {
         type: 'number',
       },

--- a/tegel/src/components/divider/divider.stories.tsx
+++ b/tegel/src/components/divider/divider.stories.tsx
@@ -29,6 +29,14 @@ export default {
         defaultValue: { summary: 'Horizontal' },
       },
     },
+    direction: {
+      name: 'Direction',
+      description: 'Set the direction of the divider',
+      control: {
+        type: 'select',
+      },
+      options: ['Top', 'Right', 'Bottom', 'Left'],
+    },
     width: {
       name: 'Width',
       description: 'Choose divider width.',
@@ -45,20 +53,12 @@ export default {
       },
       if: { arg: 'type', eq: 'Vertical' },
     },
-    direction: {
-      name: 'Direction',
-      description: 'Set the direction of the divider',
-      control: {
-        type: 'select',
-      },
-      options: ['Top', 'Right', 'Bottom', 'Left'],
-    },
   },
   args: {
     type: 'Horizontal',
+    direction: 'Top',
     width: 150,
     height: 150,
-    direction: 'Top',
   },
 };
 

--- a/tegel/src/components/divider/divider.stories.tsx
+++ b/tegel/src/components/divider/divider.stories.tsx
@@ -132,8 +132,8 @@ const BorderTemplate= ({ direction }) => {
 };
 
 
-export const Default = Template.bind({});
-Default.argTypes={
+export const Native = Template.bind({});
+Native.argTypes={
   direction: { table:  { disable: true } }  
  }
 export const Border = BorderTemplate.bind({});


### PR DESCRIPTION
**Describe pull-request**  
Standardised order of controls in Storybook for divider component. Also updated descriptions, removed unnecessary default value and renamed Default story to Native.

**Solving issue**  
Fixes: [DTS-859](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-859)

**How to test**  
1. Go to Storybook link below
2. Check in Divider-> Native and Border
3. Inspect order of controls
4. Read control descriptions

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

[DTS-859]: https://tegel.atlassian.net/browse/DTS-859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ