### PR TITLE
fix(slider): refactor slider label position

### DIFF
--- a/tegel/src/components/slider/slider.scss
+++ b/tegel/src/components/slider/slider.scss
@@ -63,6 +63,10 @@ sdds-slider {
       //@include type-style('detail-02');
       font: var(--sdds-detail-02);
       letter-spacing: var(--sdds-detail-02-ls);
+
+      &.min-value {
+        padding-left: 0px;
+      }
     }
 
     .sdds-slider__input-field-wrapper {
@@ -103,11 +107,11 @@ sdds-slider {
     user-select: none;
     position: absolute;
     color: var(--sdds-slider-label-color);
-    top: -16px;
+    padding-bottom: 16px;
     transform: translateY(-100%);
 
     &.offset {
-      top: -35px;
+      padding-bottom: 34px;
     }
   }
 

--- a/tegel/src/components/slider/slider.tsx
+++ b/tegel/src/components/slider/slider.tsx
@@ -497,13 +497,16 @@ export class Slider {
             this.wrapperElement = el as HTMLElement;
           }}
         >
+
+          <label class={this.showTickNumbers && 'offset'}>{this.label}</label>
+
           {this.useInput && (
             <div class="sdds-slider__input-values">
               <div
                 ref={(el) => {
                   this.minusElement = el as HTMLElement;
                 }}
-                class="sdds-slider__input-value"
+                class="sdds-slider__input-value min-value"
               >
                 {this.min}
               </div>
@@ -522,7 +525,7 @@ export class Slider {
           )}
 
           <div class="sdds-slider-inner">
-            <label class={this.tickValues.length > 0 && 'offset'}>{this.label}</label>
+            
 
             {this.tickValues.length > 0 && (
               <div class="sdds-slider__value-dividers-wrapper">


### PR DESCRIPTION
**Describe pull-request**  
Refactored the label position in the slider component to adhere to the design in Figma.

**Solving issue**  
Fixes: [DTS-1309](https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-1309)

**How to test**  
1. Go to Storybook link below.
2. Check in Components -> Slider -> Default
3. Set "Show label" to true
4. Try out the controls
     - Show ticks
    - Show tick numbers
    - Show controls
    - Show value input field
5. Compare label position to design in Figma

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

[DTS-1309]: https://tegel.atlassian.net/browse/DTS-1309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ