### PR TITLE
fix(tooltip): standardise order of controls in Storybook

### DIFF
--- a/tegel/src/components/tooltip/tooltip.stories.tsx
+++ b/tegel/src/components/tooltip/tooltip.stories.tsx
@@ -31,21 +31,21 @@ export default {
       description: 'Sets the position of the tooltip.',
       control: {
         type: 'select',
-        options: [
-          'Bottom-start',
-          'Bottom',
-          'Bottom-end',
-          'Top-start',
-          'Top',
-          'Top-end',
-          'Left-start',
-          'Left',
-          'Left-end',
-          'Right-start',
-          'Right',
-          'Right-end',
-        ],
       },
+      options: [
+        'Bottom-start',
+        'Bottom',
+        'Bottom-end',
+        'Top-start',
+        'Top',
+        'Top-end',
+        'Left-start',
+        'Left',
+        'Left-end',
+        'Right-start',
+        'Right',
+        'Right-end',
+      ],
     },
     text: {
       name: 'Tooltip text',
@@ -64,7 +64,9 @@ export default {
     mouseOverTooltip: {
       name: 'Open while hovering over tooltip',
       description: 'Keeps the tooltip visible as long as the mouse hovers over it.',
-      control: 'boolean',
+      control: {
+        type: 'boolean',
+      },
     },
   },
   args: {

--- a/tegel/src/components/tooltip/tooltip.stories.tsx
+++ b/tegel/src/components/tooltip/tooltip.stories.tsx
@@ -28,6 +28,7 @@ export default {
   argTypes: {
     tooltipPosition: {
       name: 'Tooltip position',
+      description: 'Sets the position of the tooltip.',
       control: {
         type: 'select',
         options: [
@@ -45,11 +46,10 @@ export default {
           'Right-end',
         ],
       },
-      description: 'Position of the tooltip',
     },
     text: {
       name: 'Tooltip text',
-      description: 'Text that will be displayed inside tooltip',
+      description: 'Sets the sext that will be displayed inside tooltip.',
       control: {
         type: 'text',
       },
@@ -63,8 +63,8 @@ export default {
     },
     mouseOverTooltip: {
       name: 'Open while hovering over tooltip',
+      description: 'Keeps the tooltip visible as long as the mouse hovers over it.',
       control: 'boolean',
-      description: 'Keep the tooltip visible as long as the mouse hover over it',
     },
   },
   args: {

--- a/tegel/src/components/tooltip/tooltip.stories.tsx
+++ b/tegel/src/components/tooltip/tooltip.stories.tsx
@@ -46,6 +46,11 @@ export default {
         'Right',
         'Right-end',
       ],
+      table: {
+        defaultValue: {
+          summary: 'bottom',
+        },
+      },
     },
     text: {
       name: 'Tooltip text',
@@ -66,6 +71,11 @@ export default {
       description: 'Keeps the tooltip visible as long as the mouse hovers over it.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        defaultValue: {
+          summary: false,
+        },
       },
     },
   },


### PR DESCRIPTION
**Describe pull-request**  
Standardised order of controls in Storybook for tooltip component. Also updated descriptions, refactored deprecated controls and added default values.

**Solving issue**  
Fixes: [DTS-871](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-871)

**How to test**  
1. Go to Storybook link below
2. Check in Tooltip -> Web Component
3. Inspect order of controls
4. Read control descriptions

[DTS-871]: https://tegel.atlassian.net/browse/DTS-871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ