### PR TITLE
fix(global): bg and color - default to light mode

### DIFF
--- a/tegel/src/components/data-table/data-table-vars.scss
+++ b/tegel/src/components/data-table/data-table-vars.scss
@@ -1,5 +1,4 @@
 :root,
-html,
 .sdds-mode-light {
   /* Table-color */
   --sdds-data-table-color: var(--sdds-grey-958);

--- a/tegel/src/global/global.scss
+++ b/tegel/src/global/global.scss
@@ -86,17 +86,16 @@ body {
   flex: 1;
 }
 
-html,
 .sdds-mode-light {
   color: var(--sdds-grey-958);
   background-color: var(--sdds-white);
 
-  & .sdds-mode-variant-primary {
+  &.sdds-mode-variant-primary {
     color: var(--sdds-grey-958);
     background-color: var(--sdds-white);
   }
 
-  & .sdds-mode-variant-secondary {
+  &.sdds-mode-variant-secondary {
     color: var(--sdds-grey-958);
     background-color: var(--sdds-grey-50);
   }
@@ -106,12 +105,12 @@ html,
   color: var(--sdds-grey-100);
   background-color: var(--sdds-grey-958);
 
-  & .sdds-mode-variant-primary {
+  &.sdds-mode-variant-primary {
     color: var(--sdds-grey-100);
     background-color: var(--sdds-grey-958);
   }
 
-  & .sdds-mode-variant-secondary {
+  &.sdds-mode-variant-secondary {
     color: var(--sdds-grey-100);
     background-color: var(--sdds-grey-900);
   }

--- a/tegel/src/global/global.scss
+++ b/tegel/src/global/global.scss
@@ -86,6 +86,7 @@ body {
   flex: 1;
 }
 
+:root,
 .sdds-mode-light {
   color: var(--sdds-grey-958);
   background-color: var(--sdds-white);

--- a/tegel/src/global/global.scss
+++ b/tegel/src/global/global.scss
@@ -91,12 +91,12 @@ body {
   color: var(--sdds-grey-958);
   background-color: var(--sdds-white);
 
-  &.sdds-mode-variant-primary {
+  & .sdds-mode-variant-primary {
     color: var(--sdds-grey-958);
     background-color: var(--sdds-white);
   }
 
-  &.sdds-mode-variant-secondary {
+  & .sdds-mode-variant-secondary {
     color: var(--sdds-grey-958);
     background-color: var(--sdds-grey-50);
   }
@@ -106,12 +106,12 @@ body {
   color: var(--sdds-grey-100);
   background-color: var(--sdds-grey-958);
 
-  &.sdds-mode-variant-primary {
+  & .sdds-mode-variant-primary {
     color: var(--sdds-grey-100);
     background-color: var(--sdds-grey-958);
   }
 
-  &.sdds-mode-variant-secondary {
+  & .sdds-mode-variant-secondary {
     color: var(--sdds-grey-100);
     background-color: var(--sdds-grey-900);
   }


### PR DESCRIPTION
**Describe pull-request**  
This PR enables light mode by default.

**Solving issue**  
Fixes: https://tegel.atlassian.net/browse/DTS-1477

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Data-table -> WC
3. Check that primary vs secondary is correct.
4. Check the "root" of the HTML.
5. See that it has the correct bg and color based on theme.