### PR TITLE
fix(accordion): dark/light regression color update

### DIFF
--- a/tegel/src/components/accordion/accordion-item/accordion-item.scss
+++ b/tegel/src/components/accordion/accordion-item/accordion-item.scss
@@ -34,7 +34,7 @@
     .sdds-accordion-icon {
       transform-origin: center;
       transition: transform 0.15s ease-in-out;
-      color: var(--sdds-accordion-color);
+      color: var(--sdds-accordion-icon-color);
 
       & > sdds-icon {
         display: block;

--- a/tegel/src/components/accordion/accordion-vars.scss
+++ b/tegel/src/components/accordion/accordion-vars.scss
@@ -10,6 +10,7 @@
   --sdds-accordion-color: var(--sdds-grey-958);
   --sdds-accordion-border-focus: var(--sdds-grey-500);
   --sdds-accordion-color-disabled: var(--sdds-grey-400);
+  --sdds-accordion-icon-color: var(--sdds-black);
 
   .sdds-mode-variant-primary {
     --sdds-accordion-background-hover: var(--sdds-accordion-background-hover-primary);
@@ -28,9 +29,10 @@
   --sdds-accordion-background-hover: var(--sdds-accordion-background-hover-primary);
   --sdds-accordion-background-focus: transparent;
   --sdds-accordion-background-active: var(--sdds-grey-900);
-  --sdds-accordion-color: var(--sdds-white);
+  --sdds-accordion-color: var(--sdds-grey-50);
   --sdds-accordion-border-focus: var(--sdds-grey-500);
   --sdds-accordion-color-disabled: var(--sdds-grey-800);
+  --sdds-accordion-icon-color: var(--sdds-grey-50);
 
   .sdds-mode-variant-primary {
     --sdds-accordion-background-hover: var(--sdds-accordion-background-hover-primary);


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Updating color values after regression on dark/light mode

**Solving issue**  
Fixes: DTS-1234

**How to test**  
Check these statements: 
1. The chevron is currently grey-958 in light mode, should be black.
2. In dark mode text and chevron are white, should be grey 50. 

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events


