### PR TITLE
feat(utils): appendHiddenInput

### DIFF
--- a/tegel/src/utils/utils.ts
+++ b/tegel/src/utils/utils.ts
@@ -19,3 +19,26 @@ export const formatHtmlPreview = (htmlStr) =>
 export function demoFormat(first: string, middle: string, last: string): string {
   return (first || '') + (middle ? ` ${middle}` : '') + (last ? ` ${last}` : '');
 }
+
+/** reference: https://github.com/ionic-team/ionic-framework/blob/main/core/src/utils/helpers.ts#L346
+ *
+ * Appends a hidden input element to allow the component
+ * work within and get picked up by a <form>.
+ * @param element The element on which the input with be appended.
+ * @param name Name of the input.
+ * @param value The value of the input.
+ * @param disabled Disables the input if true.
+ */
+export const appendHiddenInput = (
+  element: HTMLElement,
+  name: string,
+  value: string | undefined | null,
+  disabled: boolean,
+) => {
+  const input = element.ownerDocument!.createElement('input');
+  input.type = 'hidden';
+  element.appendChild(input);
+  input.disabled = disabled;
+  input.name = name;
+  input.value = value || '';
+};

--- a/tegel/src/utils/utils.ts
+++ b/tegel/src/utils/utils.ts
@@ -28,12 +28,14 @@ export function demoFormat(first: string, middle: string, last: string): string 
  * @param name Name of the input.
  * @param value The value of the input.
  * @param disabled Disables the input if true.
+ * @param attributes Other attributes that should be passed to the input.
  */
 export const appendHiddenInput = (
   element: HTMLElement,
   name: string,
   value: string | undefined | null,
   disabled: boolean,
+  attributes: Array<{ key: string; value: string }>,
 ) => {
   const input = element.ownerDocument!.createElement('input');
   input.type = 'hidden';
@@ -41,4 +43,7 @@ export const appendHiddenInput = (
   input.disabled = disabled;
   input.name = name;
   input.value = value || '';
+  if (attributes) {
+    attributes.forEach((attr) => input.setAttribute(attr.key, attr.value));
+  }
 };

--- a/tegel/src/utils/utils.ts
+++ b/tegel/src/utils/utils.ts
@@ -28,14 +28,14 @@ export function demoFormat(first: string, middle: string, last: string): string 
  * @param name Name of the input.
  * @param value The value of the input.
  * @param disabled Disables the input if true.
- * @param attributes Other attributes that should be passed to the input.
+ * @param additionalAttributes Additional attributes that should be passed to the input.
  */
 export const appendHiddenInput = (
   element: HTMLElement,
   name: string,
   value: string | undefined | null,
   disabled: boolean,
-  attributes: Array<{ key: string; value: string }>,
+  additionalAttributes: Array<{ key: string; value: string }>,
 ) => {
   const input = element.ownerDocument!.createElement('input');
   input.type = 'hidden';
@@ -43,7 +43,7 @@ export const appendHiddenInput = (
   input.disabled = disabled;
   input.name = name;
   input.value = value || '';
-  if (attributes) {
-    attributes.forEach((attr) => input.setAttribute(attr.key, attr.value));
+  if (additionalAttributes) {
+    additionalAttributes.forEach((attr) => input.setAttribute(attr.key, attr.value));
   }
 };


### PR DESCRIPTION
**Describe pull-request**  
Adds a utils method for appending a hidden input for form elements. This can be used by our own input element that needs has a shadowDOM.

**Solving issue** 
Fixes: #


