### PR TITLE
fix(header): standardise order of controls in Storybook

### DIFF
--- a/tegel/src/components/header/header-all.stories.tsx
+++ b/tegel/src/components/header/header-all.stories.tsx
@@ -27,7 +27,7 @@ export default {
   argTypes: {
     siteName: {
       name: 'Site name',
-      description: 'Set a custom title for the header',
+      description: 'Sets a custom title for the header.',
       type: 'string',
     },
   },

--- a/tegel/src/components/header/header-all.stories.tsx
+++ b/tegel/src/components/header/header-all.stories.tsx
@@ -28,7 +28,9 @@ export default {
     siteName: {
       name: 'Site name',
       description: 'Sets a custom title for the header.',
-      type: 'string',
+      control: {
+        type: 'text',
+      },
     },
   },
   args: {

--- a/tegel/src/components/header/header-default.stories.tsx
+++ b/tegel/src/components/header/header-default.stories.tsx
@@ -27,7 +27,7 @@ export default {
   argTypes: {
     siteName: {
       name: 'Site name',
-      description: 'Set a custom title for the header',
+      description: 'Sets a custom title for the header.',
       type: 'string',
     },
   },

--- a/tegel/src/components/header/header-default.stories.tsx
+++ b/tegel/src/components/header/header-default.stories.tsx
@@ -28,7 +28,9 @@ export default {
     siteName: {
       name: 'Site name',
       description: 'Sets a custom title for the header.',
-      type: 'string',
+      control: {
+        type: 'text',
+      },
     },
   },
   args: {

--- a/tegel/src/components/header/header-inline.stories.tsx
+++ b/tegel/src/components/header/header-inline.stories.tsx
@@ -27,7 +27,7 @@ export default {
   argTypes: {
     siteName: {
       name: 'Site name',
-      description: 'Set a custom title for the header',
+      description: 'Sets a custom title for the header.',
       type: 'string',
     },
   },

--- a/tegel/src/components/header/header-inline.stories.tsx
+++ b/tegel/src/components/header/header-inline.stories.tsx
@@ -28,7 +28,9 @@ export default {
     siteName: {
       name: 'Site name',
       description: 'Sets a custom title for the header.',
-      type: 'string',
+      control: {
+        type: 'text',
+      },
     },
   },
   args: {

--- a/tegel/src/components/header/header-search.stories.tsx
+++ b/tegel/src/components/header/header-search.stories.tsx
@@ -27,7 +27,7 @@ export default {
   argTypes: {
     siteName: {
       name: 'Site name',
-      description: 'Set a custom title for the header',
+      description: 'Sets a custom title for the header.',
       type: 'string',
     },
   },

--- a/tegel/src/components/header/header-search.stories.tsx
+++ b/tegel/src/components/header/header-search.stories.tsx
@@ -28,7 +28,9 @@ export default {
     siteName: {
       name: 'Site name',
       description: 'Sets a custom title for the header.',
-      type: 'string',
+      control: {
+        type: 'text',
+      },
     },
   },
   args: {

--- a/tegel/src/components/header/header-toolbar.stories.tsx
+++ b/tegel/src/components/header/header-toolbar.stories.tsx
@@ -27,7 +27,7 @@ export default {
   argTypes: {
     siteName: {
       name: 'Site name',
-      description: 'Set a custom title for the header',
+      description: 'Sets a custom title for the header.',
       type: 'string',
     },
   },

--- a/tegel/src/components/header/header-toolbar.stories.tsx
+++ b/tegel/src/components/header/header-toolbar.stories.tsx
@@ -28,7 +28,9 @@ export default {
     siteName: {
       name: 'Site name',
       description: 'Sets a custom title for the header.',
-      type: 'string',
+      control: {
+        type: 'text',
+      },
     },
   },
   args: {


### PR DESCRIPTION
**Describe pull-request**  
Updated control descriptions- and refactored deprecated controls.

**Solving issue**  
Fixes: [DTS-861](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-861)

**How to test**  
1. Go to Storybook link below
2. Check in Header -> All sub-stories
3. Read control descriptions
4. Check that "Site name" control works as it should

[DTS-861]: https://tegel.atlassian.net/browse/DTS-861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ