### PR TITLE
fix(side menu): selected state background color for header side menu

### DIFF
--- a/tegel/src/components/header/header-all.stories.tsx
+++ b/tegel/src/components/header/header-all.stories.tsx
@@ -63,7 +63,7 @@ const AllMenusTemplate = ({ siteName }) =>
                   </a>
               </li>
 
-              <li class='sdds-nav__item sdds-nav__item--active'>
+              <li class='sdds-nav__item sdds-nav__item--selected'>
                   <a class='sdds-nav__item-core ' href='#'>
                       <span class='sdds-nav__item-core-text'>Item 2</span>
                   </a>
@@ -79,7 +79,7 @@ const AllMenusTemplate = ({ siteName }) =>
               <ul class='sdds-nav__dropdown-menu'>
                   <li class='sdds-nav__dropdown-item'><a class='sdds-nav__dropdown-item-core' href='#'>Sub item 3 long label...</a></li>
                   <li class='sdds-nav__dropdown-item'><button class='sdds-nav__dropdown-item-core'>Sub item 3</button></li>
-                  <li class='sdds-nav__dropdown-item sdds-nav__dropdown-item--active'><a class='sdds-nav__dropdown-item-core' href='#'>Sub item 3 long label...</a></li>
+                  <li class='sdds-nav__dropdown-item sdds-nav__dropdown-item--selected'><a class='sdds-nav__dropdown-item-core' href='#'>Sub item 3 long label...</a></li>
               </ul>
               </li>
           </ul>

--- a/tegel/src/components/header/header-vars.scss
+++ b/tegel/src/components/header/header-vars.scss
@@ -96,6 +96,7 @@
   --sdds-header-mobile-searchbar-container-color: var(--sdds-grey-958);
   --sdds-header-mobile-avatar--item-btn-background: var(--sdds-white);
   --sdds-header-mobile-avatar--item-btn-background-hover: var(--sdds-grey-100);
+  --sdds-header-mobile-avatar--item-btn-background-active: var(--sdds-grey-100);
   --sdds-header-mobile-avatar--item-btn-color: var(--sdds-grey-958);
 }
 
@@ -189,5 +190,6 @@
   --sdds-header-mobile-searchbar-container-color: var(--sdds-white);
   --sdds-header-mobile-avatar--item-btn-background: var(--sdds-grey-958);
   --sdds-header-mobile-avatar--item-btn-background-hover: var(--sdds-grey-868);
+  --sdds-header-mobile-avatar--item-btn-background-active: var(--sdds-grey-868);
   --sdds-header-mobile-avatar--item-btn-color: var(--sdds-white);
 }

--- a/tegel/src/components/header/header-vars.scss
+++ b/tegel/src/components/header/header-vars.scss
@@ -97,6 +97,7 @@
   --sdds-header-mobile-avatar--item-btn-background: var(--sdds-white);
   --sdds-header-mobile-avatar--item-btn-background-hover: var(--sdds-grey-100);
   --sdds-header-mobile-avatar--item-btn-background-selected: var(--sdds-grey-100);
+  --sdds-header-mobile-avatar--item-btn-background-active: var(--sdds-grey-300);
   --sdds-header-mobile-avatar--item-btn-color: var(--sdds-grey-958);
 }
 
@@ -191,5 +192,6 @@
   --sdds-header-mobile-avatar--item-btn-background: var(--sdds-grey-958);
   --sdds-header-mobile-avatar--item-btn-background-hover: var(--sdds-grey-868);
   --sdds-header-mobile-avatar--item-btn-background-selected: var(--sdds-grey-868);
+  --sdds-header-mobile-avatar--item-btn-background-active: var(--sdds-grey-800);
   --sdds-header-mobile-avatar--item-btn-color: var(--sdds-white);
 }

--- a/tegel/src/components/header/header-vars.scss
+++ b/tegel/src/components/header/header-vars.scss
@@ -96,7 +96,7 @@
   --sdds-header-mobile-searchbar-container-color: var(--sdds-grey-958);
   --sdds-header-mobile-avatar--item-btn-background: var(--sdds-white);
   --sdds-header-mobile-avatar--item-btn-background-hover: var(--sdds-grey-100);
-  --sdds-header-mobile-avatar--item-btn-background-active: var(--sdds-grey-100);
+  --sdds-header-mobile-avatar--item-btn-background-selected: var(--sdds-grey-100);
   --sdds-header-mobile-avatar--item-btn-color: var(--sdds-grey-958);
 }
 
@@ -190,6 +190,6 @@
   --sdds-header-mobile-searchbar-container-color: var(--sdds-white);
   --sdds-header-mobile-avatar--item-btn-background: var(--sdds-grey-958);
   --sdds-header-mobile-avatar--item-btn-background-hover: var(--sdds-grey-868);
-  --sdds-header-mobile-avatar--item-btn-background-active: var(--sdds-grey-868);
+  --sdds-header-mobile-avatar--item-btn-background-selected: var(--sdds-grey-868);
   --sdds-header-mobile-avatar--item-btn-color: var(--sdds-white);
 }

--- a/tegel/src/components/header/header.scss
+++ b/tegel/src/components/header/header.scss
@@ -1034,7 +1034,7 @@ html,
 
       .sdds-nav__item--active {
         .sdds-nav__item-core {
-          background-color: var(--sdds-header-mobile-avatar--item-btn-background-active);
+          background-color: var(--sdds-header-mobile-avatar--item-btn-background-selected);
         }
       }
 

--- a/tegel/src/components/header/header.scss
+++ b/tegel/src/components/header/header.scss
@@ -181,7 +181,7 @@ html,
     }
   }
 
-  .sdds-nav__item--active::after {
+  .sdds-nav__item--selected::after {
     content: '';
     border-bottom: 4px solid var(--sdds-nav-item-border-color-after);
     width: calc(100% + 2px);
@@ -259,7 +259,7 @@ html,
     }
   }
 
-  .sdds-nav__item--active {
+  .sdds-nav__item--selected {
     .sdds-nav__item-core {
       background-color: var(--sdds-header-nav-item-background-active);
     }
@@ -327,7 +327,7 @@ html,
     }
   }
 
-  .sdds-nav__dropdown-item--active {
+  .sdds-nav__dropdown-item--selected {
     border-left: 4px solid var(--sdds-nav-item-border-color-active);
     background: var(--sdds-nav-item-background-active);
 
@@ -1032,33 +1032,56 @@ html,
         border-top: 1px solid var(--sdds-header-mobile-nav-toolbar-border-color);
       }
 
-      .sdds-nav__item--active {
+      .sdds-nav__item--selected {
         .sdds-nav__item-core {
           background-color: var(--sdds-header-mobile-avatar--item-btn-background-selected);
         }
       }
 
-      .sdds-nav__item--active::after {
-        content: '';
+      .sdds-nav__avatar-item--selected {
+        .sdds-nav__avatar-item-core {
+          background-color: var(--sdds-header-mobile-avatar--item-btn-background-selected);
+        }
+      }
+
+      // .sdds-nav__item--selected::after,
+      // .sdds-nav__avatar-btn--selected::after {
+      //   content: '';
+      //   border-bottom: none;
+      //   border-right: 4px solid var(--sdds-header-mobile-nav-center-item-border-color-active-after);
+      //   width: 0;
+      //   height: 100%;
+      //   display: block;
+      //   margin-left: 0;
+      //   top: 0;
+      //   left: 0;
+      //   position: absolute;
+      // }
+
+      .sdds-nav__item--selected,
+      .sdds-nav__avatar-btn--selected,
+      .sdds-nav__avatar-item--selected {
         border-bottom: none;
-        border-right: 4px solid var(--sdds-header-mobile-nav-center-item-border-color-active-after);
-        width: 0;
-        height: 100%;
-        display: block;
-        margin-left: 0;
-        top: 0;
-        left: 0;
-        position: absolute;
+        border-left: 4px solid var(--sdds-header-mobile-nav-center-item-border-color-active-after);
       }
 
       .sdds-nav__item-core,
-      .sdds-nav__avatar-btn {
+      .sdds-nav__avatar-btn,
+      .sdds-nav__avatar-item-core {
         background-color: var(--sdds-header-mobile-avatar--item-btn-background);
         color: var(--sdds-header-mobile-avatar--iten-btn-border-color);
 
         &:hover {
           background-color: var(--sdds-header-mobile-avatar--item-btn-background-hover);
         }
+
+        &:active {
+          background-color: var(--sdds-header-mobile-avatar--item-btn-background-active);
+        }
+      }
+
+      .sdds-nav__avatar-btn--selected {
+        background-color: var(--sdds-header-mobile-avatar--item-btn-background-selected);
       }
 
       .sdds-nav__dropdown {

--- a/tegel/src/components/header/header.scss
+++ b/tegel/src/components/header/header.scss
@@ -1044,20 +1044,6 @@ html,
         }
       }
 
-      // .sdds-nav__item--selected::after,
-      // .sdds-nav__avatar-btn--selected::after {
-      //   content: '';
-      //   border-bottom: none;
-      //   border-right: 4px solid var(--sdds-header-mobile-nav-center-item-border-color-active-after);
-      //   width: 0;
-      //   height: 100%;
-      //   display: block;
-      //   margin-left: 0;
-      //   top: 0;
-      //   left: 0;
-      //   position: absolute;
-      // }
-
       .sdds-nav__item--selected,
       .sdds-nav__avatar-btn--selected,
       .sdds-nav__avatar-item--selected {

--- a/tegel/src/components/header/header.scss
+++ b/tegel/src/components/header/header.scss
@@ -1032,6 +1032,12 @@ html,
         border-top: 1px solid var(--sdds-header-mobile-nav-toolbar-border-color);
       }
 
+      .sdds-nav__item--active {
+        .sdds-nav__item-core {
+          background-color: var(--sdds-header-mobile-avatar--item-btn-background-active);
+        }
+      }
+
       .sdds-nav__item--active::after {
         content: '';
         border-bottom: none;

--- a/tegel/src/components/side-menu/side-menu-vars.scss
+++ b/tegel/src/components/side-menu/side-menu-vars.scss
@@ -14,8 +14,8 @@
   --sdds-sidebar-side-menu-bottom-menu-border-top: var(--sdds-grey-300);
   --sdds-sidebar-side-menu-single-item-border-bottom: var(--sdds-grey-300);
   --sdds-sidebar-side-menu-single-item-color: var(--sdds-grey-958);
-  --sdds-sidebar-side-menu-single-item-background-active: var(--sdds-grey-50);
-  --sdds-sidebar-side-menu-single-item-border-left-active: var(--sdds-blue-400);
+  --sdds-sidebar-side-menu-single-item-background-selected: var(--sdds-grey-100);
+  --sdds-sidebar-side-menu-single-item-border-left-selected: var(--sdds-blue-400);
   --sdds-sidebar-side-menu-single-subitem-color: var(--sdds-grey-800);
   --sdds-sidebar-side-menu-single-subitem-title-color: var(--sdds-grey-958);
   --sdds-sidebar-side-menu-single-subitem-color-active: var(--sdds-grey-958);
@@ -39,8 +39,8 @@
   --sdds-sidebar-side-menu-bottom-menu-border-top: var(--sdds-grey-868);
   --sdds-sidebar-side-menu-single-item-border-bottom: var(--sdds-grey-868);
   --sdds-sidebar-side-menu-single-item-color: var(--sdds-grey-50);
-  --sdds-sidebar-side-menu-single-item-background-active: var(--sdds-grey-50);
-  --sdds-sidebar-side-menu-single-item-border-left-active: var(--sdds-blue-400);
+  --sdds-sidebar-side-menu-single-item-background-selected: var(--sdds-grey-868);
+  --sdds-sidebar-side-menu-single-item-border-left-selected: var(--sdds-blue-400);
   --sdds-sidebar-side-menu-single-subitem-color: var(--sdds-grey-100);
   --sdds-sidebar-side-menu-single-subitem-title-color: var(--sdds-grey-50);
   --sdds-sidebar-side-menu-single-subitem-color-active: var(--sdds-grey-958);

--- a/tegel/src/components/side-menu/side-menu.scss
+++ b/tegel/src/components/side-menu/side-menu.scss
@@ -254,9 +254,9 @@
       }
     }
 
-    .sdds-item--active {
+    .sdds-sidebar-nav__item--selected {
       .sdds-sidebar-nav__item-link {
-        background-color: var(--sdds-sidebar-side-menu-single-item-background-active);
+        background-color: var(--sdds-sidebar-side-menu-single-item-background-selected);
         position: relative;
 
         &::before {
@@ -266,7 +266,7 @@
           top: 0;
           bottom: 0;
           width: 4px;
-          background-color: var(--sdds-sidebar-side-menu-single-item-border-left-active);
+          background-color: var(--sdds-sidebar-side-menu-single-item-border-left-selected);
         }
       }
     }
@@ -322,7 +322,7 @@
         }
       }
 
-      .sdds-item--active {
+      .sdds-sidebar-nav__item--selected {
         .sdds-sidebar-nav__item-link {
           //@include type-style('headline-07');
           font: var(--sdds-headline-07);

--- a/tegel/src/components/side-menu/side-menu.stories.tsx
+++ b/tegel/src/components/side-menu/side-menu.stories.tsx
@@ -111,7 +111,7 @@ const Template = ({ showIcons, collapsed }) => {
           </li>
         </ul>
       </li>
-      <li class="sdds-sidebar-nav__item sdds-sidebar-nav__extended">
+      <li class="sdds-sidebar-nav__item--selected sdds-sidebar-nav__extended">
       <button class="sdds-sidebar-nav__item-link">
       <div>
         <sdds-icon class="sdds-sidebar-nav__icon" name="truck" size="20px"></sdds-icon>

--- a/tegel/src/components/side-menu/side-menu.stories.tsx
+++ b/tegel/src/components/side-menu/side-menu.stories.tsx
@@ -111,7 +111,7 @@ const Template = ({ showIcons, collapsed }) => {
           </li>
         </ul>
       </li>
-      <li class="sdds-sidebar-nav__item--selected sdds-sidebar-nav__extended">
+      <li class="sdds-sidebar-nav__item sdds-sidebar-nav__item--selected sdds-sidebar-nav__extended">
       <button class="sdds-sidebar-nav__item-link">
       <div>
         <sdds-icon class="sdds-sidebar-nav__icon" name="truck" size="20px"></sdds-icon>


### PR DESCRIPTION
**Describe pull-request**  
Implemented a selected state background color for selected menu items in the headers side menu. Previously there was only a hover state background color in mobile view, where the side menu is visible. 

**Solving issue**  
Fixes: [DTS-1393](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-1393)

**How to test**  
1. Go to Storybook link below
2. Check in Header -> All Menus
3. Resize the window so the menu items are moved into the side menu
4. Open the side menu and inspect the selected menu item
5. Check in both light and dark mode and compare with Figma

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

[DTS-1393]: https://tegel.atlassian.net/browse/DTS-1393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ