### PR TITLE
fix(textfield): sb controls for prefix and suffix. Temp fix for margins

### DIFF
--- a/tegel/src/components/textfield/textfield.scss
+++ b/tegel/src/components/textfield/textfield.scss
@@ -395,6 +395,7 @@ slot[name="sdds-suffix"]::slotted(*) {
 
 .textfield-slot-wrap-prefix {
   align-self: center;
+  margin-left: 14px ;
 
   > * {
     font: var(--sdds-detail-02);
@@ -413,6 +414,7 @@ slot[name="sdds-suffix"]::slotted(*) {
 
 .textfield-slot-wrap-suffix {
   align-self: center;
+  margin-right: 14px;
 
   > * {
     font: var(--sdds-detail-02);

--- a/tegel/src/components/textfield/textfield.tsx
+++ b/tegel/src/components/textfield/textfield.tsx
@@ -145,7 +145,7 @@ export class Textfield {
         )}
         <div onClick={() => this.textInput.focus()} class="textfield-container">
           <div class={`textfield-slot-wrap-prefix textfield-${this.state}`}>
-            <slot name="prefix" />
+            <slot name="sdds-prefix" />
           </div>
 
           <div class="textfield-input-container">
@@ -181,7 +181,7 @@ export class Textfield {
           <div class="textfield-bar"></div>
 
           <div class={`textfield-slot-wrap-suffix textfield-${this.state}`}>
-            <slot name="suffix" />
+            <slot name="sdds-suffix" />
           </div>
           <span class="textfield-icon__readonly">
             <sdds-icon name="edit_inactive" size="20px"></sdds-icon>


### PR DESCRIPTION
**Describe pull-request**  
Fixed the controls in sb by changing the slot name from prefix/suffix to sdds-prefix/suffix. This is the slot name used in sb and in scss so I assumed that was the correct one.

Also made a temporary margin for prefix/suffix, but it seems like the styling (colors, etc) doesn't work them but I'm writing a separate ticket for that

**How to test**  
_Add description how to test if possible_
1. Check that the controls work in sb
