### PR TITLE
fix(button): update secondary default border color

### DIFF
--- a/tegel/src/components/button/button-vars.scss
+++ b/tegel/src/components/button/button-vars.scss
@@ -27,7 +27,7 @@
   //Secondary
   --sdds-btn-secondary-background: transparent;
   --sdds-btn-secondary-color: var(--sdds-black);
-  --sdds-btn-secondary-border-color: rgb(0 0 0 / 38%);
+  --sdds-btn-secondary-border-color: rgb(0 0 0 / 48%);
   --sdds-btn-secondary-background-hover: var(--sdds-blue-500);
   --sdds-btn-secondary-color-hover: var(--sdds-white);
   --sdds-btn-secondary-border-color-hover: var(--sdds-blue-500);


### PR DESCRIPTION
**Describe pull-request**  
Updated the default border color for button with type secondary to distinguish it from the disabled state. Before they had the same border color.

**Solving issue**  
Fixes: [DTS-1253](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-1253)

**How to test**  
1. Go to Storybook link below
2. Check in Button -> Native and Web Component
3. Put "Type" control in "Secondary"
4. Check the button border color (should be rgb(0 0 0 / 48%) )
5. Put button in disabled state
6. Check button border color again (should now be rgb(0 0 0 / 38%) )

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events