### PR TITLE
fix(breadcrumb): removed default slot 

### DIFF
--- a/tegel/src/components/breadcrumb/sdds-breadcrumb-link/sdds-breadcrumb-link.scss
+++ b/tegel/src/components/breadcrumb/sdds-breadcrumb-link/sdds-breadcrumb-link.scss
@@ -39,7 +39,7 @@
     }
   }
 
-  a::after {
+  ::slotted(*)::after {
     content: '\203A';
     color: var(--sdds-breadcrumb-separator-color);
     margin-right: 4px;
@@ -51,7 +51,7 @@
 }
 
 :host(.last) {
-  a::after {
+  ::slotted(*)::after {
     display: none;
   }
 }

--- a/tegel/src/components/breadcrumb/sdds-breadcrumb-link/sdds-breadcrumb-link.tsx
+++ b/tegel/src/components/breadcrumb/sdds-breadcrumb-link/sdds-breadcrumb-link.tsx
@@ -29,7 +29,7 @@ export class SddsBreadcrumbLink {
       ${this.disabled ? 'disabled' : ''}`}
       >
         <a href={!this.disabled ? this.href : null} target={this.target} rel={this.rel}>
-          <slot></slot>
+          <slot name="label"></slot>
         </a>
       </div>
     );

--- a/tegel/src/components/breadcrumb/sdds-breadcrumb.stories.tsx
+++ b/tegel/src/components/breadcrumb/sdds-breadcrumb.stories.tsx
@@ -25,9 +25,15 @@ const Template = () =>
   formatHtmlPreview(
     `   
       <sdds-breadcrumb>
-        <sdds-breadcrumb-link href="#">Page 1</sdds-breadcrumb-link>
-        <sdds-breadcrumb-link href="google.se">Page 2</sdds-breadcrumb-link>
-        <sdds-breadcrumb-link current>Page 3</sdds-breadcrumb-link>
+        <sdds-breadcrumb-link href="#">
+          <div slot="label">Page 1</div>
+        </sdds-breadcrumb-link>
+        <sdds-breadcrumb-link href="google.se">
+          <div slot="label">Page 2</div>
+        </sdds-breadcrumb-link>
+        <sdds-breadcrumb-link current>
+          <div slot="label">Page 3</div>
+        </sdds-breadcrumb-link>
       </sdds-breadcrumb>
       `,
   );


### PR DESCRIPTION
**Describe pull-request**  
Replaced default slot with named.

**Solving issue**  
Fixes: -

**How to test**  
1. Go to storybook link below
2. Check in Components -> Breadcrumb -> Web Component
3. Check that it still works as inteded.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

**Screenshots**  

**Additional context**  
