### PR TITLE
fix(dropdown): correct disabled background color vars

### DIFF
--- a/tegel/src/components/dropdown/dropdown-vars.scss
+++ b/tegel/src/components/dropdown/dropdown-vars.scss
@@ -16,17 +16,16 @@
   --sdds-dropdown-border-not-focused: var(--sdds-grey-600);
   --sdds-dropdown-option-color: var(--sdds-grey-900);
   --sdds-dropdown-option-disabled-color: var(--sdds-grey-400);
+  --sdds-dropdown-background-disabled: var(--sdds-dropdown-background);
 
   .sdds-mode-variant-primary {
     --sdds-dropdown-background: var(--sdds-grey-50);
     --sdds-dropdown-background-hover: var(--sdds-grey-100);
-    --sdds-dropdown-background-disabled: var(--sdds-grey-50);
   }
 
   .sdds-mode-variant-secondary {
     --sdds-dropdown-background: var(--sdds-white);
     --sdds-dropdown-background-hover: var(--sdds-grey-50);
-    --sdds-dropdown-background-disabled: var(--sdds-white);
   }
 }
 
@@ -35,7 +34,6 @@
   --sdds-dropdown-color: var(--sdds-grey-400);
   --sdds-dropdown-background: var(--sdds-grey-868);
   --sdds-dropdown-background-hover: var(--sdds-grey-800);
-  --sdds-dropdown-background-disabled: var(--sdds-grey-900);
   --sdds-dropdown-disabled: var(--sdds-grey-800);
   --sdds-dropdown-border: var(--sdds-grey-800);
   --sdds-dropdown-label-inside: var(--sdds-grey-400);
@@ -44,16 +42,15 @@
   --sdds-dropdown-border-not-focused: var(--sdds-grey-600);
   --sdds-dropdown-option-color: var(--sdds-grey-50);
   --sdds-dropdown-option-disabled-color: var(--sdds-grey-800);
+  --sdds-dropdown-background-disabled: var(--sdds-dropdown-background);
 
   .sdds-mode-variant-primary {
     --sdds-dropdown-background: var(--sdds-grey-868);
     --sdds-dropdown-background-hover: var(--sdds-grey-800);
-    --sdds-dropdown-background-disabled: var(--sdds-grey-868);
   }
 
   .sdds-mode-variant-secondary {
     --sdds-dropdown-background: var(--sdds-grey-900);
     --sdds-dropdown-background-hover: var(--sdds-grey-800);
-    --sdds-dropdown-background-disabled: var(--sdds-grey-900);
   }
 }


### PR DESCRIPTION
**Describe pull-request**  
Corrected the disabled backgound color variable for the web component dropdown.

**Solving issue**  
Fixes: [DTS-1264](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-1264)

**How to test**  
1. Go to storybook link below.
2. Check in Dropdown -> Web Component Default
3. Set class sdds-mode-light to wrapping div
4. Check the styling for light/dark mode

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

[DTS-1264]: https://tegel.atlassian.net/browse/DTS-1264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ