### PR TITLE
chore(react-sandbox): responsive data table example

### DIFF
--- a/sandbox/react/src/App.js
+++ b/sandbox/react/src/App.js
@@ -4,6 +4,7 @@ import Header from './components/header/Header';
 import Form from './components/form/Form';
 import Home from './components/home/Home';
 import Footer from './components/footer/Footer';
+import DataTable from './components/dataTable/dataTable';
 
 function App() {
   const [expand, setExpand] = useState(false);
@@ -23,11 +24,14 @@ function App() {
                 <Route path="/form">
                   <Form />
                 </Route>
+                <Route path="/data-table">
+                  <DataTable />
+                </Route>
               </Switch>
             </div>
-            <Footer />
           </div>
         </div>
+        <Footer />
       </Router>
     </div>
   );

--- a/sandbox/react/src/App.js
+++ b/sandbox/react/src/App.js
@@ -4,7 +4,6 @@ import Header from './components/header/Header';
 import Form from './components/form/Form';
 import Home from './components/home/Home';
 import Footer from './components/footer/Footer';
-import SideMenu from './components/sideMenu/SideMenu';
 
 function App() {
   const [expand, setExpand] = useState(false);
@@ -14,9 +13,8 @@ function App() {
         <sdds-theme />
         <div className={`sdds-navbar-overlay ${expand ? 'expanded' : null}`} />
         <Header onDrawerClick={() => setExpand(!expand)} expand={expand} />
-        <div className="sdds-push sdds-demo-container">
-          <SideMenu expand={expand} />
-          <div className={'sdds-content-push'}>
+        <div className="sdds-demo-container">
+          <div>
             <div className="sdds-container-fluid content-wrapper">
               <Switch>
                 <Route exact path="/">

--- a/sandbox/react/src/components/dataTable/dataTable.js
+++ b/sandbox/react/src/components/dataTable/dataTable.js
@@ -1,0 +1,36 @@
+const DataTable = () => {
+  return (
+    <div className="sdds-row">
+      <div className="sdds-no-padding sdds-col-md-12 sdds-col-sm-12 sdds-col-xs-12 ">
+        <sdds-table
+          no-min-width
+          body-data='[{"truck":"L-series","driver":"Miki","country":"USA","mileage":123987},{"truck":"P-series","driver":"Guerra","country":"Sweden","mileage":2000852},{"truck":"G-series","driver":"Ferrell","country":"Germany","mileage":564},{"truck":"R-series","driver":"Cox","country":"Spain","mileage":1789357},{"truck":"S-series","driver":"Montgomery","country":"Croatia","mileage":65},{"truck":"L-series","driver":"Sheryl","country":"Greece","mileage":365784},{"truck":"G-series","driver":"Bojan","country":"Norway","mileage":80957}]'
+        >
+          <sdds-header-cell
+            column-key="truck"
+            column-title="Truck type"
+            custom-width="25vw"
+          ></sdds-header-cell>
+          <sdds-header-cell
+            column-key="driver"
+            column-title="Driver name"
+            custom-width="25vw"
+          ></sdds-header-cell>
+          <sdds-header-cell
+            column-key="country"
+            column-title="Country"
+            custom-width="25vw"
+          ></sdds-header-cell>
+          <sdds-header-cell
+            column-key="mileage"
+            column-title="Mileage"
+            text-align="right"
+            custom-width="25vw"
+          ></sdds-header-cell>
+        </sdds-table>
+      </div>
+    </div>
+  );
+};
+
+export default DataTable;

--- a/sandbox/react/src/components/dataTable/dataTable.js
+++ b/sandbox/react/src/components/dataTable/dataTable.js
@@ -2,6 +2,7 @@ const DataTable = () => {
   return (
     <div className="sdds-row">
       <div className="sdds-no-padding sdds-col-md-12 sdds-col-sm-12 sdds-col-xs-12 ">
+        <h2>Data table responsive example 1</h2>
         <sdds-table
           no-min-width
           body-data='[{"truck":"L-series","driver":"Miki","country":"USA","mileage":123987},{"truck":"P-series","driver":"Guerra","country":"Sweden","mileage":2000852},{"truck":"G-series","driver":"Ferrell","country":"Germany","mileage":564},{"truck":"R-series","driver":"Cox","country":"Spain","mileage":1789357},{"truck":"S-series","driver":"Montgomery","country":"Croatia","mileage":65},{"truck":"L-series","driver":"Sheryl","country":"Greece","mileage":365784},{"truck":"G-series","driver":"Bojan","country":"Norway","mileage":80957}]'
@@ -14,6 +15,34 @@ const DataTable = () => {
             column-key="mileage"
             column-title="Mileage"
             text-align="right"
+          ></sdds-header-cell>
+        </sdds-table>
+
+        <h2>Data table responsive example 2</h2>
+        <sdds-table
+          no-min-width
+          body-data='[{"truck":"L-series","driver":"Miki","country":"USA","mileage":123987},{"truck":"P-series","driver":"Guerra","country":"Sweden","mileage":2000852},{"truck":"G-series","driver":"Ferrell","country":"Germany","mileage":564},{"truck":"R-series","driver":"Cox","country":"Spain","mileage":1789357},{"truck":"S-series","driver":"Montgomery","country":"Croatia","mileage":65},{"truck":"L-series","driver":"Sheryl","country":"Greece","mileage":365784},{"truck":"G-series","driver":"Bojan","country":"Norway","mileage":80957}]'
+        >
+          <sdds-header-cell
+            column-key="truck"
+            column-title="Truck type"
+            custom-width="25vw"
+          ></sdds-header-cell>
+          <sdds-header-cell
+            column-key="driver"
+            column-title="Driver name"
+            custom-width="25vw"
+          ></sdds-header-cell>
+          <sdds-header-cell
+            column-key="country"
+            column-title="Country"
+            custom-width="25vw"
+          ></sdds-header-cell>
+          <sdds-header-cell
+            column-key="mileage"
+            column-title="Mileage"
+            text-align="right"
+            custom-width="25vw"
           ></sdds-header-cell>
         </sdds-table>
       </div>

--- a/sandbox/react/src/components/dataTable/dataTable.js
+++ b/sandbox/react/src/components/dataTable/dataTable.js
@@ -5,15 +5,27 @@ const DataTable = () => {
         <sdds-table
           no-min-width
           body-data='[{"truck":"L-series","driver":"Miki","country":"USA","mileage":123987},{"truck":"P-series","driver":"Guerra","country":"Sweden","mileage":2000852},{"truck":"G-series","driver":"Ferrell","country":"Germany","mileage":564},{"truck":"R-series","driver":"Cox","country":"Spain","mileage":1789357},{"truck":"S-series","driver":"Montgomery","country":"Croatia","mileage":65},{"truck":"L-series","driver":"Sheryl","country":"Greece","mileage":365784},{"truck":"G-series","driver":"Bojan","country":"Norway","mileage":80957}]'
-          style={{ width: '100%', display: 'grid' }}
         >
-          <sdds-header-cell column-key="truck" column-title="Truck type"></sdds-header-cell>
-          <sdds-header-cell column-key="driver" column-title="Driver name"></sdds-header-cell>
-          <sdds-header-cell column-key="country" column-title="Country"></sdds-header-cell>
+          <sdds-header-cell
+            column-key="truck"
+            column-title="Truck type"
+            custom-width="25vw"
+          ></sdds-header-cell>
+          <sdds-header-cell
+            column-key="driver"
+            column-title="Driver name"
+            custom-width="25vw"
+          ></sdds-header-cell>
+          <sdds-header-cell
+            column-key="country"
+            column-title="Country"
+            custom-width="25vw"
+          ></sdds-header-cell>
           <sdds-header-cell
             column-key="mileage"
             column-title="Mileage"
             text-align="right"
+            custom-width="25vw"
           ></sdds-header-cell>
         </sdds-table>
       </div>

--- a/sandbox/react/src/components/dataTable/dataTable.js
+++ b/sandbox/react/src/components/dataTable/dataTable.js
@@ -5,27 +5,15 @@ const DataTable = () => {
         <sdds-table
           no-min-width
           body-data='[{"truck":"L-series","driver":"Miki","country":"USA","mileage":123987},{"truck":"P-series","driver":"Guerra","country":"Sweden","mileage":2000852},{"truck":"G-series","driver":"Ferrell","country":"Germany","mileage":564},{"truck":"R-series","driver":"Cox","country":"Spain","mileage":1789357},{"truck":"S-series","driver":"Montgomery","country":"Croatia","mileage":65},{"truck":"L-series","driver":"Sheryl","country":"Greece","mileage":365784},{"truck":"G-series","driver":"Bojan","country":"Norway","mileage":80957}]'
+          style={{ width: '100%', display: 'grid' }}
         >
-          <sdds-header-cell
-            column-key="truck"
-            column-title="Truck type"
-            custom-width="25vw"
-          ></sdds-header-cell>
-          <sdds-header-cell
-            column-key="driver"
-            column-title="Driver name"
-            custom-width="25vw"
-          ></sdds-header-cell>
-          <sdds-header-cell
-            column-key="country"
-            column-title="Country"
-            custom-width="25vw"
-          ></sdds-header-cell>
+          <sdds-header-cell column-key="truck" column-title="Truck type"></sdds-header-cell>
+          <sdds-header-cell column-key="driver" column-title="Driver name"></sdds-header-cell>
+          <sdds-header-cell column-key="country" column-title="Country"></sdds-header-cell>
           <sdds-header-cell
             column-key="mileage"
             column-title="Mileage"
             text-align="right"
-            custom-width="25vw"
           ></sdds-header-cell>
         </sdds-table>
       </div>

--- a/sandbox/react/src/components/header/Header.js
+++ b/sandbox/react/src/components/header/Header.js
@@ -50,6 +50,18 @@ const Header = ({ onDrawerClick, expand }) => {
               <p className="sdds-nav__item-core-text">Form</p>
             </Link>
           </li>
+
+          <li
+            className={
+              splitLocation[1] === 'data-table'
+                ? 'sdds-nav__item sdds-nav__item--active'
+                : 'sdds-nav__item'
+            }
+          >
+            <Link className="sdds-nav__item-core" to="/data-table">
+              <p className="sdds-nav__item-core-text">Data Table</p>
+            </Link>
+          </li>
         </ul>
       </div>
 

--- a/sandbox/react/src/components/header/Header.js
+++ b/sandbox/react/src/components/header/Header.js
@@ -1,6 +1,16 @@
 import './Header.css';
+import { Link, useLocation } from 'react-router-dom';
 
 const Header = ({ onDrawerClick, expand }) => {
+  //assigning location variable
+  const location = useLocation();
+
+  //destructuring pathname from location
+  const { pathname } = location;
+
+  //Javascript split method to get the name of the path in array
+  const splitLocation = pathname.split('/');
+
   return (
     <nav class="sdds-nav sdds-u-fixed sdds-u-top0">
       <div class="sdds-nav__left">
@@ -10,24 +20,41 @@ const Header = ({ onDrawerClick, expand }) => {
           onClick={onDrawerClick}
         >
           <div id="sdds-nav__mob-menu-icon">
-            <span
-              className="sdds-nav__mob-menu-icon-line"
-              id="sdds-nav__mob-menu-icon-line-1"
-            />
-            <span
-              className="sdds-nav__mob-menu-icon-line"
-              id="sdds-nav__mob-menu-icon-line-2"
-            />
-            <span
-              className="sdds-nav__mob-menu-icon-line"
-              id="sdds-nav__mob-menu-icon-line-3"
-            />
+            <span className="sdds-nav__mob-menu-icon-line" id="sdds-nav__mob-menu-icon-line-1" />
+            <span className="sdds-nav__mob-menu-icon-line" id="sdds-nav__mob-menu-icon-line-2" />
+            <span className="sdds-nav__mob-menu-icon-line" id="sdds-nav__mob-menu-icon-line-3" />
           </div>
         </button>
         <div className="sdds-nav__app-name">SDDS DEMO REACT</div>
       </div>
+
+      <div className="sdds-nav__center">
+        <ul className="sdds-nav__inline-menu">
+          <li
+            className={
+              splitLocation[1] === '' ? 'sdds-nav__item sdds-nav__item--active' : 'sdds-nav__item'
+            }
+          >
+            <Link className="sdds-nav__item-core" to="/">
+              <p className="sdds-nav__item-core-text">Home</p>
+            </Link>
+          </li>
+          <li
+            className={
+              splitLocation[1] === 'form'
+                ? 'sdds-nav__item sdds-nav__item--active'
+                : 'sdds-nav__item'
+            }
+          >
+            <Link className="sdds-nav__item-core" to="/form">
+              <p className="sdds-nav__item-core-text">Form</p>
+            </Link>
+          </li>
+        </ul>
+      </div>
+
       <div className="sdds-nav__right">
-        <a className="sdds-nav__item sdds-nav__app-logo" href="#" />
+        <a className="sdds-nav__item sdds-nav__app-logo" href="https://www.scania.com" />
       </div>
     </nav>
   );


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Testing data-table component responsive feature in React sandbox

**Solving issue**  
There was a question from a user in the Development channel.

**Good to know**

- Separate page  was created to make tests for data table
- there are two different commits on how to deal with the responsiveness of data-table, please take a look on them
- this code relies on using the latest "@scania/components"

