### PR TITLE
feat(accordion): cancelable events

### DIFF
--- a/tegel/src/components/accordion/accordion-item/accordion-item.tsx
+++ b/tegel/src/components/accordion/accordion-item/accordion-item.tsx
@@ -24,8 +24,9 @@ export class AccordionItem {
   /** Method for toggeling the expanded state of the accordion item. */
   @Method()
   async toggleAccordionItem() {
+    // This is negated in order to emit the value the accordion item will have after it has expanded/redacted.
     const event = this.sddsToggle.emit({
-      expanded: this.expanded,
+      expanded: !this.expanded,
     });
     if (!event.defaultPrevented) {
       this.expanded = !this.expanded;

--- a/tegel/src/components/accordion/accordion-item/accordion-item.tsx
+++ b/tegel/src/components/accordion/accordion-item/accordion-item.tsx
@@ -21,9 +21,9 @@ export class AccordionItem {
   /** When true 16px on right padding instead of 64px */
   @Prop() paddingReset: boolean = false;
 
-  /**  */
+  /** Method for toggeling the expanded state of the accordion item. */
   @Method()
-  toggleAccordionItem() {
+  async toggleAccordionItem() {
     const event = this.sddsToggle.emit({
       expanded: this.expanded,
     });

--- a/tegel/src/components/accordion/accordion-item/accordion-item.tsx
+++ b/tegel/src/components/accordion/accordion-item/accordion-item.tsx
@@ -1,4 +1,4 @@
-import { Component, Event, EventEmitter, h, Host, Prop } from '@stencil/core';
+import { Component, Event, EventEmitter, h, Host, Method, Prop } from '@stencil/core';
 
 @Component({
   tag: 'sdds-accordion-item',
@@ -21,19 +21,27 @@ export class AccordionItem {
   /** When true 16px on right padding instead of 64px */
   @Prop() paddingReset: boolean = false;
 
-  /** Fires after the accordion item is closed or opened, emitting the value (as boolean) of the current state of the accordion */
+  /**  */
+  @Method()
+  toggleAccordionItem() {
+    const event = this.sddsToggle.emit({
+      expanded: this.expanded,
+    });
+    if (!event.defaultPrevented) {
+      this.expanded = !this.expanded;
+    }
+  }
+
+  /** Fires when the accordion item is clicked but before the it is closed or opened. */
   @Event({
     eventName: 'sddsToggle',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  sddsToggle: EventEmitter<boolean>;
-
-  openAccordion() {
-    this.expanded = !this.expanded;
-    this.sddsToggle.emit(this.expanded);
-  }
+  sddsToggle: EventEmitter<{
+    expanded: boolean;
+  }>;
 
   render() {
     return (
@@ -48,10 +56,13 @@ export class AccordionItem {
             type="button"
             aria-expanded={this.expanded}
             class={`sdds-accordion-header-icon-${this.expandIconPosition}`}
-            onClick={() => this.openAccordion()}
+            onClick={() => this.toggleAccordionItem()}
             disabled={this.disabled}
           >
-            <div class="sdds-accordion-title">{this.header}</div>
+            <div class="sdds-accordion-title">
+              {this.header}
+              <slot name="accordion-item-header"></slot>
+            </div>
             <div class="sdds-accordion-icon">
               <sdds-icon name="chevron_down" size="16px"></sdds-icon>
             </div>

--- a/tegel/src/components/accordion/accordion-item/readme.md
+++ b/tegel/src/components/accordion/accordion-item/readme.md
@@ -17,9 +17,22 @@
 
 ## Events
 
-| Event        | Description                                                                                                               | Type                   |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
-| `sddsToggle` | Fires after the accordion item is closed or opened, emitting the value (as boolean) of the current state of the accordion | `CustomEvent<boolean>` |
+| Event        | Description                                                                     | Type                                  |
+| ------------ | ------------------------------------------------------------------------------- | ------------------------------------- |
+| `sddsToggle` | Fires when the accordion item is clicked but before the it is closed or opened. | `CustomEvent<{ expanded: boolean; }>` |
+
+
+## Methods
+
+### `toggleAccordionItem() => Promise<void>`
+
+
+
+#### Returns
+
+Type: `Promise<void>`
+
+
 
 
 ## Dependencies

--- a/tegel/src/components/accordion/accordion-item/readme.md
+++ b/tegel/src/components/accordion/accordion-item/readme.md
@@ -26,7 +26,7 @@
 
 ### `toggleAccordionItem() => Promise<void>`
 
-Method for toggeling the expanded state of the accordion item.
+Method for toggling the expanded state of the accordion item.
 
 #### Returns
 

--- a/tegel/src/components/accordion/accordion-item/readme.md
+++ b/tegel/src/components/accordion/accordion-item/readme.md
@@ -26,7 +26,7 @@
 
 ### `toggleAccordionItem() => Promise<void>`
 
-
+Method for toggeling the expanded state of the accordion item.
 
 #### Returns
 

--- a/tegel/src/components/accordion/accordion.stories.tsx
+++ b/tegel/src/components/accordion/accordion.stories.tsx
@@ -97,7 +97,7 @@ const Template = ({ disabled, iconPosition, paddingReset, modeVariant }) => {
     accordionItems = document.querySelectorAll('sdds-accordion-item');
     for (let i = 0; i < accordionItems.length; i++) {
       accordionItems[i].addEventListener('sddsToggle',(event) => {
-        console.log(event)
+        console.log(event.detail.expanded)
       })
     }
   </script>`);

--- a/tegel/src/components/accordion/accordion.stories.tsx
+++ b/tegel/src/components/accordion/accordion.stories.tsx
@@ -81,15 +81,17 @@ const Template = ({ disabled, iconPosition, paddingReset, modeVariant }) => {
     <sdds-accordion ${
       modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''
     }>
-      <sdds-accordion-item disabled ${affixAttr} ${disabledAttr} ${paddingResetAttr}>
+      <sdds-accordion-item header="First item" ${affixAttr} ${disabledAttr} ${paddingResetAttr}>
         This is the panel, which contains associated information with the header. Usually it contains text, set in the same size as the header.
         Lorem ipsum doler sit amet.
       </sdds-accordion-item>
-      <sdds-accordion-item header="Second item" ${affixAttr} ${disabledAttr} ${paddingResetAttr} expanded>
+      <sdds-accordion-item ${affixAttr} ${disabledAttr} ${paddingResetAttr} expanded>
+        <div slot="accordion-item-header">Second item</div>
         This is the panel, which contains associated information with the header. Usually it contains text, set in the same size as the header.
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis laoreet vestibulum fermentum.
       </sdds-accordion-item>
     </sdds-accordion>
+
     <!-- Script tag for demo purposes -->
   <script>    
     accordionItems = document.querySelectorAll('sdds-accordion-item');
@@ -98,9 +100,7 @@ const Template = ({ disabled, iconPosition, paddingReset, modeVariant }) => {
         console.log(event)
       })
     }
-
   </script>`);
 };
 
-export const Default = Template.bind({});
-Default.args = {};
+export const WebComponent = Template.bind({});

--- a/tegel/src/components/accordion/accordion.stories.tsx
+++ b/tegel/src/components/accordion/accordion.stories.tsx
@@ -97,7 +97,7 @@ const Template = ({ disabled, iconPosition, paddingReset, modeVariant }) => {
     accordionItems = document.querySelectorAll('sdds-accordion-item');
     for (let i = 0; i < accordionItems.length; i++) {
       accordionItems[i].addEventListener('sddsToggle',(event) => {
-        console.log(event.detail.expanded)
+        console.log(event)
       })
     }
   </script>`);

--- a/tegel/src/components/accordion/accordion.stories.tsx
+++ b/tegel/src/components/accordion/accordion.stories.tsx
@@ -7,7 +7,8 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
-      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
+      description:
+        'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
@@ -80,7 +81,7 @@ const Template = ({ disabled, iconPosition, paddingReset, modeVariant }) => {
     <sdds-accordion ${
       modeVariant !== 'Inherit from parent' ? `mode-variant="${modeVariant.toLowerCase()}"` : ''
     }>
-      <sdds-accordion-item header="First item" ${affixAttr} ${disabledAttr} ${paddingResetAttr}>
+      <sdds-accordion-item disabled ${affixAttr} ${disabledAttr} ${paddingResetAttr}>
         This is the panel, which contains associated information with the header. Usually it contains text, set in the same size as the header.
         Lorem ipsum doler sit amet.
       </sdds-accordion-item>
@@ -89,15 +90,15 @@ const Template = ({ disabled, iconPosition, paddingReset, modeVariant }) => {
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis laoreet vestibulum fermentum.
       </sdds-accordion-item>
     </sdds-accordion>
-
     <!-- Script tag for demo purposes -->
-  <script>
+  <script>    
     accordionItems = document.querySelectorAll('sdds-accordion-item');
     for (let i = 0; i < accordionItems.length; i++) {
-      accordionItems[i].addEventListener('sddsToggle',() => {
-        console.log(i + 1 + ". item of accordion is toggled")
+      accordionItems[i].addEventListener('sddsToggle',(event) => {
+        console.log(event)
       })
     }
+
   </script>`);
 };
 


### PR DESCRIPTION
**Describe pull-request**  
This PR enables for users to cancel the sddsToggle event that is emitted whenever a accordion-item is toggled. It also adds a public method for the users to trigger the event with. Lastly I added a "accordion-item-header" slot that can be used instead of the 'header' prop currently on the component.


**Solving issue**  
Fixes: [DTS-1083](https://tegel.atlassian.net/browse/DTS-1083)

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Accordion
3. Check the readme for the event and the public method.
4. Check out the branch
5. Try preventing an event
6. See it fail to execute

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events



[DTS-1083]: https://tegel.atlassian.net/browse/DTS-1083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ