### PR TITLE
fix(footer): removed default slot

### DIFF
--- a/tegel/src/components/footer/webcomponent/sdds-footer-link/sdds-footer-link.tsx
+++ b/tegel/src/components/footer/webcomponent/sdds-footer-link/sdds-footer-link.tsx
@@ -29,7 +29,7 @@ export class SddsFooterLink {
     return (
       <div role="listitem" class={`${this.parentIsTopPart ? 'top-part-child' : ''}`}>
         <a target={this.target} rel={this.rel} href={this.href}>
-          <slot></slot>
+          <slot name="label"></slot>
         </a>
       </div>
     );

--- a/tegel/src/components/footer/webcomponent/sdds-footer.stories.tsx
+++ b/tegel/src/components/footer/webcomponent/sdds-footer.stories.tsx
@@ -66,33 +66,60 @@ const Template = ({ topPart, modeVariant }) =>
           ? `
       <div slot="top">
         <sdds-footer-link-group title-text="Title">
-          <sdds-footer-link href="#">Link text</sdds-footer-link>
-          <sdds-footer-link href="#">Link text</sdds-footer-link>
-          <sdds-footer-link href="#">Link text</sdds-footer-link>
+          <sdds-footer-link href="#">
+          <div slot="label">Link text</div></sdds-footer-link>
+          <sdds-footer-link href="#">
+          <div slot="label">Link text</div></sdds-footer-link>
+          <sdds-footer-link href="#">
+          <div slot="label">Link text</div></sdds-footer-link>
         </sdds-footer-link-group>
 
         <sdds-footer-link-group title-text="Title">
-          <sdds-footer-link href="#">Link text</sdds-footer-link>
-          <sdds-footer-link href="#">Link text</sdds-footer-link>
-          <sdds-footer-link href="#">Link text</sdds-footer-link>
+          <sdds-footer-link href="#">
+          <div slot="label">Link text</div>
+          </sdds-footer-link>
+          <sdds-footer-link href="#">
+          <div slot="label">Link text</div>
+          </sdds-footer-link>
+          <sdds-footer-link href="#">
+          <div slot="label">Link text</div>
+          </sdds-footer-link>
         </sdds-footer-link-group>
 
         <sdds-footer-link-group title-text="Title">
-          <sdds-footer-link href="#">Link text</sdds-footer-link>
-          <sdds-footer-link href="#">Link text</sdds-footer-link>
-          <sdds-footer-link href="#">Link text</sdds-footer-link>
+          <sdds-footer-link href="#">
+          <div slot="label">Link text</div>
+          </sdds-footer-link>
+          <sdds-footer-link href="#">
+          <div slot="label">Link text</div>
+          </sdds-footer-link>
+          <sdds-footer-link href="#">
+          <div slot="label">Link text</div>
+          </sdds-footer-link>
         </sdds-footer-link-group>
 
         <sdds-footer-link-group title-text="Title">
-          <sdds-footer-link href="#">Link text</sdds-footer-link>
-          <sdds-footer-link href="#">Link text</sdds-footer-link>
-          <sdds-footer-link href="#">Link text</sdds-footer-link>
+          <sdds-footer-link href="#">
+          <div slot="label">Link text</div>
+          </sdds-footer-link>
+          <sdds-footer-link href="#">
+          <div slot="label">Link text</div>
+          </sdds-footer-link>
+          <sdds-footer-link href="#">
+          <div slot="label">Link text</div>
+          </sdds-footer-link>
         </sdds-footer-link-group>
 
         <sdds-footer-link-group title-text="Title">
-          <sdds-footer-link href="#">Link text</sdds-footer-link>
-          <sdds-footer-link href="#">Link text</sdds-footer-link>
-          <sdds-footer-link href="#">Link text</sdds-footer-link>
+          <sdds-footer-link href="#">
+          <div slot="label">Link text</div>
+          </sdds-footer-link>
+          <sdds-footer-link href="#">
+          <div slot="label">Link text</div>
+          </sdds-footer-link>
+          <sdds-footer-link href="#">
+          <div slot="label">Link text</div>
+          </sdds-footer-link>
         </sdds-footer-link-group>
       </div>
       `
@@ -100,9 +127,15 @@ const Template = ({ topPart, modeVariant }) =>
       }
       <div slot="main-left">
         <sdds-footer-link-group>
-          <sdds-footer-link href="#">Link text</sdds-footer-link>
-          <sdds-footer-link href="#">Link text</sdds-footer-link>
-          <sdds-footer-link href="#">Link text</sdds-footer-link>
+          <sdds-footer-link href="#">
+          <div slot="label">Link text</div>
+          </sdds-footer-link>
+          <sdds-footer-link href="#">
+          <div slot="label">Link text</div>
+          </sdds-footer-link>
+          <sdds-footer-link href="#">
+          <div slot="label">Link text</div>
+          </sdds-footer-link>
         </sdds-footer-link-group>
       </div>
       <div slot="main-right">


### PR DESCRIPTION
**Describe pull-request**  
Removed default slot and introduced named slot for label.

**Solving issue**  
Fixes: -

**How to test**  
1. Go to storybook
2. Check in Components -> Footer -> Web Components
3. Check that the links are still working correct and look correct.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
