### PR TITLE
fix(sdds-toggle): added a name to the default slot

### DIFF
--- a/tegel/src/components/toggle/sdds-toggle.stories.tsx
+++ b/tegel/src/components/toggle/sdds-toggle.stories.tsx
@@ -75,14 +75,14 @@ export default {
   },
 };
 
-const Template = ({ size, headline, label, checked, disabled, }) =>
+const Template = ({ size, headline, label, checked, disabled }) =>
   formatHtmlPreview(`
       <sdds-toggle
         ${checked ? 'checked' : ''}
         ${disabled ? 'disabled' : ''}
         ${headline ? `headline="${headline}"` : ''}
         size="${size === 'Large' ? 'lg' : 'sm'}">
-        ${label}
+        <div slot="label">${label}</div>
     </sdds-toggle>
 
     <!-- Script tag with eventlistener for demo purposes. -->

--- a/tegel/src/components/toggle/sdds-toggle.tsx
+++ b/tegel/src/components/toggle/sdds-toggle.tsx
@@ -83,7 +83,7 @@ export class SddsToggle {
           role="switch"
         />
         <label class={`${this.disabled ? 'disabled' : ''}`} htmlFor={this.toggleId}>
-          <slot></slot>
+          <slot name="label"></slot>
         </label>
       </div>
     );


### PR DESCRIPTION
**Describe pull-request**  
Added a name to the default slot to make it handle dynamic data.

**Solving issue**  
Fixes: -

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Toggle -> Web Component
3. Check that everything is still working as expected.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
