### PR TITLE
feat(banner): aligned banner with toast on slots vs props

### DIFF
--- a/tegel/src/components/banner/readme.md
+++ b/tegel/src/components/banner/readme.md
@@ -7,19 +7,14 @@
 
 ## Properties
 
-| Property     | Attribute     | Description                                                                                                                                                                                                                                        | Type                                         | Default               |
-| ------------ | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | --------------------- |
-| `bannerId`   | `banner-id`   | ID used for internal table functionality and events, must be unique.  **NOTE**: If you're listening for banner close events you need to set this ID yourself to identify the banner, as the default ID is random and will be different every time. | `string`                                     | `crypto.randomUUID()` |
-| `header`     | `header`      | Header text.                                                                                                                                                                                                                                       | `string`                                     | `undefined`           |
-| `hidden`     | `hidden`      | Hides the banner                                                                                                                                                                                                                                   | `boolean`                                    | `false`               |
-| `href`       | `href`        | Href for the link                                                                                                                                                                                                                                  | `string`                                     | `undefined`           |
-| `icon`       | `icon`        | Name of the icon for the component. For error and information type the icon is predefined.                                                                                                                                                         | `string`                                     | `undefined`           |
-| `linkRel`    | `link-rel`    | 'noopener' is a security measure for legacy browsers that preventsthe opened page from getting access to the original page when using target='_blank'.                                                                                             | `string`                                     | `'noopener'`          |
-| `linkTarget` | `link-target` | Where to open the linked URL                                                                                                                                                                                                                       | `"_blank" \| "_parent" \| "_self" \| "_top"` | `'_self'`             |
-| `linkText`   | `link-text`   | Link text.                                                                                                                                                                                                                                         | `string`                                     | `undefined`           |
-| `persistent` | `persistent`  | Removes the close button on the banner.                                                                                                                                                                                                            | `boolean`                                    | `false`               |
-| `subheader`  | `subheader`   | Subheader text.                                                                                                                                                                                                                                    | `string`                                     | `undefined`           |
-| `type`       | `type`        | Type of banner                                                                                                                                                                                                                                     | `"error" \| "information" \| "none"`         | `'none'`              |
+| Property     | Attribute    | Description                                                                                                                                                                                                                                        | Type                                 | Default               |
+| ------------ | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | --------------------- |
+| `bannerId`   | `banner-id`  | ID used for internal table functionality and events, must be unique.  **NOTE**: If you're listening for banner close events you need to set this ID yourself to identify the banner, as the default ID is random and will be different every time. | `string`                             | `crypto.randomUUID()` |
+| `header`     | `header`     | Header text.                                                                                                                                                                                                                                       | `string`                             | `undefined`           |
+| `hidden`     | `hidden`     | Hides the banner                                                                                                                                                                                                                                   | `boolean`                            | `false`               |
+| `icon`       | `icon`       | Name of the icon for the component. For error and information type the icon is predefined.                                                                                                                                                         | `string`                             | `undefined`           |
+| `persistent` | `persistent` | Removes the close button on the banner.                                                                                                                                                                                                            | `boolean`                            | `false`               |
+| `type`       | `type`       | Type of banner                                                                                                                                                                                                                                     | `"error" \| "information" \| "none"` | `'none'`              |
 
 
 ## Events
@@ -57,13 +52,11 @@ Type: `Promise<{ bannerId: string; hidden: boolean; }>`
 ### Depends on
 
 - [sdds-icon](../icon)
-- [sdds-link](../link)
 
 ### Graph
 ```mermaid
 graph TD;
   sdds-banner --> sdds-icon
-  sdds-banner --> sdds-link
   style sdds-banner fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/tegel/src/components/banner/sdds-banner.scss
+++ b/tegel/src/components/banner/sdds-banner.scss
@@ -51,15 +51,25 @@
       letter-spacing: var(--sdds-headline-06-ls);
     }
 
-    .banner-subheader {
+    slot[name='banner-subheader'] {
+      display: block;
       margin-top: 4px;
       font: var(--sdds-detail-02);
       letter-spacing: var(--sdds-detail-02-ls);
     }
 
-    sdds-link {
-      width: fit-content;
-      margin-top: 16px;
+    .banner-link {
+      slot[name='banner-link'] {
+        display: block;
+        width: fit-content;
+        margin-top: 16px;
+      }
+
+      &.no-subheader {
+        slot[name='banner-link'] {
+          margin-top: 4px;
+        }
+      }
     }
   }
 

--- a/tegel/src/components/banner/sdds-banner.stories.tsx
+++ b/tegel/src/components/banner/sdds-banner.stories.tsx
@@ -48,31 +48,14 @@ export default {
         type: 'text',
       },
     },
-    linkText: {
+    link: {
       name: 'Link',
-      description: 'Sets text to be displayed in the link section.',
+      description: 'Sets a link to be displayed in the link section.',
       control: {
         type: 'text',
       },
     },
-    href: {
-      name: 'Link href',
-      description: 'Sets the href for the link.',
-      control: {
-        type: 'text',
-      },
-    },
-    linkTarget: {
-      name: 'Link target',
-      description: 'Sets where to open the linked URL.',
-      control: {
-        type: 'radio',
-      },
-      options: ['_self', '_blank', '_parent', '_top'],
-      table: {
-        defaultValue: { summary: '_self' },
-      },
-    },
+
     icon: {
       name: 'Icon',
       description: 'Name of icon to display, choose `none` to remove the icon.',
@@ -96,28 +79,23 @@ export default {
   args: {
     type: 'Default',
     header: 'This is a header text area',
-    subheader: 'SubHeader text area',
-    linkText: 'Learn more',
-    href: 'tegel.scania.com',
-    linkTarget: '_self',
+    subheader: '<div slot="banner-subheader">Short subheader</div>',
+    link: '<sdds-link slot="banner-link" href="/">Link example</sdds-link>',
     icon: 'truck',
     persistent: false,
   },
 };
 
-const Template = ({ type, icon, header, subheader, linkText, href, persistent, linkTarget }) =>
+const Template = ({ type, icon, header, subheader, persistent, link }) =>
   formatHtmlPreview(`
       <sdds-banner
           ${type !== 'Default' ? `type="${type.toLowerCase()}"` : ''}
           ${icon !== 'none' ? `icon="${icon}"` : ''}
           ${header !== '' ? `header="${header}"` : ''}
-          ${subheader !== '' ? `subheader="${subheader}"` : ''}
-          ${linkText !== '' ? `link-text="${linkText}"` : ''}
-          ${href !== '' ? `href="${href}"` : ''}
-          ${linkTarget !== '' ? `link-target="${linkTarget}"` : ''}
-
           ${persistent ? `persistent` : ''}
           >
+          ${subheader ? `${subheader}` : ''}
+          ${link ? `${link}` : ''}
       </sdds-banner>
 
       <!-- Script tag with eventlistener for demo purposes. -->

--- a/tegel/src/components/banner/sdds-banner.tsx
+++ b/tegel/src/components/banner/sdds-banner.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, h, Prop, Event, EventEmitter, Method, Element } from '@stencil/core';
-import { HostElement } from '@stencil/core/internal';
+import { HostElement, State } from '@stencil/core/internal';
 
 @Component({
   tag: 'sdds-banner',
@@ -12,21 +12,6 @@ export class SddsBanner {
 
   /** Header text. */
   @Prop() header: string;
-
-  /** Subheader text. */
-  @Prop() subheader: string;
-
-  /** Link text. */
-  @Prop() linkText: string;
-
-  /** Href for the link */
-  @Prop() href: string;
-
-  /** Where to open the linked URL */
-  @Prop() linkTarget: '_self' | '_blank' | '_parent' | '_top' = '_self';
-
-  /** 'noopener' is a security measure for legacy browsers that preventsthe opened page from getting access to the original page when using target='_blank'. */
-  @Prop() linkRel: string = 'noopener';
 
   /** Type of banner */
   @Prop() type: 'error' | 'information' | 'none' = 'none';
@@ -42,6 +27,10 @@ export class SddsBanner {
 
   /** Hides the banner */
   @Prop() hidden = false;
+
+  @State() hasSubheader: boolean;
+
+  @State() hasLink: boolean;
 
   @Element() host: HostElement;
 
@@ -95,6 +84,9 @@ export class SddsBanner {
     } else if (this.type === 'information') {
       this.icon = 'info';
     }
+    const children = Array.from(this.host.children);
+    this.hasSubheader = children.some((childElement) => childElement.slot === 'banner-subheader');
+    this.hasLink = children.some((childElement) => childElement.slot === 'banner-link');
   }
 
   handleClose = () => {
@@ -125,11 +117,11 @@ export class SddsBanner {
         )}
         <div class={`banner-content ${this.type} ${!this.icon ? 'no-icon' : ''}`}>
           {this.header && <span class={`banner-header`}>{this.header}</span>}
-          {this.subheader && <span class={`banner-subheader`}>{this.subheader}</span>}
-          {this.linkText && this.href && (
-            <sdds-link href={this.href} rel={this.linkRel} target={this.linkTarget}>
-              {this.linkText}
-            </sdds-link>
+          {this.hasSubheader && <slot name="banner-subheader"></slot>}
+          {this.hasLink && (
+            <div class={`banner-link ${!this.hasSubheader ? 'no-subheader' : ''}`}>
+              <slot name="banner-link"></slot>
+            </div>
           )}
         </div>
         {!this.persistent && (

--- a/tegel/src/components/link/readme.md
+++ b/tegel/src/components/link/readme.md
@@ -16,19 +16,6 @@
 | `underline` | `underline` | Displays the link with an underline.                                                                                                                   | `boolean`                                    | `true`       |
 
 
-## Dependencies
-
-### Used by
-
- - [sdds-banner](../banner)
-
-### Graph
-```mermaid
-graph TD;
-  sdds-banner --> sdds-link
-  style sdds-link fill:#f9f,stroke:#333,stroke-width:4px
-```
-
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*


### PR DESCRIPTION
**Describe pull-request**  
Aligned how banner handles link and subheader with toast. Removed all the props and introduces two slots instead.

**Solving issue**  
Fixes: [#DTS](https://tegel.atlassian.net/browse/DTS-1343)

**How to test**  
1. Go to storybook link below
2. Check in Components -> Banner -> Web Component
3. Check the styles for the link and subheader.


## Note:
This does not solve the issue of the link having a different color than it's default in dark mode. 

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
