### PR TITLE
feat(modal): allow propagation up the DOM tree

### DIFF
--- a/tegel/src/components/modal/modal.tsx
+++ b/tegel/src/components/modal/modal.tsx
@@ -97,7 +97,6 @@ export class Modal {
   initializeReferenceElement = (referenceEl) => {
     if (referenceEl) {
       referenceEl.addEventListener('click', (event) => {
-        event.stopPropagation();
         if (this.isShown) {
           this.handleClose(event);
         } else {


### PR DESCRIPTION
**Describe pull-request**  
Make sure the modal follows the acceptance criteria for cancellable events. Also removed the stopPropagation(), by doing so we allow for events to bubble up the DOM tree. 
**Solving issue**  
Fixes: [DTS-1101](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-1101&text=Modal)

**How to test**  
_Add description how to test if possible_
1. Go to...
2. Check in...
3. Run ...

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

Question, should we have a ```sddsShow/open```event also? Something like this:

`@Event({
  eventName: 'sddsOpen',
  composed: true,
  cancelable: true,
  bubbles: true,
})
sddsOpen: EventEmitter<any>;`

To be called on from ```handleShow```, like this:

`handleShow = () => {
  this.isShown = true;
  this.sddsOpen.emit();
};`

Will create a ticket for it in the backlog. 


[DTS-1101]: https://tegel.atlassian.net/browse/DTS-1101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ