### PR TITLE
fix(DTS-703): textarea error state icon

### DIFF
--- a/components/src/components/textarea/textarea.scss
+++ b/components/src/components/textarea/textarea.scss
@@ -120,6 +120,12 @@
   }
 }
 
+.helper-wrapper {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+}
+
 .sdds-textarea-textcounter {
   @extend .sdds-textfield-textcounter;
 
@@ -131,8 +137,8 @@
 .sdds-textarea-helper {
   @extend .sdds-textfield-helper;
 
-  flex-grow: 2;
-  flex-basis: auto;
+  display: flex;
+  gap: 8px;
 
   ~ .sdds-textarea-textcounter {
     flex-basis: auto;

--- a/components/src/components/textarea/textarea.tsx
+++ b/components/src/components/textarea/textarea.tsx
@@ -193,13 +193,39 @@ export class Textarea {
 
           <span class="sdds-textarea-icon__readonly-label">This field is non-editable</span>
         </div>
-        {this.helper.length > 0 && <span class={'sdds-textarea-helper'}>{this.helper}</span>}
-        {this.maxlength > 0 && (
-          <div class={'sdds-textarea-textcounter'}>
-            {this.value === null ? 0 : this.value?.length}
-            <span class="sdds-textfield-textcounter-divider"> / </span> {this.maxlength}
-          </div>
-        )}
+        <div class="helper-wrapper">
+          {this.helper.length > 0 && (
+            <span class={`sdds-textarea-helper ${this.state === 'error' ? 'error' : ''}`}>
+              {this.state === 'error' && (
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    clip-rule="evenodd"
+                    d="M8 2.00015C4.6853 2.00015 1.9982 4.68725 1.9982 8.00195C1.9982 11.3167 4.6853 14.0038 8 14.0038C11.3147 14.0038 14.0018 11.3167 14.0018 8.00195C14.0018 4.68725 11.3147 2.00015 8 2.00015ZM1 8.00195C1 4.13596 4.13401 1.00195 8 1.00195C11.866 1.00195 15 4.13596 15 8.00195C15 11.8679 11.866 15.002 8 15.002C4.13401 15.002 1 11.8679 1 8.00195Z"
+                    fill="#FF2340"
+                  />
+                  <path
+                    d="M7.4014 7.2352V5H8.5894V7.2352L8.4134 9.3824H7.5774L7.4014 7.2352ZM7.375 10.0512H8.6246V11.248H7.375V10.0512Z"
+                    fill="#FF2340"
+                  />
+                </svg>
+              )}
+              {this.helper}
+            </span>
+          )}
+          {this.maxlength > 0 && (
+            <div class={'sdds-textarea-textcounter'}>
+              {this.value === null ? 0 : this.value?.length}
+              <span class="sdds-textfield-textcounter-divider"> / </span> {this.maxlength}
+            </div>
+          )}
+        </div>
       </div>
     );
   }

--- a/components/src/components/textfield/textfield.tsx
+++ b/components/src/components/textfield/textfield.tsx
@@ -75,7 +75,6 @@ export class Textfield {
     this.value = event.target.value;
     this.value = event.target.value;
     this.sddsInput.emit(event);
-    this.sddsInput.emit(event);
     this.value = event.target.value;
   }
 

--- a/components/src/components/textfield/textfield.tsx
+++ b/components/src/components/textfield/textfield.tsx
@@ -71,8 +71,10 @@ export class Textfield {
   sddsInput: EventEmitter<InputEvent>;
 
   // Data input event in value prop
-  this.value = event.target.value;
-  this.sddsInput.emit(event);
+  handleInput(event): void {
+    this.value = event.target.value;
+    this.value = event.target.value;
+    this.sddsInput.emit(event);
     this.sddsInput.emit(event);
     this.value = event.target.value;
   }

--- a/components/src/components/textfield/textfield.tsx
+++ b/components/src/components/textfield/textfield.tsx
@@ -72,8 +72,6 @@ export class Textfield {
 
   // Data input event in value prop
   handleInput(event): void {
-    this.value = event.target.value;
-    this.value = event.target.value;
     this.sddsInput.emit(event);
     this.value = event.target.value;
   }

--- a/components/src/components/textfield/textfield.tsx
+++ b/components/src/components/textfield/textfield.tsx
@@ -87,7 +87,6 @@ export class Textfield {
 
   /** Set the input as focus when clicking the whole textfield with suffix/prefix */
   handleFocus(event): void {
-    console.log('hej');
     this.textInput.focus();
     this.focusInput = true;
     this.sddsFocus.emit(event);


### PR DESCRIPTION
**Describe pull-request**  
Added a error icon to the error state of the textarea. 

Also corrected previously commited error. The textarea was missing the function name for handleInput, which was causing the entire file to error.

<img width="740" alt="Screenshot 2023-03-13 at 13 42 13" src="https://user-images.githubusercontent.com/62651103/224705156-5cd656c0-1e95-4f4a-a8c1-bd8250e98146.png">

**Solving issue**  
Fixes: [#](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-703)

**How to test**  
1. Go to checkout branch.
2. Run storybook for @components
3. Check that the textarea has a prefix error icon on helper in error state.
4. Check that the textarea works as expected.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

