### PR TITLE
feat(tabs): cancelable events

### DIFF
--- a/tegel/src/components/tabs/folder-tabs/folder-tabs.stories.tsx
+++ b/tegel/src/components/tabs/folder-tabs/folder-tabs.stories.tsx
@@ -103,7 +103,7 @@ const Template = ({ modeVariant, selectedIndex, defaultSelectedIndex }) =>
   
     tabs.addEventListener('sddsChange', (event) => {
       selectedTabIndex.innerHTML = event.detail.selectedTabIndex
-      console.log('Tab change, selected tab index:', event.detail.selectedTabIndex)
+      console.log(event)
     })
     </script>
 `);

--- a/tegel/src/components/tabs/folder-tabs/folder-tabs.tsx
+++ b/tegel/src/components/tabs/folder-tabs/folder-tabs.tsx
@@ -5,7 +5,6 @@ import {
   Element,
   Prop,
   h,
-  Watch,
   Event,
   EventEmitter,
   Method,

--- a/tegel/src/components/tabs/folder-tabs/folder-tabs.tsx
+++ b/tegel/src/components/tabs/folder-tabs/folder-tabs.tsx
@@ -35,15 +35,15 @@ export class InlineTabs {
 
   @State() showRightScroll: boolean = false;
 
-  navWrapperElement: HTMLElement = null; // reference to container with nav buttons
+  private navWrapperElement: HTMLElement = null; // reference to container with nav buttons
 
-  componentWidth: number = 0; // visible width of this component
+  private componentWidth: number = 0; // visible width of this component
 
-  buttonsWidth: number = 0; // total width of all nav items combined
+  private buttonsWidth: number = 0; // total width of all nav items combined
 
-  scrollWidth: number = 0; // total amount that is possible to scroll in the nav wrapper
+  private scrollWidth: number = 0; // total amount that is possible to scroll in the nav wrapper
 
-  children: Array<HTMLSddsFolderTabElement>;
+  private children: Array<HTMLSddsFolderTabElement>;
 
   /** Event emitted when the selected tab is changed. */
   @Event({

--- a/tegel/src/components/tabs/folder-tabs/folder-tabs.tsx
+++ b/tegel/src/components/tabs/folder-tabs/folder-tabs.tsx
@@ -149,20 +149,24 @@ export class InlineTabs {
   };
 
   addEventListenerToTabs = () => {
-    this.children = Array.from(this.host.children) as Array<HTMLSddsFolderTabElement>;
-    this.children = this.children.map((item, index) => {
-      item.addEventListener('click', () => {
-        if (!item.disabled) {
-          this.children.forEach((element) => element.setSelected(false));
-          item.setSelected(true);
-          this.selectedIndex = index;
-          this.sddsChange.emit({
-            selectedTabIndex: this.selectedIndex,
+      this.children = Array.from(this.host.children) as Array<HTMLSddsFolderTabElement>;
+      this.children = this.children.map((item, index) => {
+        item.addEventListener('click', () => {
+          const sddsChangeEvent = this.sddsChange.emit({
+            selectedTabIndex: this.children.indexOf(item)
           });
-        }
+
+          if(!sddsChangeEvent.defaultPrevented) {
+            if (!item.disabled) {
+              this.children.forEach((element) => element.setSelected(false));
+              item.setSelected(true);
+              this.selectedIndex = index;
+            }
+          }
+        });
+        return item;
       });
-      return item;
-    });
+    
   };
 
   connectedCallback() {

--- a/tegel/src/components/tabs/folder-tabs/folder-tabs.tsx
+++ b/tegel/src/components/tabs/folder-tabs/folder-tabs.tsx
@@ -27,7 +27,7 @@ export class InlineTabs {
 
   /** Sets the selected tab.
    * If this is set all tab changes needs to be handled by the user. */
-  @Prop() selectedIndex: number;
+  @Prop({ reflect: true }) selectedIndex: number;
 
   @State() buttonWidth: number = 0;
 
@@ -55,11 +55,6 @@ export class InlineTabs {
   sddsChange: EventEmitter<{
     selectedTabIndex: number;
   }>;
-
-  @Watch('selectedIndex')
-  handleSelectedTabIndexChange() {
-    this.host.setAttribute('selected-index', `${this.selectedIndex}`);
-  }
 
   /** Sets the passed tabindex as the selected tab. */
   @Method()

--- a/tegel/src/components/tabs/inline-tabs/inline-tabs.stories.tsx
+++ b/tegel/src/components/tabs/inline-tabs/inline-tabs.stories.tsx
@@ -97,6 +97,7 @@ const Template = ({ modeVariant, selectedIndex, defaultSelectedIndex }) =>
    
    tabs.addEventListener('sddsChange', (event) => {
      selectedTabIndex.innerHTML = event.detail.selectedTabIndex
+     console.log(event)
     })
    </script>
 `);

--- a/tegel/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/tegel/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -126,13 +126,18 @@ export class InlineTabsFullbleed {
   addEventListenerToTabs = () => {
     this.children = this.children.map((item, index) => {
       item.addEventListener('click', () => {
-        if (!item.disabled) {
-          this.children.forEach((element) => element.setSelected(false));
-          item.setSelected(true);
-          this.selectedIndex = index;
-          this.sddsChange.emit({
-            selectedTabIndex: this.selectedIndex,
-          });
+        const sddsChangeEvent = this.sddsChange.emit({
+          selectedTabIndex: this.children.indexOf(item)
+        });
+        if(!sddsChangeEvent.defaultPrevented) {
+          if (!item.disabled) {
+            this.children.forEach((element) => element.setSelected(false));
+            item.setSelected(true);
+            this.selectedIndex = index;
+            this.sddsChange.emit({
+              selectedTabIndex: this.selectedIndex,
+            });
+          }
         }
       });
       return item;

--- a/tegel/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/tegel/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -25,15 +25,15 @@ export class InlineTabsFullbleed {
 
   @State() buttonWidth: number = 0; // current calculated width of the largest nav button
 
-  navWrapperElement: HTMLElement = null; // reference to container with nav buttons
+  private navWrapperElement: HTMLElement = null; // reference to container with nav buttons
 
-  componentWidth: number = 0; // visible width of this component
+  private componentWidth: number = 0; // visible width of this component
 
-  buttonsWidth: number = 0; // total width of all nav items combined
+  private buttonsWidth: number = 0; // total width of all nav items combined
 
-  scrollWidth: number = 0; // total amount that is possible to scroll in the nav wrapper
+  private scrollWidth: number = 0; // total amount that is possible to scroll in the nav wrapper
 
-  children: Array<HTMLSddsInlineTabElement>;
+  private children: Array<HTMLSddsInlineTabElement>;
 
   @Event({
     eventName: 'sddsChange',

--- a/tegel/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/tegel/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, State, Element, h, Prop, Event, EventEmitter } from '@stencil/core';
-import { HostElement, Method, Watch } from '@stencil/core/internal';
+import { HostElement, Method } from '@stencil/core/internal';
 
 @Component({
   tag: 'sdds-inline-tabs',

--- a/tegel/src/components/tabs/inline-tabs/inline-tabs.tsx
+++ b/tegel/src/components/tabs/inline-tabs/inline-tabs.tsx
@@ -15,7 +15,7 @@ export class InlineTabsFullbleed {
 
   /** Sets the selected tab.
    * If this is set all tab changes needs to be handled by the user. */
-  @Prop() selectedIndex: number;
+  @Prop({ reflect: true }) selectedIndex: number;
 
   @Element() host: HostElement;
 
@@ -44,11 +44,6 @@ export class InlineTabsFullbleed {
   sddsChange: EventEmitter<{
     selectedTabIndex: number;
   }>;
-
-  @Watch('selectedIndex')
-  handleSelectedTabIndexChange() {
-    this.host.setAttribute('selected-index', `${this.selectedIndex}`);
-  }
 
   /** Selects a tab based on tabindex, will not select a disabled tab. */
   @Method()

--- a/tegel/src/components/tabs/navigation-tabs/navigation-tabs.stories.tsx
+++ b/tegel/src/components/tabs/navigation-tabs/navigation-tabs.stories.tsx
@@ -99,6 +99,7 @@ const Template = ({ modeVariant, selectedIndex, defaultSelectedIndex }) =>
     
     tabs.addEventListener('sddsChange', (event) => {
       selectedTabIndex.innerHTML = event.detail.selectedTabIndex
+      console.log(event)
     })
     </script>
     `);

--- a/tegel/src/components/tabs/navigation-tabs/navigation-tabs.tsx
+++ b/tegel/src/components/tabs/navigation-tabs/navigation-tabs.tsx
@@ -25,7 +25,7 @@ export class NavigationTabs {
 
   /** Sets the selected tab.
    * If this is set all tab changes needs to be handled by the user. */
-  @Prop() selectedIndex: number;
+  @Prop({ reflect: true }) selectedIndex: number;
 
   @Element() host: HTMLElement;
 
@@ -59,11 +59,6 @@ export class NavigationTabs {
     return {
       selectedTabIndex: this.selectedIndex,
     };
-  }
-
-  @Watch('selectedIndex')
-  handleSelectedTabIndexChange() {
-    this.host.setAttribute('selected-index', `${this.selectedIndex}`);
   }
 
   /** Event emitted when the selected tab is changed. */

--- a/tegel/src/components/tabs/navigation-tabs/navigation-tabs.tsx
+++ b/tegel/src/components/tabs/navigation-tabs/navigation-tabs.tsx
@@ -141,13 +141,18 @@ export class NavigationTabs {
     this.children = Array.from(this.host.children) as Array<HTMLSddsNavigationTabElement>;
     this.children = this.children.map((item, index) => {
       item.addEventListener('click', () => {
-        if (!item.disabled) {
-          this.children.forEach((element) => element.setSelected(false));
-          item.setSelected(true);
-          this.selectedIndex = index;
-          this.sddsChange.emit({
-            selectedTabIndex: this.selectedIndex,
-          });
+        const sddsChangeEvent = this.sddsChange.emit({
+          selectedTabIndex: this.children.indexOf(item)
+        });
+        if(!sddsChangeEvent.defaultPrevented) {
+          if (!item.disabled) {
+            this.children.forEach((element) => element.setSelected(false));
+            item.setSelected(true);
+            this.selectedIndex = index;
+            this.sddsChange.emit({
+              selectedTabIndex: this.selectedIndex,
+            });
+          }
         }
       });
       return item;
@@ -162,17 +167,13 @@ export class NavigationTabs {
 
   componentDidLoad = () => {
     if (this.selectedIndex === undefined) {
-      console.log(this.selectedIndex);
       this.addEventListenerToTabs();
-
       this.children[this.defaultSelectedIndex].setSelected(true);
       this.selectedIndex = this.defaultSelectedIndex;
       this.sddsChange.emit({
         selectedTabIndex: this.selectedIndex,
       });
     } else {
-      console.log(this.selectedIndex);
-
       this.children[this.selectedIndex].setSelected(true);
       this.sddsChange.emit({
         selectedTabIndex: this.selectedIndex,

--- a/tegel/src/components/tabs/navigation-tabs/navigation-tabs.tsx
+++ b/tegel/src/components/tabs/navigation-tabs/navigation-tabs.tsx
@@ -7,7 +7,6 @@ import {
   Prop,
   Event,
   EventEmitter,
-  Watch,
   Method,
 } from '@stencil/core';
 


### PR DESCRIPTION
**Describe pull-request**  
Enabled events to be cancelable, made internal variables private, removed watcher and logged entire event object in Storybook.

**Solving issue**  
Fixes: [DTS-1109](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-1109)

**How to test**  
1. Go to storybook link below.
2.  Check in Components -> Tabs -> All sub stories.
3. Check the log for the event object when switching tabs.
4. Check out the branch and try to prevent the event.
5. See it fail to execute.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

[DTS-1109]: https://tegel.atlassian.net/browse/DTS-1109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ