### PR TITLE
fix(button): button should not fill its parent

### DIFF
--- a/tegel/src/components/button/button.scss
+++ b/tegel/src/components/button/button.scss
@@ -22,7 +22,7 @@ $iconProps: (fill, color);
 
   font: var(--sdds-detail-02);
   letter-spacing: var(--sdds-detail-02-ls);
-  display: flex;
+  display: inline-flex;
   align-items: center;
   border-radius: 4px;
   border: none;

--- a/tegel/src/components/button/button.scss
+++ b/tegel/src/components/button/button.scss
@@ -318,7 +318,7 @@ i.sdds-btn-icon[slot='icon'] {
 }
 
 :host(sdds-button) {
-  display: flex;
+  display: inline-flex;
   align-items: center;
 
   ::slotted([slot='icon']) {
@@ -354,7 +354,7 @@ i.sdds-btn-icon[slot='icon'] {
 }
 
 :host(sdds-button:not([only-icon])) {
-  display: flex;
+  display: inline-flex;
   align-items: center;
 
   .sdds-btn-sm {

--- a/tegel/src/components/toast/readme.md
+++ b/tegel/src/components/toast/readme.md
@@ -26,23 +26,23 @@
 
 ## Methods
 
-### `hideToast() => Promise<{ toastId: string; }>`
+### `hideToast() => Promise<void>`
 
 Hides the toast.
 
 #### Returns
 
-Type: `Promise<{ toastId: string; }>`
+Type: `Promise<void>`
 
 
 
-### `showToast() => Promise<{ toastId: string; }>`
+### `showToast() => Promise<void>`
 
 Shows the toast.
 
 #### Returns
 
-Type: `Promise<{ toastId: string; }>`
+Type: `Promise<void>`
 
 
 


### PR DESCRIPTION
**Describe pull-request**  
The current implementation of the button makes it fill its parent, this fixes that.

**Solving issue**  
Fixes: [DTS-1458](https://tegel.atlassian.net/browse/DTS-1458)

**How to test**  
1. Go to Storybook
2. Check in Button webcomponent, inspect it and make sure it does not take the whole widht.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

[DTS-1458]: https://tegel.atlassian.net/browse/DTS-1458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ