### PR TITLE
fix(banner & footer): update link prop

### DIFF
--- a/tegel/src/components/banner/sdds-banner.tsx
+++ b/tegel/src/components/banner/sdds-banner.tsx
@@ -127,7 +127,7 @@ export class SddsBanner {
           {this.header && <span class={`banner-header`}>{this.header}</span>}
           {this.subheader && <span class={`banner-subheader`}>{this.subheader}</span>}
           {this.linkText && this.href && (
-            <sdds-link href={this.href} rel={this.linkRel} link-target={this.linkTarget}>
+            <sdds-link href={this.href} rel={this.linkRel} target={this.linkTarget}>
               {this.linkText}
             </sdds-link>
           )}

--- a/tegel/src/components/banner/sdds-banner.tsx
+++ b/tegel/src/components/banner/sdds-banner.tsx
@@ -127,7 +127,7 @@ export class SddsBanner {
           {this.header && <span class={`banner-header`}>{this.header}</span>}
           {this.subheader && <span class={`banner-subheader`}>{this.subheader}</span>}
           {this.linkText && this.href && (
-            <sdds-link link-href={this.href} rel={this.linkRel} link-target={this.linkTarget}>
+            <sdds-link href={this.href} rel={this.linkRel} link-target={this.linkTarget}>
               {this.linkText}
             </sdds-link>
           )}

--- a/tegel/src/components/footer/webcomponent/sdds-footer-link/readme.md
+++ b/tegel/src/components/footer/webcomponent/sdds-footer-link/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property   | Attribute   | Description                                                                                                                                             | Type                                         | Default      |
-| ---------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | ------------ |
-| `linkHref` | `link-href` | URL for the link                                                                                                                                        | `string`                                     | `undefined`  |
-| `rel`      | `rel`       | 'noopener' is a security measure for legacy browsers that prevents the opened page from getting access to the original page when using target='_blank'. | `string`                                     | `'noopener'` |
-| `target`   | `target`    | Where to open the linked URL                                                                                                                            | `"_blank" \| "_parent" \| "_self" \| "_top"` | `'_self'`    |
+| Property | Attribute | Description                                                                                                                                             | Type                                         | Default      |
+| -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | ------------ |
+| `href`   | `href`    | URL for the link                                                                                                                                        | `string`                                     | `undefined`  |
+| `rel`    | `rel`     | 'noopener' is a security measure for legacy browsers that prevents the opened page from getting access to the original page when using target='_blank'. | `string`                                     | `'noopener'` |
+| `target` | `target`  | Where to open the linked URL                                                                                                                            | `"_blank" \| "_parent" \| "_self" \| "_top"` | `'_self'`    |
 
 
 ----------------------------------------------

--- a/tegel/src/components/footer/webcomponent/sdds-footer-link/sdds-footer-link.tsx
+++ b/tegel/src/components/footer/webcomponent/sdds-footer-link/sdds-footer-link.tsx
@@ -9,7 +9,7 @@ import { HostElement } from '@stencil/core/internal';
 })
 export class SddsFooterLink {
   /** URL for the link */
-  @Prop() linkHref: string;
+  @Prop() href: string;
 
   /** Where to open the linked URL */
   @Prop() target: '_self' | '_blank' | '_parent' | '_top' = '_self';
@@ -28,7 +28,7 @@ export class SddsFooterLink {
   render() {
     return (
       <div role="listitem" class={`${this.parentIsTopPart ? 'top-part-child' : ''}`}>
-        <a target={this.target} rel={this.rel} href={this.linkHref}>
+        <a target={this.target} rel={this.rel} href={this.href}>
           <slot></slot>
         </a>
       </div>

--- a/tegel/src/components/footer/webcomponent/sdds-footer.stories.tsx
+++ b/tegel/src/components/footer/webcomponent/sdds-footer.stories.tsx
@@ -24,7 +24,8 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
-      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
+      description:
+        'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
@@ -65,33 +66,33 @@ const Template = ({ topPart, modeVariant }) =>
           ? `
       <div slot="top">
         <sdds-footer-link-group title-text="Title">
-          <sdds-footer-link link-href="#">Link text</sdds-footer-link>
-          <sdds-footer-link link-href="#">Link text</sdds-footer-link>
-          <sdds-footer-link link-href="#">Link text</sdds-footer-link>
+          <sdds-footer-link href="#">Link text</sdds-footer-link>
+          <sdds-footer-link href="#">Link text</sdds-footer-link>
+          <sdds-footer-link href="#">Link text</sdds-footer-link>
         </sdds-footer-link-group>
 
         <sdds-footer-link-group title-text="Title">
-          <sdds-footer-link link-href="#">Link text</sdds-footer-link>
-          <sdds-footer-link link-href="#">Link text</sdds-footer-link>
-          <sdds-footer-link link-href="#">Link text</sdds-footer-link>
+          <sdds-footer-link href="#">Link text</sdds-footer-link>
+          <sdds-footer-link href="#">Link text</sdds-footer-link>
+          <sdds-footer-link href="#">Link text</sdds-footer-link>
         </sdds-footer-link-group>
 
         <sdds-footer-link-group title-text="Title">
-          <sdds-footer-link link-href="#">Link text</sdds-footer-link>
-          <sdds-footer-link link-href="#">Link text</sdds-footer-link>
-          <sdds-footer-link link-href="#">Link text</sdds-footer-link>
+          <sdds-footer-link href="#">Link text</sdds-footer-link>
+          <sdds-footer-link href="#">Link text</sdds-footer-link>
+          <sdds-footer-link href="#">Link text</sdds-footer-link>
         </sdds-footer-link-group>
 
         <sdds-footer-link-group title-text="Title">
-          <sdds-footer-link link-href="#">Link text</sdds-footer-link>
-          <sdds-footer-link link-href="#">Link text</sdds-footer-link>
-          <sdds-footer-link link-href="#">Link text</sdds-footer-link>
+          <sdds-footer-link href="#">Link text</sdds-footer-link>
+          <sdds-footer-link href="#">Link text</sdds-footer-link>
+          <sdds-footer-link href="#">Link text</sdds-footer-link>
         </sdds-footer-link-group>
 
         <sdds-footer-link-group title-text="Title">
-          <sdds-footer-link link-href="#">Link text</sdds-footer-link>
-          <sdds-footer-link link-href="#">Link text</sdds-footer-link>
-          <sdds-footer-link link-href="#">Link text</sdds-footer-link>
+          <sdds-footer-link href="#">Link text</sdds-footer-link>
+          <sdds-footer-link href="#">Link text</sdds-footer-link>
+          <sdds-footer-link href="#">Link text</sdds-footer-link>
         </sdds-footer-link-group>
       </div>
       `
@@ -99,20 +100,20 @@ const Template = ({ topPart, modeVariant }) =>
       }
       <div slot="main-left">
         <sdds-footer-link-group>
-          <sdds-footer-link link-href="#">Link text</sdds-footer-link>
-          <sdds-footer-link link-href="#">Link text</sdds-footer-link>
-          <sdds-footer-link link-href="#">Link text</sdds-footer-link>
+          <sdds-footer-link href="#">Link text</sdds-footer-link>
+          <sdds-footer-link href="#">Link text</sdds-footer-link>
+          <sdds-footer-link href="#">Link text</sdds-footer-link>
         </sdds-footer-link-group>
       </div>
       <div slot="main-right">
         <sdds-footer-link-group>
-          <sdds-footer-link link-href="#">
+          <sdds-footer-link href="#">
           <sdds-icon name="truck"></sdds-icon>
           </sdds-footer-link>
-          <sdds-footer-link link-href="#">
+          <sdds-footer-link href="#">
             <sdds-icon name="truck"></sdds-icon>
           </sdds-footer-link>
-          <sdds-footer-link link-href="#">
+          <sdds-footer-link href="#">
             <sdds-icon name="truck"></sdds-icon>
           </sdds-footer-link>
         </sdds-footer-link-group>


### PR DESCRIPTION
**Describe pull-request**  
The banner was using the old link prop (link-href) which was breaking it. And the footer-group-links was using the old link- prefix.

**Solving issue**  
Fixes: -

**How to test**  
1. Go to storybook link below
2. Check in Components -> Banner -> Web Components
3. Check that the link opens a new page
4. To the same for footer links (web component)

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

