### PR TITLE
fix(sider-menu): correct color on header in side menu dark mode

### DIFF
--- a/tegel/src/components/header/header-vars.scss
+++ b/tegel/src/components/header/header-vars.scss
@@ -103,11 +103,11 @@
   --sdds-header-background: var(--sdds-blue-900);
   --sdds-header-mob-menu-open-color: var(--sdds-white);
   --sdds-header-mob-menu-open-background: var(--sdds-grey-958);
-  --sdds-header-mob-menu-open-border: var(--sdds-blue-700);
+  --sdds-header-mob-menu-open-border: var(--sdds-grey-868);
   --sdds-nav-item-background: var(--sdds-grey-800);
   --sdds-nav-item-background-hover: var(--sdds-grey-700);
   --sdds-nav-item-background-active: var(--sdds-grey-700);
-  --sdds-nav-item-border-color: var(--sdds-blue-700);
+  --sdds-nav-item-border-color: var(--sdds-grey-868);
   --sdds-nav-item-border-color-active: var(--sdds-blue-300);
   --sdds-nav-item-core-background-hover: var(--sdds-grey-700);
   --sdds-nav-item-core-color-active: var(--sdds-grey-50);

--- a/tegel/src/components/header/header-vars.scss
+++ b/tegel/src/components/header/header-vars.scss
@@ -102,7 +102,7 @@
 .sdds-mode-dark {
   --sdds-header-background: var(--sdds-blue-900);
   --sdds-header-mob-menu-open-color: var(--sdds-white);
-  --sdds-header-mob-menu-open-background: var(--sdds-blue-800);
+  --sdds-header-mob-menu-open-background: var(--sdds-grey-958);
   --sdds-header-mob-menu-open-border: var(--sdds-blue-700);
   --sdds-nav-item-background: var(--sdds-grey-800);
   --sdds-nav-item-background-hover: var(--sdds-grey-700);

--- a/tegel/src/components/header/header-vars.scss
+++ b/tegel/src/components/header/header-vars.scss
@@ -107,7 +107,7 @@
   --sdds-nav-item-background: var(--sdds-grey-800);
   --sdds-nav-item-background-hover: var(--sdds-grey-700);
   --sdds-nav-item-background-active: var(--sdds-grey-700);
-  --sdds-nav-item-border-color: var(--sdds-grey-868);
+  --sdds-nav-item-border-color: var(--sdds-blue-700);
   --sdds-nav-item-border-color-active: var(--sdds-blue-300);
   --sdds-nav-item-core-background-hover: var(--sdds-grey-700);
   --sdds-nav-item-core-color-active: var(--sdds-grey-50);

--- a/tegel/src/components/header/header.scss
+++ b/tegel/src/components/header/header.scss
@@ -206,6 +206,7 @@ html,
     .sdds-nav__mob-menu-btn {
       color: var(--sdds-header-mob-menu-open-color);
       background-color: var(--sdds-header-mob-menu-open-background);
+      border-right: none;
       position: absolute;
       height: 64px;
       width: 64px;
@@ -215,7 +216,6 @@ html,
       @media all and (max-width: $grid-sm) {
         left: auto;
         right: 0;
-        border-right: none;
         z-index: 1;
       }
 


### PR DESCRIPTION
**Describe pull-request**  
Correct color for close icons header part. 

**Solving issue**  
Fixes: [#](https://tegel.atlassian.net/browse/DTS-1394)

**How to test**  
1.Go to Storybook link below
2. Check in Header -> Inline Menu, switch to dark mode
Resize the window so the menu items are moved into the side menu
Open the menu and see that the color is the same as Figma.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

**Screenshots** 
Should look like this below.
![Skärmavbild 2023-03-22 kl  16 16 38](https://user-images.githubusercontent.com/201671/226951641-b490e038-435c-4042-b85b-d1eea863c999.png)
