### PR TITLE
fix(link): removed default slot

### DIFF
--- a/tegel/src/components/banner/sdds-banner.scss
+++ b/tegel/src/components/banner/sdds-banner.scss
@@ -60,8 +60,6 @@
     sdds-link {
       width: fit-content;
       margin-top: 16px;
-      text-decoration: underline;
-      text-decoration-color: var(--sdds-link);
     }
   }
 

--- a/tegel/src/components/banner/sdds-banner.scss
+++ b/tegel/src/components/banner/sdds-banner.scss
@@ -60,6 +60,8 @@
     sdds-link {
       width: fit-content;
       margin-top: 16px;
+      text-decoration: underline;
+      text-decoration-color: var(--sdds-link);
     }
   }
 

--- a/tegel/src/components/banner/sdds-banner.tsx
+++ b/tegel/src/components/banner/sdds-banner.tsx
@@ -128,7 +128,7 @@ export class SddsBanner {
           {this.subheader && <span class={`banner-subheader`}>{this.subheader}</span>}
           {this.linkText && this.href && (
             <sdds-link href={this.href} rel={this.linkRel} target={this.linkTarget}>
-              {this.linkText}
+              <div slot="label">{this.linkText}</div>
             </sdds-link>
           )}
         </div>

--- a/tegel/src/components/link/sdds-link.stories.tsx
+++ b/tegel/src/components/link/sdds-link.stories.tsx
@@ -68,7 +68,9 @@ const Template = ({ underline, target, disabled }) =>
         href="#"
         target="${target}"
         >
-        This is a link.
+        <div slot="label">
+          This is a link.
+        </div>
     </sdds-link>
   `,
   );

--- a/tegel/src/components/link/sdds-link.tsx
+++ b/tegel/src/components/link/sdds-link.tsx
@@ -33,7 +33,7 @@ export class SddsLink {
         target={this.target}
         rel={this.rel}
       >
-        <slot></slot>
+        <slot name="label"></slot>
       </a>
     );
   }


### PR DESCRIPTION
**Describe pull-request**  
Replaced the default slot on link with a named one. Also updated the use of sdds-link in the banner.

**Solving issue**  
Fixes: -

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Link/Banner -> Web Component
3. Check that the components still behaves as expected.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
