### PR TITLE
fix(slider): input field border radius

### DIFF
--- a/tegel/src/components/slider/slider.scss
+++ b/tegel/src/components/slider/slider.scss
@@ -70,6 +70,7 @@ sdds-slider {
       display: flex;
       align-items: center;
       justify-content: center;
+      border-radius: 4px 4px 0 0;
 
       input.sdds-slider__input-field {
         // @include type-style('detail-02');


### PR DESCRIPTION
**Describe pull-request**  
Added correct border-radius to input field wrapper.

**Solving issue**
Fixes: https://tegel.atlassian.net/browse/DTS-1312

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Slider
3. Add the input field.
4. Check the top left and right border-radius on the input field.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
