### PR TITLE
fix(dropdown): refactor scss rule to display label-outside color

### DIFF
--- a/tegel/src/components/dropdown/dropdown.scss
+++ b/tegel/src/components/dropdown/dropdown.scss
@@ -14,8 +14,10 @@
 
 :host,
 ::slotted(*) {
-  --sdds-dropdown-label-outside: var(--sdds-dropdown-label-outside);
-  --sdds-dropdown-label-outside-text-decoration: none;
+  .sdds-dropdown-label-outside {
+    color: var(--sdds-dropdown-label-outside);
+    text-decoration: none;
+  } 
 
   font: var(--sdds-detail-02);
   letter-spacing: var(--sdds-detail-02-ls);


### PR DESCRIPTION
**Describe pull-request**  
Refactored SCSS rule to properly implement and display the color variable for when the "Label position" is set to "Outside".

**Solving issue**  
Fixes: [DTS-1474](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-1474)

**How to test**  
1. Go to Storybook link below
2. Check in Dropdown -> Web Component Default, Web Component Multiselect
3. Check in Dropdown Filter -> Default
4. Set "Label position" to "Outside"
5. Check that the label is visible in both light and dark mode.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

[DTS-1474]: https://tegel.atlassian.net/browse/DTS-1474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ