### PR TITLE
feat(dropdown-filter): open direction prop

### DIFF
--- a/components/src/components.d.ts
+++ b/components/src/components.d.ts
@@ -210,6 +210,10 @@ export namespace Components {
          */
         "labelPosition": 'no-label' | 'inside' | 'outside';
         /**
+          * Direction that the dropdown will open. By default set to auto.
+         */
+        "openDirection": 'up' | 'down' | 'auto';
+        /**
           * Placeholder text for dropdown with no selected item
          */
         "placeholder": string;
@@ -1066,6 +1070,10 @@ declare namespace LocalJSX {
           * Position of label: `no-label` (default), `inside`, `outside`
          */
         "labelPosition"?: 'no-label' | 'inside' | 'outside';
+        /**
+          * Direction that the dropdown will open. By default set to auto.
+         */
+        "openDirection"?: 'up' | 'down' | 'auto';
         /**
           * Placeholder text for dropdown with no selected item
          */

--- a/components/src/components/dropdown/dropdown-filter.tsx
+++ b/components/src/components/dropdown/dropdown-filter.tsx
@@ -1,13 +1,4 @@
-import {
-  Component,
-  h,
-  Host,
-  Listen,
-  Method,
-  Prop,
-  State,
-  Watch,
-} from '@stencil/core';
+import { Component, h, Host, Listen, Method, Prop, State, Watch } from '@stencil/core';
 
 @Component({
   tag: 'sdds-dropdown-filter',
@@ -45,6 +36,9 @@ export class DropdownFilter {
 
   /** Set to true to make the width following the label text length */
   @Prop() inline: boolean = false;
+
+  /** Direction that the dropdown will open. By default set to auto. */
+  @Prop() openDirection: 'up' | 'down' | 'auto' = 'auto';
 
   /** Position of label: `no-label` (default), `inside`, `outside` */
   @Prop() labelPosition: 'no-label' | 'inside' | 'outside' = 'no-label';
@@ -127,11 +121,7 @@ export class DropdownFilter {
       return newList;
     }
     return (
-      <sdds-dropdown-option
-        tabindex="-1"
-        value="no-result"
-        class="sdds-option--no-result"
-      >
+      <sdds-dropdown-option tabindex="-1" value="no-result" class="sdds-option--no-result">
         No result
       </sdds-dropdown-option>
     );
@@ -143,10 +133,7 @@ export class DropdownFilter {
 
   render() {
     return (
-      <Host
-        selected-value={this.selectedValue}
-        selected-text={this.selectedLabel}
-      >
+      <Host selected-value={this.selectedValue} selected-text={this.selectedLabel}>
         <sdds-dropdown
           ref={(el) => (this.dropdownRef = el)}
           exportparts="dropdown-filter-disabled"
@@ -161,6 +148,7 @@ export class DropdownFilter {
           selectedOption={this.selectedOption}
           type="filter"
           tabindex={this.disabled ? '-1' : null}
+          openDirection={this.openDirection}
         >
           {this.setOptionsContent()}
         </sdds-dropdown>

--- a/components/src/components/dropdown/dropdown.stories.js
+++ b/components/src/components/dropdown/dropdown.stories.js
@@ -239,6 +239,7 @@ const FilterTemplate = ({
   placeholder,
   defaultOption,
   width,
+  openDirection,
 }) => `
     <div style="width:${width}px">
         <sdds-dropdown-filter
@@ -249,6 +250,7 @@ const FilterTemplate = ({
         helper="${helper}"
         default-option="${defaultOption}"      
         data=${`[{"value":"option-1","label":"Jakarta"},{"value":"option-2","label":"Stockholm"},{"value":"option-3","label":"Barcelona"}]`}
+        open-direction="${openDirection.toLowerCase()}"
         ></sdds-dropdown-filter>
       </div>
   `;

--- a/components/src/components/modal/readme.md
+++ b/components/src/components/modal/readme.md
@@ -5,11 +5,11 @@
 
 ## Properties
 
-| Property   | Attribute  | Description                                                                                                 | Type                           | Default |
-| ---------- | ---------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------ | ------- |
-| `prevent`  | `prevent`  | Disables closing modal on clicking on overlay area.                                                         | `boolean`                      | `false` |
-| `selector` | `selector` | Target selector that triggers opening of modal, for example button with id="btn1", then selector is "#btn1" | `string`                       | `''`    |
-| `size`     | `size`     | Size of modal. Accepted strings are: xs, sm, md, lg.                                                        | `"lg" \| "md" \| "sm" \| "xs"` | `'md'`  |
+| Property   | Attribute  | Description                                                                                                 | Type                           | Default     |
+| ---------- | ---------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------ | ----------- |
+| `prevent`  | `prevent`  | Disables closing modal on clicking on overlay area.                                                         | `boolean`                      | `false`     |
+| `selector` | `selector` | Target selector that triggers opening of modal, for example button with id="btn1", then selector is "#btn1" | `string`                       | `undefined` |
+| `size`     | `size`     | Size of modal. Accepted strings are: xs, sm, md, lg.                                                        | `"lg" \| "md" \| "sm" \| "xs"` | `'md'`      |
 
 
 ## Events


### PR DESCRIPTION
**Describe pull-request**  
Adds a open-direction prop to the dropdown-filter.

**Solving issue**  
Fixes: https://tegel.atlassian.net/browse/DTS-1409

**How to test**  
1. Check out the branch and run storybook.
2. Check in Components -> Dropdown -> Filter
3. Try the open direction controls.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events