### PR TITLE
fix(modal): added null check to avoid empty selector

### DIFF
--- a/components/src/components/modal/modal.tsx
+++ b/components/src/components/modal/modal.tsx
@@ -44,22 +44,22 @@ export class Modal {
 
   componentDidLoad() {
     let targets;
-    if (!this.selector) {
+    if (this.selector) {
       targets = document.querySelectorAll(this.selector);
+
+      // If the modal doesn't have a selector to be triggered
+      if (!targets) {
+        console.warn('No prop for modal targeted, please add selector attribute');
+        return;
+      }
+      // Find all buttons with selector (id/class) and add onclick event on it
+      targets.forEach((el) => {
+        el.addEventListener('click', () => {
+          this.show = true;
+        });
+      });
     }
     this.dismissModal();
-
-    // If the modal doesn't have a selector to be triggered
-    if (!targets) {
-      console.warn('No prop for modal targeted, please add selector attribute');
-      return;
-    }
-    // Find all buttons with selector (id/class) and add onclick event on it
-    targets.forEach((el) => {
-      el.addEventListener('click', () => {
-        this.show = true;
-      });
-    });
   }
 
   dismissModal() {

--- a/components/src/components/modal/modal.tsx
+++ b/components/src/components/modal/modal.tsx
@@ -19,7 +19,7 @@ import {
 })
 export class Modal {
   /** Target selector that triggers opening of modal, for example button with id="btn1", then selector is "#btn1" */
-  @Prop() selector: string = '';
+  @Prop() selector: string;
 
   /** Disables closing modal on clicking on overlay area. */
   @Prop() prevent: boolean = false;
@@ -43,7 +43,10 @@ export class Modal {
   }
 
   componentDidLoad() {
-    const targets = document.querySelectorAll(this.selector);
+    let targets;
+    if (!this.selector) {
+      targets = document.querySelectorAll(this.selector);
+    }
     this.dismissModal();
 
     // If the modal doesn't have a selector to be triggered

--- a/components/src/components/modal/modal.tsx
+++ b/components/src/components/modal/modal.tsx
@@ -43,9 +43,8 @@ export class Modal {
   }
 
   componentDidLoad() {
-    let targets;
     if (this.selector) {
-      targets = document.querySelectorAll(this.selector);
+      const targets = document.querySelectorAll(this.selector);
 
       // If the modal doesn't have a selector to be triggered
       if (!targets) {


### PR DESCRIPTION
**Describe pull-request**  
If the user used the modal methods to contol the open/closed state of the modal it would render an error in the console where we did a querySelectAll() - with an empty argument. This PR adds a simple null check to avoid this.

**Solving issue**  
Fixes: #975

**How to test**  
1. Check out branch.
2. Check in Components -> Modal
3. Remove the selector from one of the modal and open it with it's class method.
4. Check that there are no errors in the console.