### PR TITLE
feat(toast): cancelable event

### DIFF
--- a/tegel/src/components/toast/sdds-toast.stories.tsx
+++ b/tegel/src/components/toast/sdds-toast.stories.tsx
@@ -87,7 +87,7 @@ const Template = ({ type, header, subheader, link }) =>
     </sdds-toast>
         <script>
         document.addEventListener('sddsClose', (event) => {
-            console.log('Toast with id: ', event.detail.toastId, ' was closed.')
+            console.log(event)
         })
     </script>
   `,

--- a/tegel/src/components/toast/sdds-toast.tsx
+++ b/tegel/src/components/toast/sdds-toast.tsx
@@ -34,19 +34,13 @@ export class SddsToast {
   /** Hides the toast. */
   @Method()
   async hideToast() {
-    this.hidden = true;
-    return {
-      toastId: this.toastId,
-    };
+    this.handleClose();
   }
 
   /** Shows the toast. */
   @Method()
   async showToast() {
-    this.hidden = false;
-    return {
-      toastId: this.toastId,
-    };
+    this.handleShow();
   }
 
   /** Sends unique toast identifier component is closed. */
@@ -81,6 +75,15 @@ export class SddsToast {
     });
     if (!sddsCloseEvent.defaultPrevented) {
       this.hidden = true;
+    }
+  };
+
+  handleShow = () => {
+    const sddsCloseEvent = this.sddsClose.emit({
+      toastId: this.toastId,
+    });
+    if (!sddsCloseEvent.defaultPrevented) {
+      this.hidden = false;
     }
   };
 


### PR DESCRIPTION
**Describe pull-request**  
Cleaned up the emitting of close event for toast. Logged the entire event object in storybook.

**Solving issue**  
Fixes: https://tegel.atlassian.net/browse/DTS-1112

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Toast -> Web Component
3. Check the log for the event object when closed.
4. Check out the branch and try to prevent the event.
5. See it fail to execute.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
