### PR TITLE
fix(stepper): propagate prop updates & CSS changes

### DIFF
--- a/tegel/src/components/stepper/readme.md
+++ b/tegel/src/components/stepper/readme.md
@@ -18,9 +18,9 @@
 
 ## Events
 
-| Event                     | Description | Type                                                                             |
-| ------------------------- | ----------- | -------------------------------------------------------------------------------- |
-| `internalSddsPropsChange` |             | `CustomEvent<{ stepperId: string; changed: (keyof Props)[]; } & Partial<Props>>` |
+| Event                     | Description | Type                                                                                                   |
+| ------------------------- | ----------- | ------------------------------------------------------------------------------------------------------ |
+| `internalSddsPropsChange` |             | `CustomEvent<{ stepperId: string; changed: (keyof SddsStepperProps)[]; } & Partial<SddsStepperProps>>` |
 
 
 ----------------------------------------------

--- a/tegel/src/components/stepper/readme.md
+++ b/tegel/src/components/stepper/readme.md
@@ -7,12 +7,20 @@
 
 ## Properties
 
-| Property        | Attribute        | Description                                           | Type                         | Default        |
-| --------------- | ---------------- | ----------------------------------------------------- | ---------------------------- | -------------- |
-| `direction`     | `direction`      | The direction the children are layed out.             | `"horizontal" \| "vertical"` | `'horizontal'` |
-| `hideLabels`    | `hide-labels`    | Hides the label for the child components if true.     | `boolean`                    | `false`        |
-| `labelPosition` | `label-position` | Text position, only available on direction:horizontal | `"aside" \| "below"`         | `'below'`      |
-| `size`          | `size`           | Size of the component and it's children.              | `"lg" \| "sm"`               | `'lg'`         |
+| Property        | Attribute        | Description                                                                                                                                                                                                                                      | Type                         | Default               |
+| --------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------- | --------------------- |
+| `hideLabels`    | `hide-labels`    | Hides the label for the child components if true.                                                                                                                                                                                                | `boolean`                    | `false`               |
+| `labelPosition` | `label-position` | Text position, only available on direction:horizontal                                                                                                                                                                                            | `"aside" \| "below"`         | `'below'`             |
+| `orientation`   | `orientation`    | The orientation the children are layed out.                                                                                                                                                                                                      | `"horizontal" \| "vertical"` | `'horizontal'`        |
+| `size`          | `size`           | Size of the component and it's children.                                                                                                                                                                                                         | `"lg" \| "sm"`               | `'lg'`                |
+| `stepperId`     | `stepper-id`     | ID used for internal stepper functionality and events, must be unique.  **NOTE**: If you're listening for stepper events you need to set this ID yourself to identify the stepper, as the default ID is random and will be different every time. | `string`                     | `crypto.randomUUID()` |
+
+
+## Events
+
+| Event                     | Description | Type                                                                             |
+| ------------------------- | ----------- | -------------------------------------------------------------------------------- |
+| `internalSddsPropsChange` |             | `CustomEvent<{ stepperId: string; changed: (keyof Props)[]; } & Partial<Props>>` |
 
 
 ----------------------------------------------

--- a/tegel/src/components/stepper/sdds-stepper.scss
+++ b/tegel/src/components/stepper/sdds-stepper.scss
@@ -1,10 +1,19 @@
 :host {
   [role='list'] {
+    &:not(.text-position-aside) {
+      display: table;
+      table-layout: fixed;
+      width: 100%;
+      list-style: none;
+    }
+
     display: flex;
     justify-content: space-evenly;
+    min-width: 100%;
 
     &.vertical {
       height: 100%;
+      display: flex;
       flex-direction: column;
       justify-content: unset;
       gap: 52px;

--- a/tegel/src/components/stepper/sdds-stepper.stories.ts
+++ b/tegel/src/components/stepper/sdds-stepper.stories.ts
@@ -32,9 +32,9 @@ export default {
         defaultValue: { summary: 'lg' },
       },
     },
-    direction: {
-      name: 'Direction',
-      description: 'Sets the direction which the stepper is displayed.',
+    orientation: {
+      name: 'Orientation',
+      description: 'Sets the orientation which the stepper is displayed.',
       control: {
         type: 'radio',
       },
@@ -46,12 +46,12 @@ export default {
     labelPosition: {
       name: 'Text position',
       description:
-        'Sets the position of the text, only available when the direction is horizontal.',
+        'Sets the position of the text, only available when the orientation is horizontal.',
       control: {
         type: 'radio',
       },
       options: ['Below', 'Aside'],
-      if: { arg: 'direction', neq: 'Vertical' },
+      if: { arg: 'orientation', neq: 'Vertical' },
       table: {
         defaultValue: { summary: 'below' },
       },
@@ -69,7 +69,7 @@ export default {
   },
   args: {
     size: 'Large',
-    direction: 'Horizontal',
+    orientation: 'Horizontal',
     labelPosition: 'Below',
     hideLabels: false,
   },
@@ -79,46 +79,24 @@ const sizeLookUp = {
   Large: 'lg',
   Small: 'sm',
 };
-const Template = ({ size, direction, labelPosition, hideLabels }) =>
+const Template = ({ size, orientation, labelPosition, hideLabels }) =>
   formatHtmlPreview(
     `<sdds-stepper ${hideLabels ? 'hide-labels' : ''} size="${sizeLookUp[size]}" ${
-      direction === 'Horizontal' ? `label-position="${labelPosition?.toLowerCase()}"` : ''
-    } direction="${direction.toLowerCase()}">
-    <sdds-stepper-item state="success" label-text="Step label">
-      <div slot="index">1</div>
+      orientation === 'Horizontal' ? `label-position="${labelPosition?.toLowerCase()}"` : ''
+    } orientation="${orientation.toLowerCase()}">
+    <sdds-stepper-item state="success" index="1">
+      <div slot="label">Success step</div>
     </sdds-stepper-item>
-    <sdds-stepper-item state="current" label-text="Current step">
-      <div slot="index">2</div>
+    <sdds-stepper-item state="error" index="2">
+      <div slot="label">Error step</div>
     </sdds-stepper-item>
-    <sdds-stepper-item label-text="Step label">
-      <div slot="index">3</div>
+    <sdds-stepper-item state="current" index="3">
+      <div slot="label">Current step</div>
     </sdds-stepper-item>
-    <sdds-stepper-item label-text="Step label">
-      <div slot="index">4</div>
+    <sdds-stepper-item index="4">
+      <div slot="label">Upcoming step</div>
     </sdds-stepper-item>
   </sdds-stepper>
         `,
   );
 export const WebComponent = Template.bind({});
-
-const TemplateWithError = ({ size, hideLabels, labelPosition, direction }) =>
-  formatHtmlPreview(
-    `<sdds-stepper ${hideLabels ? 'hide-labels' : ''} size="${sizeLookUp[size]}" ${
-      direction === 'Horizontal' ? `label-position="${labelPosition?.toLowerCase()}"` : ''
-    } direction="${direction.toLowerCase()}">
-    <sdds-stepper-item state="success" label-text="Step label">
-      <div slot="index">1</div>
-    </sdds-stepper-item>
-    <sdds-stepper-item state="error" label-text="Current step">
-      <div slot="index">2</div>
-    </sdds-stepper-item>
-    <sdds-stepper-item label-text="Step label">
-      <div slot="index">3</div>
-    </sdds-stepper-item>
-    <sdds-stepper-item label-text="Step label">
-      <div slot="index">4</div>
-    </sdds-stepper-item>
-  </sdds-stepper>
-        `,
-  );
-export const WebComponentWithError = TemplateWithError.bind({});

--- a/tegel/src/components/stepper/sdds-stepper.tsx
+++ b/tegel/src/components/stepper/sdds-stepper.tsx
@@ -108,12 +108,12 @@ export class SddsStepper {
   render() {
     return (
       <Host>
-        <ol
+        <div
           role="list"
           class={`${this.orientation} text-position-${this.labelPosition} ${this.size}`}
         >
           <slot></slot>
-        </ol>
+        </div>
       </Host>
     );
   }

--- a/tegel/src/components/stepper/sdds-stepper.tsx
+++ b/tegel/src/components/stepper/sdds-stepper.tsx
@@ -1,7 +1,8 @@
 import { Component, Host, h, Prop, Element, Event } from '@stencil/core';
 import { EventEmitter, HostElement, State, Watch } from '@stencil/core/internal';
-type Props = {
-  direction: 'horizontal' | 'vertical';
+
+type SddsStepperProps = {
+  orientation: 'horizontal' | 'vertical';
   labelPosition: 'aside' | 'below';
   size: 'sm' | 'lg';
   hideLabels: boolean;
@@ -9,8 +10,8 @@ type Props = {
 
 export type InternalSddsStepperPropChange = {
   stepperId: string;
-  changed: Array<keyof Props>;
-} & Partial<Props>;
+  changed: Array<keyof SddsStepperProps>;
+} & Partial<SddsStepperProps>;
 
 @Component({
   tag: 'sdds-stepper',
@@ -73,8 +74,8 @@ export class SddsStepper {
   handleDirectionChange() {
     this.internalSddsPropsChange.emit({
       stepperId: this.stepperId,
-      changed: ['direction'],
-      direction: this.orientation,
+      changed: ['orientation'],
+      orientation: this.orientation,
     });
   }
 

--- a/tegel/src/components/stepper/sdds-stepper.tsx
+++ b/tegel/src/components/stepper/sdds-stepper.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, h, Prop, Element, Event } from '@stencil/core';
-import { EventEmitter, HostElement, State, Watch } from '@stencil/core/internal';
+import { EventEmitter, HostElement, Watch } from '@stencil/core/internal';
 
 type SddsStepperProps = {
   orientation: 'horizontal' | 'vertical';
@@ -19,6 +19,8 @@ export type InternalSddsStepperPropChange = {
   shadow: true,
 })
 export class SddsStepper {
+  @Element() host: HostElement;
+
   /** The orientation the children are layed out. */
   @Prop() orientation: 'horizontal' | 'vertical' = 'horizontal';
 
@@ -37,28 +39,11 @@ export class SddsStepper {
    */
   @Prop() stepperId: string = crypto.randomUUID();
 
-  @State() width: number = 0;
-
-  @Element() host: HostElement;
-
-  private children: Array<HTMLSddsStepperItemElement>;
-
   componentWillLoad() {
     this.host.children[0].classList.add('first');
     this.host.children[this.host.children.length - 1].classList.add('last');
     if (this.orientation === 'vertical') {
       this.labelPosition = 'aside';
-    }
-  }
-
-  componentDidLoad() {
-    if (this.labelPosition === 'below') {
-      this.children = Array.from(this.host.children) as Array<HTMLSddsStepperItemElement>;
-      this.children.forEach((item) => {
-        if (item.offsetWidth > this.width) {
-          this.width = item.offsetWidth;
-        }
-      });
     }
   }
 

--- a/tegel/src/components/stepper/stepper-item/readme.md
+++ b/tegel/src/components/stepper/stepper-item/readme.md
@@ -7,10 +7,10 @@
 
 ## Properties
 
-| Property | Attribute | Description                                                                     | Type                                              | Default      |
-| -------- | --------- | ------------------------------------------------------------------------------- | ------------------------------------------------- | ------------ |
-| `index`  | `index`   | Index of the step. Will be displayed in the step if state is current/upcomming. | `string`                                          | `undefined`  |
-| `state`  | `state`   | State of the stepper-item                                                       | `"current" \| "error" \| "success" \| "upcoming"` | `'upcoming'` |
+| Property | Attribute | Description                                                                    | Type                                              | Default      |
+| -------- | --------- | ------------------------------------------------------------------------------ | ------------------------------------------------- | ------------ |
+| `index`  | `index`   | Index of the step. Will be displayed in the step if state is current/upcoming. | `string`                                          | `undefined`  |
+| `state`  | `state`   | State of the stepper-item                                                      | `"current" \| "error" \| "success" \| "upcoming"` | `'upcoming'` |
 
 
 ## Dependencies

--- a/tegel/src/components/stepper/stepper-item/readme.md
+++ b/tegel/src/components/stepper/stepper-item/readme.md
@@ -7,23 +7,10 @@
 
 ## Properties
 
-| Property    | Attribute    | Description                      | Type                                              | Default      |
-| ----------- | ------------ | -------------------------------- | ------------------------------------------------- | ------------ |
-| `labelText` | `label-text` | Label text for the stepper-item. | `string`                                          | `''`         |
-| `state`     | `state`      | State of the stepper-item        | `"current" \| "error" \| "success" \| "upcoming"` | `'upcoming'` |
-
-
-## Methods
-
-### `setWidth(width: any) => Promise<void>`
-
-Method to set the width if the stepper item based on its siblings widht, used by the parent element.
-
-#### Returns
-
-Type: `Promise<void>`
-
-
+| Property | Attribute | Description                                                                     | Type                                              | Default      |
+| -------- | --------- | ------------------------------------------------------------------------------- | ------------------------------------------------- | ------------ |
+| `index`  | `index`   | Index of the step. Will be displayed in the step if state is current/upcomming. | `string`                                          | `undefined`  |
+| `state`  | `state`   | State of the stepper-item                                                       | `"current" \| "error" \| "success" \| "upcoming"` | `'upcoming'` |
 
 
 ## Dependencies

--- a/tegel/src/components/stepper/stepper-item/sdds-stepper-item.scss
+++ b/tegel/src/components/stepper/stepper-item/sdds-stepper-item.scss
@@ -73,7 +73,7 @@
               top: 16px;
               width: 10px;
               left: auto;
-              right: -18px;
+              right: -10px;
             }
 
             &::before {
@@ -215,8 +215,6 @@
 
 :host(.last) {
   [role='listItem'] {
-    padding-right: 0;
-
     &.sm,
     &.lg {
       &::after {
@@ -238,8 +236,6 @@
 
 :host(.first) {
   [role='listItem'] {
-    padding-left: 0;
-
     &.sm,
     &.lg {
       &::before {

--- a/tegel/src/components/stepper/stepper-item/sdds-stepper-item.scss
+++ b/tegel/src/components/stepper/stepper-item/sdds-stepper-item.scss
@@ -7,6 +7,7 @@
 
 :host {
   position: relative;
+  display: table-cell;
 
   sdds-icon {
     line-height: 1;
@@ -51,7 +52,7 @@
           height: 1px;
           left: calc(50% + 24px);
           right: 0;
-          top: 16px;
+          top: 18px;
         }
 
         &::before {
@@ -60,7 +61,7 @@
           height: 1px;
           right: calc(50% + 24px);
           left: 0;
-          top: 16px;
+          top: 18px;
         }
 
         &.text-aside {
@@ -72,7 +73,7 @@
               top: 16px;
               width: 10px;
               left: auto;
-              right: -10px;
+              right: -18px;
             }
 
             &::before {
@@ -214,6 +215,8 @@
 
 :host(.last) {
   [role='listItem'] {
+    padding-right: 0;
+
     &.sm,
     &.lg {
       &::after {
@@ -235,6 +238,8 @@
 
 :host(.first) {
   [role='listItem'] {
+    padding-left: 0;
+
     &.sm,
     &.lg {
       &::before {

--- a/tegel/src/components/stepper/stepper-item/sdds-stepper-item.scss
+++ b/tegel/src/components/stepper/stepper-item/sdds-stepper-item.scss
@@ -31,7 +31,7 @@
 
       .content-container {
         height: 30px;
-        width: 30px;
+        min-width: 30px;
       }
 
       &.vertical {
@@ -97,7 +97,7 @@
 
       .content-container {
         height: 24px;
-        width: 24px;
+        min-width: 24px;
       }
 
       &.vertical {

--- a/tegel/src/components/stepper/stepper-item/sdds-stepper-item.tsx
+++ b/tegel/src/components/stepper/stepper-item/sdds-stepper-item.tsx
@@ -27,7 +27,7 @@ export class SddsStepper {
 
   private stepperId: string;
 
-  /* Needs to be onload to do this on any udpates. */
+  /* Needs to be onload to do this on any updates. */
   componentWillLoad() {
     this.stepperEl = this.el.closest('sdds-stepper');
     this.orientation = this.stepperEl.orientation;

--- a/tegel/src/components/stepper/stepper-item/sdds-stepper-item.tsx
+++ b/tegel/src/components/stepper/stepper-item/sdds-stepper-item.tsx
@@ -7,7 +7,7 @@ import { InternalSddsStepperPropChange } from '../sdds-stepper';
   shadow: true,
 })
 export class SddsStepper {
-  /** Index of the step. Will be displayed in the step if state is current/upcomming. */
+  /** Index of the step. Will be displayed in the step if state is current/upcoming. */
   @Prop() index: string;
 
   /** State of the stepper-item */

--- a/tegel/src/components/stepper/stepper-item/sdds-stepper-item.tsx
+++ b/tegel/src/components/stepper/stepper-item/sdds-stepper-item.tsx
@@ -1,4 +1,5 @@
-import { Component, Host, h, Prop, Element, State, Method } from '@stencil/core';
+import { Component, Host, h, Prop, Element, State, Listen } from '@stencil/core';
+import { InternalSddsStepperPropChange } from '../sdds-stepper';
 
 @Component({
   tag: 'sdds-stepper-item',
@@ -6,38 +7,49 @@ import { Component, Host, h, Prop, Element, State, Method } from '@stencil/core'
   shadow: true,
 })
 export class SddsStepper {
-  /** Label text for the stepper-item. */
-  @Prop() labelText: string = '';
+  /** Index of the step. Will be displayed in the step if state is current/upcomming. */
+  @Prop() index: string;
 
   /** State of the stepper-item */
   @Prop() state: 'current' | 'error' | 'success' | 'upcoming' = 'upcoming';
 
   @State() hideLabel: boolean;
 
-  @State() size: string;
+  @State() size: 'sm' | 'lg';
 
-  @State() iconSize: string;
+  @State() orientation: 'horizontal' | 'vertical';
 
-  @State() direction: string;
-
-  @State() labelPosition: string;
+  @State() labelPosition: 'aside' | 'below';
 
   @Element() el: HTMLElement;
 
-  stepperEl: HTMLSddsStepperElement;
+  private stepperEl: HTMLSddsStepperElement;
 
+  private stepperId: string;
+
+  /* Needs to be onload to do this on any udpates. */
   componentWillLoad() {
     this.stepperEl = this.el.closest('sdds-stepper');
-    this.direction = this.stepperEl.direction;
+    this.orientation = this.stepperEl.orientation;
     this.labelPosition = this.stepperEl.labelPosition;
     this.size = this.stepperEl.size;
     this.hideLabel = this.stepperEl.hideLabels;
+    this.stepperId = this.stepperEl.stepperId;
   }
 
-  /** Method to set the width if the stepper item based on its siblings widht, used by the parent element. */
-  @Method()
-  async setWidth(width) {
-    this.el.style.width = `${width}px`;
+  @Listen('internalSddsPropsChange', { target: 'body' })
+  handlePropsChange(event: CustomEvent<InternalSddsStepperPropChange>) {
+    if (this.stepperId === event.detail.stepperId) {
+      event.detail.changed.forEach((changedProp) => {
+        if (typeof this[changedProp] === 'undefined') {
+          throw new Error(`Table prop is not supported: ${changedProp}`);
+        }
+        if (this[changedProp] === this.orientation && event.detail[changedProp] === 'vertical') {
+          this.labelPosition = 'aside';
+        }
+        this[changedProp] = event.detail[changedProp];
+      });
+    }
   }
 
   render() {
@@ -45,7 +57,7 @@ export class SddsStepper {
       <Host>
         <div
           role="listItem"
-          class={`${this.size} ${this.direction} text-${this.labelPosition} ${
+          class={`${this.size} ${this.orientation} text-${this.labelPosition} ${
             this.hideLabel ? 'hide-labels' : ''
           }`}
         >
@@ -56,11 +68,13 @@ export class SddsStepper {
                 size={this.size === 'lg' ? '20px' : '16px'}
               ></sdds-icon>
             ) : (
-              <slot name="index"></slot>
+              this.index
             )}
           </div>
           {!this.hideLabel && (
-            <div class={`label ${this.size} ${this.state}`}>{this.labelText}</div>
+            <div class={`label ${this.size} ${this.state}`}>
+              <slot name="label"></slot>
+            </div>
           )}
         </div>
       </Host>


### PR DESCRIPTION
**Describe pull-request**  
This PR does a few things:
 * The sdds-stepper emits a `internalSddsPropsChange` event when one of its props have changes.
 * The stepper children (sdds-stepper-item) listens for a `internalSddsPropsChange` and updates if their parent has had changes.
 * I removed the setting of widths of child components via JS and instead to it with CSS. This should hinder any flickering of the width of the stepper children. 

**Solving issue**  
Fixes: https://tegel.atlassian.net/browse/DTS-1266

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Stepper -> Web Component
3. Check that the styling is correct. 

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events