### PR TITLE
fix(stepper): update stepper gap in vertical

### DIFF
--- a/tegel/src/components/stepper/sdds-stepper.scss
+++ b/tegel/src/components/stepper/sdds-stepper.scss
@@ -7,7 +7,7 @@
       height: 100%;
       flex-direction: column;
       justify-content: unset;
-      gap: 48px;
+      gap: 52px;
     }
 
     &.vertical.sm {


### PR DESCRIPTION
**Describe pull-request**  
Updates the gap between steps on the vertical stepper. 

**Solving issue**  
_In case of GitHub issue add # plus the number of the issue (for example #123) OR if it is Azure then AB# and number of ticket_
Fixes: [DTS-1265](https://tegel.atlassian.net/browse/DTS-1265)

**How to test**  
Go to storybook link below.
Check in Components -> Stepper -> Webcomponent
Change to the Vertical version. Check that the distance is 52px

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events


[DTS-1265]: https://tegel.atlassian.net/browse/DTS-1265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ