### PR TITLE
fix(stepper): added correct border styling on native label in dark mode

### DIFF
--- a/tegel/src/components/stepper/sdds-stepper.stories.ts
+++ b/tegel/src/components/stepper/sdds-stepper.stories.ts
@@ -84,10 +84,18 @@ const Template = ({ size, direction, labelPosition, hideLabels }) =>
     `<sdds-stepper ${hideLabels ? 'hide-labels' : ''} size="${sizeLookUp[size]}" ${
       direction === 'Horizontal' ? `label-position="${labelPosition?.toLowerCase()}"` : ''
     } direction="${direction.toLowerCase()}">
-    <sdds-stepper-item state="success" label-text="Step label">1</sdds-stepper-item>
-    <sdds-stepper-item state="current" label-text="Current step">3</sdds-stepper-item>
-    <sdds-stepper-item label-text="Step label">3</sdds-stepper-item>
-    <sdds-stepper-item label-text="Step label">4</sdds-stepper-item>
+    <sdds-stepper-item state="success" label-text="Step label">
+      <div slot="index">1</div>
+    </sdds-stepper-item>
+    <sdds-stepper-item state="current" label-text="Current step">
+      <div slot="index">2</div>
+    </sdds-stepper-item>
+    <sdds-stepper-item label-text="Step label">
+      <div slot="index">3</div>
+    </sdds-stepper-item>
+    <sdds-stepper-item label-text="Step label">
+      <div slot="index">4</div>
+    </sdds-stepper-item>
   </sdds-stepper>
         `,
   );
@@ -98,11 +106,19 @@ const TemplateWithError = ({ size, hideLabels, labelPosition, direction }) =>
     `<sdds-stepper ${hideLabels ? 'hide-labels' : ''} size="${sizeLookUp[size]}" ${
       direction === 'Horizontal' ? `label-position="${labelPosition?.toLowerCase()}"` : ''
     } direction="${direction.toLowerCase()}">
-  <sdds-stepper-item state="success" label-text="Step label">1</sdds-stepper-item>
-  <sdds-stepper-item state="error" label-text="Step label">2</sdds-stepper-item>
-  <sdds-stepper-item state="current" label-text="Current step">3</sdds-stepper-item>
-  <sdds-stepper-item label-text="Step label">4</sdds-stepper-item>
-</sdds-stepper>
-      `,
+    <sdds-stepper-item state="success" label-text="Step label">
+      <div slot="index">1</div>
+    </sdds-stepper-item>
+    <sdds-stepper-item state="error" label-text="Current step">
+      <div slot="index">2</div>
+    </sdds-stepper-item>
+    <sdds-stepper-item label-text="Step label">
+      <div slot="index">3</div>
+    </sdds-stepper-item>
+    <sdds-stepper-item label-text="Step label">
+      <div slot="index">4</div>
+    </sdds-stepper-item>
+  </sdds-stepper>
+        `,
   );
 export const WebComponentWithError = TemplateWithError.bind({});

--- a/tegel/src/components/stepper/stepper.scss
+++ b/tegel/src/components/stepper/stepper.scss
@@ -196,11 +196,17 @@
 
     &--inactive {
       .sdds-stepper__step-icon {
-        border-color: rgb(0 21 51 / 16%);
+        border-color: var(--sdds-stepper-label-border-color-upcoming);
+        opacity: var(--sdds-stepper-label-text-opacity-upcoming);
+
+        &::after, &::before {
+          opacity: unset;
+          opacity: 0.38;
+        }
       }
 
       .sdds-stepper__step-icon-value {
-        opacity: 0.38;
+        opacity: 1;
       }
 
       .sdds-stepper__step_label {


### PR DESCRIPTION
**Describe pull-request**  
Added the correct border styling for inactive step in dark mode. 

**Solving issue**  
Fixes: https://tegel.atlassian.net/browse/DTS-1269

**How to test**  
1. Go to storybook
2. Check in Components -> Stepper -> Native
3. Check that the styling is correct in both modes.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events