### PR TITLE
fix(button): added correct color to focused button with icon in darkmode

### DIFF
--- a/tegel/src/components/button/button-vars.scss
+++ b/tegel/src/components/button/button-vars.scss
@@ -41,6 +41,8 @@
   --sdds-btn-secondary-background-disabled: transparent;
   --sdds-btn-secondary-color-disabled: rgb(0 0 0 / 38%);
   --sdds-btn-secondary-border-color-disabled: rgb(0 0 0 / 38%);
+  --sdds-btn-icon-secondary-color-focus: var(--sdds-black);
+  --sdds-btn-icon-secondary-fill-focus: var(--sdds-black);
 
   /* ICON */ //not used
   --sdds-btn-icon-secondary-fill: var(--sdds-black);
@@ -49,10 +51,6 @@
   /* ICON HOVER */ //not used
   --sdds-btn-icon-secondary-fill-hover: var(--sdds-grey-50);
   --sdds-btn-icon-secondary-color-hover: var(--sdds-grey-50);
-
-  /* ICON FOCUS */ //not used
-  --sdds-btn-icon-secondary-fill-focus: var(--sdds-black);
-  --sdds-btn-icon-secondary-color-focus: var(--sdds-black);
 
   //Ghost
   --sdds-btn-ghost-background: transparent;
@@ -147,6 +145,8 @@
   --sdds-btn-secondary-background-disabled: transparent;
   --sdds-btn-secondary-color-disabled: rgb(255 255 255 / 38%);
   --sdds-btn-secondary-border-color-disabled: rgb(255 255 255 / 38%);
+  --sdds-btn-icon-secondary-color-focus: var(--sdds-white);
+  --sdds-btn-icon-secondary-fill-focus: var(--sdds-white);
 
   /* ICON */ //not used
   --sdds-btn-icon-secondary-fill: var(--sdds-grey-50);


### PR DESCRIPTION
**Describe pull-request**  
Added the correct color for native, focused secondary button with icon.


**Solving issue**  
Fixes: [ #DTS-](https://tegel.atlassian.net/browse/DTS-1254)

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Button -> Native With Icon
3. Check the focused state of the secondary type.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
