### PR TITLE
fix(toast): standardise order of controls in Storybook

### DIFF
--- a/tegel/src/components/toast/sdds-toast.stories.tsx
+++ b/tegel/src/components/toast/sdds-toast.stories.tsx
@@ -56,7 +56,7 @@ export default {
     },
   },
   args: {
-    type: 'Success',
+    type: 'Information',
     header: 'Header',
     subheader: '',
     link: false,

--- a/tegel/src/components/toast/sdds-toast.stories.tsx
+++ b/tegel/src/components/toast/sdds-toast.stories.tsx
@@ -34,7 +34,7 @@ export default {
       },
     },
     header: {
-      name: 'Subheader',
+      name: 'Header',
       description: 'Adds a header text.',
       control: {
         type: 'text',

--- a/tegel/src/components/toast/sdds-toast.stories.tsx
+++ b/tegel/src/components/toast/sdds-toast.stories.tsx
@@ -22,7 +22,7 @@ export default {
   argTypes: {
     type: {
       name: 'Message type',
-      description: 'Changes the type of message',
+      description: 'Changes the type of message.',
       control: {
         type: 'radio',
       },
@@ -35,21 +35,21 @@ export default {
     },
     header: {
       name: 'Subheader',
-      description: 'Adds a subheader',
+      description: 'Adds a header text.',
       control: {
         type: 'text',
       },
     },
     subheader: {
       name: 'Subheader',
-      description: 'Adds a subheader',
+      description: 'Adds a subheader text.',
       control: {
         type: 'text',
       },
     },
     link: {
       name: 'Link',
-      description: 'Adds a CTA link',
+      description: 'Adds a CTA link.',
       control: {
         type: 'boolean',
       },

--- a/tegel/src/components/toast/toast.stories.tsx
+++ b/tegel/src/components/toast/toast.stories.tsx
@@ -21,7 +21,7 @@ export default {
   argTypes: {
     type: {
       name: 'Message type',
-      description: 'Changes the type of message',
+      description: 'Changes the type of message.',
       control: {
         type: 'radio',
       },
@@ -29,25 +29,25 @@ export default {
     },
     header: {
       name: 'Subheader',
-      description: 'Adds a subheader',
+      description: 'Adds a header text.',
       control: {
         type: 'text',
       },
     },
     subheader: {
       name: 'Subheader',
-      description: 'Adds a subheader',
+      description: 'Adds a subheader text.',
       control: {
         type: 'text',
       },
     },
     link: {
       name: 'Link',
-      description: 'Adds a CTA link',
+      description: 'Adds a CTA link.',
     },
     iconType: {
       name: 'Icon type',
-      description: 'Native/Web Component',
+      description: 'Switch between showing a native or a web component icon.',
       control: {
         type: 'radio',
       },

--- a/tegel/src/components/toast/toast.stories.tsx
+++ b/tegel/src/components/toast/toast.stories.tsx
@@ -28,7 +28,7 @@ export default {
       options: ['Success', 'Info', 'Warning', 'Error'],
     },
     header: {
-      name: 'Subheader',
+      name: 'Header',
       description: 'Adds a header text.',
       control: {
         type: 'text',

--- a/tegel/src/components/toast/toast.stories.tsx
+++ b/tegel/src/components/toast/toast.stories.tsx
@@ -25,7 +25,7 @@ export default {
       control: {
         type: 'radio',
       },
-      options: ['Success', 'Info', 'Warning', 'Error'],
+      options: ['Information', 'Success', 'Warning', 'Error'],
     },
     header: {
       name: 'Header',
@@ -67,7 +67,7 @@ export default {
     },
   },
   args: {
-    type: 'Success',
+    type: 'Information',
     header: 'Header',
     subheader: '',
     link: false,
@@ -77,13 +77,13 @@ export default {
 };
 const typeLookup = {
   Success: 'success',
-  Info: 'info',
+  Information: 'info',
   Warning: 'warning',
   Error: 'error',
 };
 const iconLookup = {
   Success: 'tick',
-  Info: 'info',
+  Information: 'info',
   Warning: 'warning',
   Error: 'error',
 };

--- a/tegel/src/components/toast/toast.stories.tsx
+++ b/tegel/src/components/toast/toast.stories.tsx
@@ -44,6 +44,9 @@ export default {
     link: {
       name: 'Link',
       description: 'Adds a CTA link.',
+      control: {
+        type: 'boolean',
+      },
     },
     icon: {
       name: 'Icon',

--- a/tegel/src/components/toast/toast.stories.tsx
+++ b/tegel/src/components/toast/toast.stories.tsx
@@ -45,14 +45,6 @@ export default {
       name: 'Link',
       description: 'Adds a CTA link.',
     },
-    iconType: {
-      name: 'Icon type',
-      description: 'Switch between showing a native or a web component icon.',
-      control: {
-        type: 'radio',
-      },
-      options: ['Native', 'Web Component'],
-    },
     icon: {
       name: 'Icon',
       description:
@@ -63,14 +55,22 @@ export default {
       options: ['none', 'recommended', ...iconsNames],
       if: { arg: 'size', neq: 'xs' },
     },
+    iconType: {
+      name: 'Icon type',
+      description: 'Switch between showing a native or a web component icon.',
+      control: {
+        type: 'radio',
+      },
+      options: ['Native', 'Web Component'],
+    },
   },
   args: {
     type: 'Success',
     header: 'Header',
     subheader: '',
     link: false,
-    iconType: 'Web Component',
     icon: 'recommended',
+    iconType: 'Web Component',
   },
 };
 const typeLookup = {

--- a/tegel/src/components/toast/toast.stories.tsx
+++ b/tegel/src/components/toast/toast.stories.tsx
@@ -56,7 +56,6 @@ export default {
         type: 'select',
       },
       options: ['none', 'recommended', ...iconsNames],
-      if: { arg: 'size', neq: 'xs' },
     },
     iconType: {
       name: 'Icon type',


### PR DESCRIPTION
**Describe pull-request**  
Standardised order of controls in Storybook for toast component. Also updated descriptions, added control spec and removed unnecessary if-statement.

**Solving issue**  
Fixes: [DTS-869](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-869)

**How to test**  
1. Go to Storybook link below
2. Check in Toast -> Native and Web Component
3. Inspect order of controls
4. Read control descriptions

[DTS-869]: https://tegel.atlassian.net/browse/DTS-869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ