### PR TITLE
fix(slider): set change event to not be cancelable

### DIFF
--- a/tegel/src/components/slider/slider.stories.tsx
+++ b/tegel/src/components/slider/slider.stories.tsx
@@ -248,7 +248,7 @@ const Template = ({
 
     slider.removeEventListener('sddsChange', null)
     slider.addEventListener('sddsChange', (event) => {
-      console.log('Slider changed, value:', event.detail.value);
+      console.log(event);
     });
 
     </script>

--- a/tegel/src/components/slider/slider.tsx
+++ b/tegel/src/components/slider/slider.tsx
@@ -104,7 +104,7 @@ export class Slider {
   @Event({
     eventName: 'sddsChange',
     composed: true,
-    cancelable: true,
+    cancelable: false,
     bubbles: true,
   })
   sddsChange: EventEmitter<{


### PR DESCRIPTION
**Describe pull-request**  
Set cancelable: false for non cancelable events. 

**Solving issue**  
Fixes: [DTS-1106](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-1106)

**How to test**  
1. Go to Storybook link below
2. Check in Slider -> Default
3. Change the value on the slider
4. Check that the logged event has cancelable: false

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

[DTS-1106]: https://tegel.atlassian.net/browse/DTS-1106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ