### PR TITLE
fix(checkbox): correct color for focused and hover states

### DIFF
--- a/tegel/src/components/checkbox/checkbox-vars.scss
+++ b/tegel/src/components/checkbox/checkbox-vars.scss
@@ -5,6 +5,8 @@
   --sdds-checkbox-interaction-02: var(--sdds-white);
   --sdds-checkbox-background-hover: var(--sdds-blue-800);
   --sdds-checkbox-background-focus: var(--sdds-blue-800);
+  --sdds-checkbox-background-opacity-hover: 0.12;
+  --sdds-checkbox-background-opacity-focus: 0.24;
   --sdds-checkbox-disabled: var(--sdds-grey-400);
   --sdds-checkbox-background-img: url("data:image/svg+xml;utf8,<svg width='8' height='6' viewBox='0 0 8 6' fill='none' xmlns='http://www.w3.org/2000/svg'> <path d='M1 2.33333L3.4 5C4.80589 3.4379 5.59411 2.5621 7 1' stroke='%23ffffff' stroke-linecap='round' stroke-linejoin='round'/></svg>");
   --sdds-checkbox-background-img-disabled: url("data:image/svg+xml;utf8,<svg width='8' height='6' viewBox='0 0 8 6' fill='none' xmlns='http://www.w3.org/2000/svg'> <path d='M1 2.33333L3.4 5C4.80589 3.4379 5.59411 2.5621 7 1' stroke='%23b0b7c4' stroke-linecap='round' stroke-linejoin='round'/></svg>");
@@ -16,8 +18,10 @@
     --sdds-checkbox-color: var(--sdds-white);
     --sdds-checkbox-interaction-01: var(--sdds-white);
     --sdds-checkbox-interaction-02: var(--sdds-grey-958);
-    --sdds-checkbox-background-hover: white;
-    --sdds-checkbox-background-focus: white;
+    --sdds-checkbox-background-hover: var(--sdds-grey-600);
+    --sdds-checkbox-background-focus: var(--sdds-grey-600);
+    --sdds-checkbox-background-opacity-hover: 0.48;
+    --sdds-checkbox-background-opacity-focus: 0.72;
     --sdds-checkbox-disabled: white;
     --sdds-checkbox-background-img: url("data:image/svg+xml;utf8,<svg width='8' height='6' viewBox='0 0 8 6' fill='none' xmlns='http://www.w3.org/2000/svg'> <path d='M1 2.33333L3.4 5C4.80589 3.4379 5.59411 2.5621 7 1' stroke='%230D0F13' stroke-linecap='round' stroke-linejoin='round'/></svg>");
     --sdds-checkbox-background-img-disabled: url("data:image/svg+xml;utf8,<svg width='8' height='6' viewBox='0 0 8 6' fill='none' xmlns='http://www.w3.org/2000/svg'> <path d='M1 2.33333L3.4 5C4.80589 3.4379 5.59411 2.5621 7 1' stroke='%2356657A' stroke-linecap='round' stroke-linejoin='round'/></svg>");

--- a/tegel/src/components/checkbox/checkbox.scss
+++ b/tegel/src/components/checkbox/checkbox.scss
@@ -35,7 +35,6 @@
       content: '';
       position: absolute;
       box-sizing: border-box;
-      border-radius: 2px;
     }
 
     &::before {
@@ -43,6 +42,7 @@
       height: 24px;
       left: 0;
       top: 0;
+      border-radius: 4px;
     }
 
     &::after {
@@ -52,6 +52,7 @@
       height: 16px;
       left: 4px;
       top: 4px;
+      border-radius: 2px;
     }
 
     &:hover {

--- a/tegel/src/components/checkbox/checkbox.scss
+++ b/tegel/src/components/checkbox/checkbox.scss
@@ -57,14 +57,14 @@
     &:hover {
       &::before {
         background-color: var(--sdds-checkbox-background-hover);
-        opacity: 0.12;
+        opacity: var(--sdds-checkbox-background-opacity-hover);
       }
     }
 
     &:focus {
       &::before {
         background-color: var(--sdds-checkbox-background-focus);
-        opacity: 0.24;
+        opacity: var(--sdds-checkbox-background-opacity-focus);
         transition: opacity 0.2s ease-in-out;
       }
     }

--- a/tegel/src/components/checkbox/sdds-checkbox.scss
+++ b/tegel/src/components/checkbox/sdds-checkbox.scss
@@ -34,7 +34,6 @@
       content: '';
       position: absolute;
       box-sizing: border-box;
-      border-radius: 2px;
     }
 
     &::before {
@@ -42,6 +41,7 @@
       height: 24px;
       left: 0;
       top: 0;
+      border-radius: 4px;
     }
 
     &::after {
@@ -51,6 +51,7 @@
       height: 16px;
       left: 4px;
       top: 4px;
+      border-radius: 2px;
     }
 
     &:hover {

--- a/tegel/src/components/checkbox/sdds-checkbox.scss
+++ b/tegel/src/components/checkbox/sdds-checkbox.scss
@@ -56,14 +56,14 @@
     &:hover {
       &::before {
         background-color: var(--sdds-checkbox-background-hover);
-        opacity: 0.12;
+        opacity: var(--sdds-checkbox-background-opacity-hover);
       }
     }
 
     &:focus {
       &::before {
         background-color: var(--sdds-checkbox-background-focus);
-        opacity: 0.24;
+        opacity: var(--sdds-checkbox-background-opacity-focus);
         transition: opacity 0.2s ease-in-out;
       }
     }
@@ -99,7 +99,7 @@
       &:hover {
         &::before {
           background-color: var(--sdds-checkbox-background-hover);
-          opacity: 0.12;
+          opacity: var(--sdds-checkbox-background-opacity-hover);
         }
       }
 


### PR DESCRIPTION
**Describe pull-request**  
Corrected color and opacity for focused and hover states for checkbox ::before pseudo element in dark mode. Introduced variables for opacity to cater to the different opacity values in light vs dark mode. Also corrected the border-radius of the ::before element.

**Solving issue**  
Fixes: [DTS-1251](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-1251)

**How to test**  
1. Go to Storybook link below
2. Check in Checkbox -> Native and Web Component
3. Put component in focused and hover states respectively
4. Compare styling to Figma

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

[DTS-1251]: https://tegel.atlassian.net/browse/DTS-1251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ