### PR TITLE
fix(toggle): standardise order of controls in Storybook

### DIFF
--- a/tegel/src/components/toggle/sdds-toggle.stories.tsx
+++ b/tegel/src/components/toggle/sdds-toggle.stories.tsx
@@ -22,32 +22,32 @@ export default {
   argTypes: {
     size: {
       name: 'Size',
+      description: 'Sets the size of the toggle.',
       control: {
         type: 'radio',
       },
       options: ['Large', 'Small'],
-      description: 'Size of the toggle',
       table: {
         defaultValue: { summary: 'lg' },
       },
     },
     headline: {
       name: 'Headline',
-      description: 'Headline, displayed above the toggle.',
+      description: 'Sets the headline, displayed above the toggle.',
       control: {
         type: 'text',
       },
     },
     label: {
       name: 'Label',
-      description: 'Label for the toggles input element.',
+      description: 'Sets the label for the toggles input element.',
       control: {
         type: 'text',
       },
     },
     checked: {
       name: 'Checked',
-      description: 'Sets the toggle as checked',
+      description: 'Sets the toggle as checked.',
       control: {
         type: 'boolean',
       },
@@ -57,7 +57,7 @@ export default {
     },
     disabled: {
       name: 'Disabled',
-      description: 'Sets the toggle as disabled',
+      description: 'Disables the toggle.',
       control: {
         type: 'boolean',
       },

--- a/tegel/src/components/toggle/sdds-toggle.stories.tsx
+++ b/tegel/src/components/toggle/sdds-toggle.stories.tsx
@@ -52,7 +52,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: { summary: 'false' },
+        defaultValue: { summary: false },
       },
     },
     disabled: {
@@ -62,7 +62,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: { summary: 'false' },
+        defaultValue: { summary: false },
       },
     },
   },

--- a/tegel/src/components/toggle/sdds-toggle.stories.tsx
+++ b/tegel/src/components/toggle/sdds-toggle.stories.tsx
@@ -31,13 +31,6 @@ export default {
         defaultValue: { summary: 'lg' },
       },
     },
-    label: {
-      name: 'Label',
-      description: 'Label for the toggles input element.',
-      control: {
-        type: 'text',
-      },
-    },
     headline: {
       name: 'Headline',
       description: 'Headline, displayed above the toggle.',
@@ -45,14 +38,11 @@ export default {
         type: 'text',
       },
     },
-    disabled: {
-      name: 'Disabled',
-      description: 'Sets the toggle as disabled',
+    label: {
+      name: 'Label',
+      description: 'Label for the toggles input element.',
       control: {
-        type: 'boolean',
-      },
-      table: {
-        defaultValue: { summary: 'false' },
+        type: 'text',
       },
     },
     checked: {
@@ -65,17 +55,27 @@ export default {
         defaultValue: { summary: 'false' },
       },
     },
+    disabled: {
+      name: 'Disabled',
+      description: 'Sets the toggle as disabled',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        defaultValue: { summary: 'false' },
+      },
+    },
   },
   args: {
     size: 'Large',
-    label: 'Label',
     headline: 'Headline',
-    disabled: false,
+    label: 'Label',
     checked: false,
+    disabled: false,
   },
 };
 
-const Template = ({ label, size, disabled, headline, checked }) =>
+const Template = ({ size, headline, label, checked, disabled, }) =>
   formatHtmlPreview(`
       <sdds-toggle
         ${checked ? 'checked' : ''}

--- a/tegel/src/components/toggle/toggle.stories.tsx
+++ b/tegel/src/components/toggle/toggle.stories.tsx
@@ -20,22 +20,22 @@ export default {
   argTypes: {
     size: {
       name: 'Size',
+      description: 'Sets the size of the toggle.',
       control: {
         type: 'radio',
       },
       options: ['Default', 'Small'],
-      description: 'Size of the toggle',
     },
     headline: {
       name: 'Headline',
-      description: 'Optional value to be used to clarify what the toggle is switching on / off',
+      description: 'Sets the headline, displayed above the toggle.',
       control: {
         type: 'text',
       },
     },
     checked: {
       name: 'Checked',
-      description: 'Sets the toggle as checked',
+      description: 'Sets the toggle as checked.',
       control: {
         type: 'boolean',
       },
@@ -45,7 +45,7 @@ export default {
     },
     disabled: {
       name: 'Disabled',
-      description: 'Should it be disabled?',
+      description: 'Disables the toggle.',
       control: {
         type: 'boolean',
       },

--- a/tegel/src/components/toggle/toggle.stories.tsx
+++ b/tegel/src/components/toggle/toggle.stories.tsx
@@ -33,13 +33,6 @@ export default {
         type: 'text',
       },
     },
-    disabled: {
-      name: 'Disabled',
-      description: 'Should it be disabled?',
-      control: {
-        type: 'boolean',
-      },
-    },
     checked: {
       name: 'Checked',
       description: 'Sets the toggle as checked',
@@ -50,16 +43,23 @@ export default {
         defaultValue: { summary: 'false' },
       },
     },
+    disabled: {
+      name: 'Disabled',
+      description: 'Should it be disabled?',
+      control: {
+        type: 'boolean',
+      },
+    },
   },
   args: {
     size: 'Default',
     headline: 'Headline',
-    disabled: false,
     checked: false,
+    disabled: false,
   },
 };
 
-const Template = ({ size, disabled, headline, checked }) => {
+const Template = ({ size, headline, checked, disabled }) => {
   const sizeValue = size === 'Small' ? 'sdds-toggle-sm' : '';
   const headlineDiv =
     headline.length > 0 ? `<div class="sdds-toggle-headline">${headline}</div>` : '';

--- a/tegel/src/components/toggle/toggle.stories.tsx
+++ b/tegel/src/components/toggle/toggle.stories.tsx
@@ -24,7 +24,7 @@ export default {
       control: {
         type: 'radio',
       },
-      options: ['Default', 'Small'],
+      options: ['Large', 'Small'],
     },
     headline: {
       name: 'Headline',
@@ -40,7 +40,7 @@ export default {
         type: 'boolean',
       },
       table: {
-        defaultValue: { summary: 'false' },
+        defaultValue: { summary: false },
       },
     },
     disabled: {
@@ -52,7 +52,7 @@ export default {
     },
   },
   args: {
-    size: 'Default',
+    size: 'Large',
     headline: 'Headline',
     checked: false,
     disabled: false,

--- a/tegel/src/components/toggle/toggle.stories.tsx
+++ b/tegel/src/components/toggle/toggle.stories.tsx
@@ -39,9 +39,6 @@ export default {
       control: {
         type: 'boolean',
       },
-      table: {
-        defaultValue: { summary: false },
-      },
     },
     disabled: {
       name: 'Disabled',

--- a/tegel/src/components/toggle/toggle.stories.tsx
+++ b/tegel/src/components/toggle/toggle.stories.tsx
@@ -33,6 +33,13 @@ export default {
         type: 'text',
       },
     },
+    label: {
+      name: 'Label',
+      description: 'Sets the label for the toggles input element.',
+      control: {
+        type: 'text',
+      },
+    },
     checked: {
       name: 'Checked',
       description: 'Sets the toggle as checked.',
@@ -51,12 +58,13 @@ export default {
   args: {
     size: 'Large',
     headline: 'Headline',
+    label: 'Label',
     checked: false,
     disabled: false,
   },
 };
 
-const Template = ({ size, headline, checked, disabled }) => {
+const Template = ({ size, headline, label, checked, disabled }) => {
   const sizeValue = size === 'Small' ? 'sdds-toggle-sm' : '';
   const headlineDiv =
     headline.length > 0 ? `<div class="sdds-toggle-headline">${headline}</div>` : '';
@@ -68,7 +76,7 @@ const Template = ({ size, headline, checked, disabled }) => {
           disabled ? 'disabled' : ''
         } ${checked ? 'checked' : ''}>
         <span class="sdds-toggle-switch"></span>
-        <label class="sdds-toggle-label" for="customSwitch1">Toggle this switch element</label>
+        <label class="sdds-toggle-label" for="customSwitch1">${label}</label>
       </div>
   `);
 };


### PR DESCRIPTION
**Describe pull-request**  
Standardised order of controls in Storybook for toggle component. Also updated descriptions, removed unnecessary default value and aligned control options between native component and web component.

**Solving issue**  
Fixes: [DTS-870](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-870)

**How to test**  
1. Go to Storybook link below
2. Check in Toggle -> Native and Web Component
3. Inspect order of controls
4. Read control descriptions

[DTS-870]: https://tegel.atlassian.net/browse/DTS-870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ