### PR TITLE
chore: release 0.0.5

### DIFF
--- a/tegel/package-lock.json
+++ b/tegel/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@scania/tegel",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@scania/tegel",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.6",

--- a/tegel/package.json
+++ b/tegel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scania/tegel",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Tegel - Scania's Digital Design System",
   "keywords": [
     "tegel",


### PR DESCRIPTION
Bumped npm version of new tegel