### PR TITLE
fix(stepper): added a name to the default slot

### DIFF
--- a/tegel/src/components/stepper/sdds-stepper.stories.ts
+++ b/tegel/src/components/stepper/sdds-stepper.stories.ts
@@ -84,10 +84,10 @@ const Template = ({ size, direction, labelPosition, hideLabels }) =>
     `<sdds-stepper ${hideLabels ? 'hide-labels' : ''} size="${sizeLookUp[size]}" ${
       direction === 'Horizontal' ? `label-position="${labelPosition?.toLowerCase()}"` : ''
     } direction="${direction.toLowerCase()}">
-    <sdds-stepper-item state="success" label-text="Step label"><div slot="number">1</div></sdds-stepper-item>
-    <sdds-stepper-item state="active" label-text="Step label"><div slot="number">2</div></sdds-stepper-item>
-    <sdds-stepper-item label-text="Step inactive with text"><div slot="number">3</div></sdds-stepper-item>
-    <sdds-stepper-item label-text="Step label"><div slot="number">4</div></sdds-stepper-item>
+    <sdds-stepper-item state="success" label-text="Step label"><div slot="index">1</div></sdds-stepper-item>
+    <sdds-stepper-item state="active" label-text="Step label"><div slot="index">2</div></sdds-stepper-item>
+    <sdds-stepper-item label-text="Step inactive with text"><div slot="index">3</div></sdds-stepper-item>
+    <sdds-stepper-item label-text="Step label"><div slot="index">4</div></sdds-stepper-item>
   </sdds-stepper>
         `,
   );
@@ -98,10 +98,10 @@ const TemplateWithError = ({ size, hideLabels, labelPosition, direction }) =>
     `<sdds-stepper ${hideLabels ? 'hide-labels' : ''} size="${sizeLookUp[size]}" ${
       direction === 'Horizontal' ? `label-position="${labelPosition?.toLowerCase()}"` : ''
     } direction="${direction.toLowerCase()}">
-  <sdds-stepper-item state="success" label-text="Step label"><div slot="number">1</div></sdds-stepper-item>
-  <sdds-stepper-item state="error" label-text="Step label"><div slot="number">2</div></sdds-stepper-item>
-  <sdds-stepper-item label-text="Step inactive with text"><div slot="number">3</div></sdds-stepper-item>
-  <sdds-stepper-item label-text="Step label"><div slot="number">4</div></sdds-stepper-item>
+  <sdds-stepper-item state="success" label-text="Step label"><div slot="index">1</div></sdds-stepper-item>
+  <sdds-stepper-item state="error" label-text="Step label"><div slot="index">2</div></sdds-stepper-item>
+  <sdds-stepper-item label-text="Step inactive with text"><div slot="index">3</div></sdds-stepper-item>
+  <sdds-stepper-item label-text="Step label"><div slot="index">4</div></sdds-stepper-item>
 </sdds-stepper>
       `,
   );

--- a/tegel/src/components/stepper/sdds-stepper.stories.ts
+++ b/tegel/src/components/stepper/sdds-stepper.stories.ts
@@ -45,7 +45,8 @@ export default {
     },
     labelPosition: {
       name: 'Text position',
-      description: 'Sets the position of the text, only available when the direction is horizontal.',
+      description:
+        'Sets the position of the text, only available when the direction is horizontal.',
       control: {
         type: 'radio',
       },
@@ -78,20 +79,15 @@ const sizeLookUp = {
   Large: 'lg',
   Small: 'sm',
 };
-const Template = ({ 
-  size, 
-  direction, 
-  labelPosition, 
-  hideLabels, 
-}) =>
+const Template = ({ size, direction, labelPosition, hideLabels }) =>
   formatHtmlPreview(
     `<sdds-stepper ${hideLabels ? 'hide-labels' : ''} size="${sizeLookUp[size]}" ${
       direction === 'Horizontal' ? `label-position="${labelPosition?.toLowerCase()}"` : ''
     } direction="${direction.toLowerCase()}">
-    <sdds-stepper-item state="success" label-text="Step label">1</sdds-stepper-item>
-    <sdds-stepper-item state="active" label-text="Step label">2</sdds-stepper-item>
-    <sdds-stepper-item label-text="Step inactive with text">3</sdds-stepper-item>
-    <sdds-stepper-item label-text="Step label">4</sdds-stepper-item>
+    <sdds-stepper-item state="success" label-text="Step label"><div slot="number">1</div></sdds-stepper-item>
+    <sdds-stepper-item state="active" label-text="Step label"><div slot="number">2</div></sdds-stepper-item>
+    <sdds-stepper-item label-text="Step inactive with text"><div slot="number">3</div></sdds-stepper-item>
+    <sdds-stepper-item label-text="Step label"><div slot="number">4</div></sdds-stepper-item>
   </sdds-stepper>
         `,
   );
@@ -102,10 +98,10 @@ const TemplateWithError = ({ size, hideLabels, labelPosition, direction }) =>
     `<sdds-stepper ${hideLabels ? 'hide-labels' : ''} size="${sizeLookUp[size]}" ${
       direction === 'Horizontal' ? `label-position="${labelPosition?.toLowerCase()}"` : ''
     } direction="${direction.toLowerCase()}">
-  <sdds-stepper-item state="success" label-text="Step label">1</sdds-stepper-item>
-  <sdds-stepper-item state="error" label-text="Step label">2</sdds-stepper-item>
-  <sdds-stepper-item label-text="Step inactive with text">3</sdds-stepper-item>
-  <sdds-stepper-item label-text="Step label">4</sdds-stepper-item>
+  <sdds-stepper-item state="success" label-text="Step label"><div slot="number">1</div></sdds-stepper-item>
+  <sdds-stepper-item state="error" label-text="Step label"><div slot="number">2</div></sdds-stepper-item>
+  <sdds-stepper-item label-text="Step inactive with text"><div slot="number">3</div></sdds-stepper-item>
+  <sdds-stepper-item label-text="Step label"><div slot="number">4</div></sdds-stepper-item>
 </sdds-stepper>
       `,
   );

--- a/tegel/src/components/stepper/stepper-item/sdds-stepper-item.tsx
+++ b/tegel/src/components/stepper/stepper-item/sdds-stepper-item.tsx
@@ -57,7 +57,7 @@ export class SddsStepper {
               ></sdds-icon>
             ) : (
               <div class="number sdds-detail-05">
-                <slot></slot>
+                <slot name="number"></slot>
               </div>
             )}
           </div>

--- a/tegel/src/components/stepper/stepper-item/sdds-stepper-item.tsx
+++ b/tegel/src/components/stepper/stepper-item/sdds-stepper-item.tsx
@@ -56,9 +56,7 @@ export class SddsStepper {
                 size={this.size === 'lg' ? '20px' : '16px'}
               ></sdds-icon>
             ) : (
-              <div class="number sdds-detail-05">
-                <slot name="number"></slot>
-              </div>
+              <slot name="index"></slot>
             )}
           </div>
           {!this.hideLabel && (


### PR DESCRIPTION
**Describe pull-request**  
Replaced default slot with named slot, not sure if number is a great name so please provide alternatives if you have any.

**Solving issue**  
Fixes: -

**How to test**  
1. Go to storybook link below.
2. Check in Componets -> Stepper -> Web Component
3. Check that everything still works as intended.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
