### PR TITLE
fix: set default mode variant color and bgcolor

### DIFF
--- a/tegel/src/global/global.scss
+++ b/tegel/src/global/global.scss
@@ -88,8 +88,30 @@ body {
 html,
 .sdds-mode-light {
   color: var(--sdds-grey-958);
+  background-color: var(--sdds-white);
+
+  & .sdds-mode-variant-primary {
+    color: var(--sdds-grey-958);
+    background-color: var(--sdds-white);
+  }
+
+  & .sdds-mode-variant-secondary {
+    color: var(--sdds-grey-958);
+    background-color: var(--sdds-grey-50);
+  }
 }
 
 .sdds-mode-dark {
-  color: var(--sdds-white);
+  color: var(--sdds-grey-100);
+  background-color: var(--sdds-grey-958);
+
+  & .sdds-mode-variant-primary {
+    color: var(--sdds-grey-100);
+    background-color: var(--sdds-grey-958);
+  }
+
+  & .sdds-mode-variant-secondary {
+    color: var(--sdds-grey-100);
+    background-color: var(--sdds-grey-900);
+  }
 }


### PR DESCRIPTION
**Describe pull-request**  
It makes sense that if we change the text to darkmode we would also change the default background so the text is not invisible.
This PR addresses that

**How to test** 
Clone the branch, add a .sdds-mode-dark somewhere, and see the background change!
Optionally test it more or less thoroughly.