### PR TITLE
fix(slider): snap to ticks & undefined

### DIFF
--- a/components/src/components/slider/slider.tsx
+++ b/components/src/components/slider/slider.tsx
@@ -6,51 +6,45 @@ import { Component, h, Prop, Listen, EventEmitter, Event, Method } from '@stenci
   shadow: false,
 })
 export class Slider {
-  wrapperElement: HTMLElement = null;
+  private wrapperElement: HTMLElement = null;
 
-  scrubberElement: HTMLElement = null;
+  private scrubberElement: HTMLElement = null;
 
-  scrubberInnerElement: HTMLElement = null;
+  private scrubberInnerElement: HTMLElement = null;
 
-  dividersElement: HTMLElement = null;
+  private trackElement: HTMLElement = null;
 
-  trackElement: HTMLElement = null;
+  private trackFillElement: HTMLElement = null;
 
-  trackFillElement: HTMLElement = null;
+  private minusElement: HTMLElement = null;
 
-  minusElement: HTMLElement = null;
+  private plusElement: HTMLElement = null;
 
-  plusElement: HTMLElement = null;
+  private inputElement: HTMLInputElement = null;
 
-  inputElement: HTMLInputElement = null;
+  private scrubberGrabbed: boolean = false;
 
-  nativeRangeInputElement: HTMLInputElement = null;
+  private scrubberLeft: number = 0;
 
-  scrubberGrabPos: object = { x: 0, y: 0 };
+  private tickValues: Array<number> = [];
 
-  scrubberGrabbed: boolean = false;
+  private disabledState: boolean = false;
 
-  scrubberLeft: number = 0;
+  private readonlyState: boolean = false;
 
-  tickValues: Array<number> = [];
+  private useControls: boolean = false;
 
-  disabledState: boolean = false;
+  private useInput: boolean = false;
 
-  readonlyState: boolean = false;
+  private useSmall: boolean = false;
 
-  useControls: boolean = false;
+  private useSnapping: boolean = false;
 
-  useInput: boolean = false;
+  private supposedValueSlot: number = -1;
 
-  useSmall: boolean = false;
+  private resizeObserverLoaded: boolean = false;
 
-  useSnapping: boolean = false;
-
-  supposedValueSlot: number = -1;
-
-  resizeObserverLoaded: boolean = false;
-
-  eventListenersAdded: boolean = false;
+  private eventListenersAdded: boolean = false;
 
   /** Change event for the textfield */
   @Event({
@@ -110,7 +104,8 @@ export class Slider {
   @Prop() snap: boolean = null;
 
   /** Public method to re-initialise the slider if some configuration props are changed */
-  @Method() async reset() {
+  @Method()
+  async reset() {
     // @TODO: Maybe use watch-decorator (and a refactor) in the future
     this.componentWillLoad();
     this.componentDidLoad();
@@ -186,7 +181,9 @@ export class Slider {
       localLeft = event.clientX - trackRect.left;
     } else if (event.type === 'touchmove') {
       localLeft = event.touches[0].clientX - trackRect.left;
-    } else console.warn('Slider component: Unsupported event!');
+    } else {
+      console.warn('Slider component: Unsupported event!');
+    }
 
     this.supposedValueSlot = -1;
 
@@ -302,14 +299,11 @@ export class Slider {
 
       this.scrubberElement.addEventListener('mousedown', (event) => {
         event.preventDefault();
-        this.grabScrubber(event.offsetX, event.offsetY);
+        this.grabScrubber();
       });
 
-      this.scrubberElement.addEventListener('touchstart', (event) => {
-        const rect = this.scrubberElement.getBoundingClientRect();
-        const x = event.targetTouches[0].pageX - rect.left;
-        const y = event.targetTouches[0].pageY - rect.top;
-        this.grabScrubber(x, y);
+      this.scrubberElement.addEventListener('touchstart', () => {
+        this.grabScrubber();
       });
 
       if (this.useControls) {
@@ -350,15 +344,10 @@ export class Slider {
     this.updateTrack();
   }
 
-  grabScrubber(xOffset, yOffset) {
+  grabScrubber() {
     if (this.readonlyState) {
       return;
     }
-
-    this.scrubberGrabPos = {
-      x: xOffset,
-      y: yOffset,
-    };
 
     this.scrubberGrabbed = true;
     this.scrubberInnerElement.classList.add('pressed');
@@ -477,7 +466,6 @@ export class Slider {
     return (
       <div class="sdds-slider-wrapper">
         <input
-          ref={(el) => (this.nativeRangeInputElement = el as HTMLInputElement)}
           class="sdds-slider-native-element"
           type="range"
           value={this.value}
@@ -532,10 +520,7 @@ export class Slider {
 
             {this.tickValues.length > 0 && (
               <div class="sdds-slider__value-dividers-wrapper">
-                <div
-                  ref={(el) => (this.dividersElement = el as HTMLElement)}
-                  class="sdds-slider__value-dividers"
-                >
+                <div class="sdds-slider__value-dividers">
                   {this.tickValues.map((value) => (
                     <div class="sdds-slider__value-divider">
                       {this.showTickNumbers && <span>{value}</span>}

--- a/components/src/components/slider/slider.tsx
+++ b/components/src/components/slider/slider.tsx
@@ -164,31 +164,7 @@ export class Slider {
       return;
     }
 
-    const numTicks = parseInt(this.ticks);
-    const trackRect = this.trackElement.getBoundingClientRect();
-    let localLeft = event.clientX - trackRect.left;
-    this.supposedValueSlot = -1;
-
-    if (this.useSnapping && numTicks > 0) {
-      const trackWidth = this.getTrackWidth();
-      const distanceBetweenTicks = Math.round(trackWidth / (numTicks + 1));
-      localLeft = Math.round(localLeft / distanceBetweenTicks) * distanceBetweenTicks;
-
-      let scrubberPositionPX = 0;
-      if (localLeft >= 0 && localLeft <= trackWidth) {
-        scrubberPositionPX = localLeft;
-      } else if (localLeft > trackWidth) {
-        scrubberPositionPX = trackWidth;
-      } else if (localLeft < 0) {
-        scrubberPositionPX = 0;
-      }
-      this.supposedValueSlot = Math.round(scrubberPositionPX / distanceBetweenTicks);
-    }
-
-    this.scrubberLeft = this.constrainScrubber(localLeft);
-    this.scrubberElement.style.left = `${this.scrubberLeft}px`;
-    this.updateValue();
-    this.updateTrack();
+    this.scrubberCore(event);
   }
 
   @Listen('touchmove', { target: 'window' })
@@ -199,9 +175,18 @@ export class Slider {
       return;
     }
 
+    this.scrubberCore(event);
+  }
+
+  scrubberCore(event) {
     const numTicks = parseInt(this.ticks);
     const trackRect = this.trackElement.getBoundingClientRect();
-    let localLeft = event.touches[0].clientX - trackRect.left;
+    let localLeft = 0;
+    if (event.type === 'mousemove') {
+      localLeft = event.clientX - trackRect.left;
+    } else if (event.type === 'touchmove') {
+      localLeft = event.touches[0].clientX - trackRect.left;
+    } else console.warn('Slider component: Unsupported event!');
 
     this.supposedValueSlot = -1;
 

--- a/components/src/components/slider/slider.tsx
+++ b/components/src/components/slider/slider.tsx
@@ -1,12 +1,4 @@
-import {
-  Component,
-  h,
-  Prop,
-  Listen,
-  EventEmitter,
-  Event,
-  Method,
-} from '@stencil/core';
+import { Component, h, Prop, Listen, EventEmitter, Event, Method } from '@stencil/core';
 
 @Component({
   tag: 'sdds-slider',
@@ -178,15 +170,23 @@ export class Slider {
     this.supposedValueSlot = -1;
 
     if (this.useSnapping && numTicks > 0) {
-      const v = Math.round(this.getTrackWidth() / (numTicks + 1));
-      localLeft = Math.round(localLeft / v) * v;
+      const trackWidth = this.getTrackWidth();
+      const distanceBetweenTicks = Math.round(trackWidth / (numTicks + 1));
+      localLeft = Math.round(localLeft / distanceBetweenTicks) * distanceBetweenTicks;
 
-      this.supposedValueSlot = Math.round(localLeft / v);
+      let scrubberPositionPX = 0;
+      if (localLeft >= 0 && localLeft <= trackWidth) {
+        scrubberPositionPX = localLeft;
+      } else if (localLeft > trackWidth) {
+        scrubberPositionPX = trackWidth;
+      } else if (localLeft < 0) {
+        scrubberPositionPX = 0;
+      }
+      this.supposedValueSlot = Math.round(scrubberPositionPX / distanceBetweenTicks);
     }
 
     this.scrubberLeft = this.constrainScrubber(localLeft);
     this.scrubberElement.style.left = `${this.scrubberLeft}px`;
-
     this.updateValue();
     this.updateTrack();
   }
@@ -206,10 +206,19 @@ export class Slider {
     this.supposedValueSlot = -1;
 
     if (this.useSnapping && numTicks > 0) {
-      const v = Math.round(this.getTrackWidth() / (numTicks + 1));
-      localLeft = Math.round(localLeft / v) * v;
+      const trackWidth = this.getTrackWidth();
+      const distanceBetweenTicks = Math.round(trackWidth / (numTicks + 1));
+      localLeft = Math.round(localLeft / distanceBetweenTicks) * distanceBetweenTicks;
 
-      this.supposedValueSlot = Math.round(localLeft / v);
+      let scrubberPositionPX = 0;
+      if (localLeft >= 0 && localLeft <= trackWidth) {
+        scrubberPositionPX = localLeft;
+      } else if (localLeft > trackWidth) {
+        scrubberPositionPX = trackWidth;
+      } else if (localLeft < 0) {
+        scrubberPositionPX = 0;
+      }
+      this.supposedValueSlot = Math.round(scrubberPositionPX / distanceBetweenTicks);
     }
 
     this.scrubberLeft = this.constrainScrubber(localLeft);
@@ -239,9 +248,7 @@ export class Slider {
       this.value = `${supposedValue}`;
     } else {
       const percentage = this.scrubberLeft / trackWidth;
-      this.value = `${Math.trunc(
-        this.getMin() + percentage * (this.getMax() - this.getMin())
-      )}`;
+      this.value = `${Math.trunc(this.getMin() + percentage * (this.getMax() - this.getMin()))}`;
     }
 
     this.dispatchChangeEvent();
@@ -385,8 +392,7 @@ export class Slider {
     const percentage = this.scrubberLeft / trackWidth;
     const numTicks = parseInt(this.ticks);
 
-    let currentValue =
-      this.getMin() + percentage * (this.getMax() - this.getMin());
+    let currentValue = this.getMin() + percentage * (this.getMax() - this.getMin());
 
     currentValue += delta;
 
@@ -476,7 +482,7 @@ export class Slider {
 
     if (min > max) {
       console.warn(
-        'min-prop must have a higher value than max-prop for the component to work correctly.'
+        'min-prop must have a higher value than max-prop for the component to work correctly.',
       );
       this.disabledState = true;
     }
@@ -537,9 +543,7 @@ export class Slider {
           )}
 
           <div class="sdds-slider-inner">
-            <label class={this.tickValues.length > 0 && 'offset'}>
-              {this.label}
-            </label>
+            <label class={this.tickValues.length > 0 && 'offset'}>{this.label}</label>
 
             {this.tickValues.length > 0 && (
               <div class="sdds-slider__value-dividers-wrapper">

--- a/tegel/src/components/slider/readme.md
+++ b/tegel/src/components/slider/readme.md
@@ -19,7 +19,7 @@
 | `readOnly`        | `read-only`         | Sets the read only state for the whole component                                 | `boolean`      | `false`               |
 | `scrubberSize`    | `scrubber-size`     | Sets the size of the scrubber                                                    | `"lg" \| "sm"` | `'lg'`                |
 | `showTickNumbers` | `show-tick-numbers` | Decide to show numbers above the tick markers or not                             | `boolean`      | `false`               |
-| `sliderId`        | `slider-id`         | Id for the sliders input element, randomly generated if not specified.           | `string`       | `crypto.randomUUID()` |
+| `sliderId`        | `slider-id`         | ID for the sliders input element, randomly generated if not specified.           | `string`       | `crypto.randomUUID()` |
 | `snap`            | `snap`              | Snap to the ticks grid                                                           | `boolean`      | `false`               |
 | `step`            | `step`              | Defines how much to increment/decrement the value when using controls            | `string`       | `'1'`                 |
 | `ticks`           | `ticks`             | Number of tick markers (tick for min- and max-value will be added automatically) | `string`       | `'0'`                 |

--- a/tegel/src/components/slider/slider.stories.tsx
+++ b/tegel/src/components/slider/slider.stories.tsx
@@ -63,7 +63,7 @@ export default {
         type: 'number',
       },
       if: { arg: 'showTicks', eq: true },
-      
+
       table: {
         defaultValue: { summary: 0 },
       },
@@ -200,8 +200,8 @@ export default {
 };
 
 const sizeLookUp = {
-  'Large': 'lg',
-  'Small': 'sm',
+  Large: 'lg',
+  Small: 'sm',
 };
 
 const Template = ({
@@ -223,34 +223,42 @@ const Template = ({
   disabled,
 }) =>
   formatHtmlPreview(`
-    <sdds-slider id="sdds-slider"
-      min="${min}" 
-      max="${max}" 
-      ${showControls && step ? `step="${step}"` : ''}
-      value="${initialValue}" 
-      ${showTicks ? `ticks="${numTicks}"` : ''} 
-      ${showTickNumbers ? 'show-tick-numbers' : ''} 
-      ${snapToTicks ? 'snap' : ''} 
-      ${showLabel ? `label="${labelText}"` : ''} 
-      ${showTooltip ? 'tooltip' : ''} 
-      ${showControls ? 'controls' : ''} 
-      ${showInput ? 'input' : ''} 
-      ${disabled ? 'disabled' : ''} 
-      scrubber-size="${sizeLookUp[scrubberSize]}"
-      ${readonly ? 'read-only' : ''} 
-      >
+ <!-- Style code below is just for demo purposes -->
+    <style>
+      .demo-wrapper {
+          width: 500px;
+          margin-left: 150px;
+      }
+    </style>
 
-    </sdds-slider>
+   <div class="demo-wrapper">
+     <sdds-slider id="sdds-slider"
+        min="${min}"
+        max="${max}"
+        ${showControls && step ? `step="${step}"` : ''}
+        value="${initialValue}"
+        ${showTicks ? `ticks="${numTicks}"` : ''}
+        ${showTickNumbers ? 'show-tick-numbers' : ''}
+        ${snapToTicks ? 'snap' : ''}
+        ${showLabel ? `label="${labelText}"` : ''}
+        ${showTooltip ? 'tooltip' : ''}
+        ${showControls ? 'controls' : ''}
+        ${showInput ? 'input' : ''}
+        ${disabled ? 'disabled' : ''}
+        scrubber-size="${sizeLookUp[scrubberSize]}"
+        ${readonly ? 'read-only' : ''}
+        >
+      </sdds-slider>
+    </div>
 
-    <!-- Script tag for demo purposes -->
+     <!-- Script tag for demo purposes -->
     <script>
-    slider = document.querySelectorAll('sdds-slider')[0]
+      slider = document.querySelectorAll('sdds-slider')[0]
 
-    slider.removeEventListener('sddsChange', null)
-    slider.addEventListener('sddsChange', (event) => {
-      console.log(event);
-    });
-
+      slider.removeEventListener('sddsChange', null)
+      slider.addEventListener('sddsChange', (event) => {
+        console.log(event);
+      });
     </script>
   `);
 

--- a/tegel/src/components/slider/slider.tsx
+++ b/tegel/src/components/slider/slider.tsx
@@ -181,7 +181,6 @@ export class Slider {
   }
 
   scrubberCore(event) {
-    console.log(`Event is: ${event.type}`);
     const numTicks = parseInt(this.ticks);
     const trackRect = this.trackElement.getBoundingClientRect();
     let localLeft = 0;

--- a/tegel/src/components/slider/slider.tsx
+++ b/tegel/src/components/slider/slider.tsx
@@ -51,54 +51,48 @@ export class Slider {
   /** Snap to the ticks grid */
   @Prop() snap: boolean = false;
 
-  /** Id for the sliders input element, randomly generated if not specified. */
+  /** ID for the sliders input element, randomly generated if not specified. */
   @Prop() sliderId: string = crypto.randomUUID();
 
-  wrapperElement: HTMLElement = null;
+  private wrapperElement: HTMLElement = null;
 
-  scrubberElement: HTMLElement = null;
+  private scrubberElement: HTMLElement = null;
 
-  scrubberInnerElement: HTMLElement = null;
+  private scrubberInnerElement: HTMLElement = null;
 
-  dividersElement: HTMLElement = null;
+  private trackElement: HTMLElement = null;
 
-  trackElement: HTMLElement = null;
+  private trackFillElement: HTMLElement = null;
 
-  trackFillElement: HTMLElement = null;
+  private minusElement: HTMLElement = null;
 
-  minusElement: HTMLElement = null;
+  private plusElement: HTMLElement = null;
 
-  plusElement: HTMLElement = null;
+  private inputElement: HTMLInputElement = null;
 
-  inputElement: HTMLInputElement = null;
+  private scrubberGrabbed: boolean = false;
 
-  nativeRangeInputElement: HTMLInputElement = null;
+  private scrubberLeft: number = 0;
 
-  scrubberGrabPos: object = { x: 0, y: 0 };
+  private tickValues: Array<number> = [];
 
-  scrubberGrabbed: boolean = false;
+  private disabledState: boolean = false;
 
-  scrubberLeft: number = 0;
+  private readonlyState: boolean = false;
 
-  tickValues: Array<number> = [];
+  private useControls: boolean = false;
 
-  disabledState: boolean = false;
+  private useInput: boolean = false;
 
-  readonlyState: boolean = false;
+  private useSmall: boolean = false;
 
-  useControls: boolean = false;
+  private useSnapping: boolean = false;
 
-  useInput: boolean = false;
+  private supposedValueSlot: number = -1;
 
-  useSmall: boolean = false;
+  private eventListenersAdded: boolean = false;
 
-  useSnapping: boolean = false;
-
-  supposedValueSlot: number = -1;
-
-  eventListenersAdded: boolean = false;
-
-  resizeObserverAdded: boolean = false;
+  private resizeObserverAdded: boolean = false;
 
   /** Sends the value of the slider when changed. */
   @Event({
@@ -303,14 +297,11 @@ export class Slider {
 
       this.scrubberElement.addEventListener('mousedown', (event) => {
         event.preventDefault();
-        this.grabScrubber(event.offsetX, event.offsetY);
+        this.grabScrubber();
       });
 
-      this.scrubberElement.addEventListener('touchstart', (event) => {
-        const rect = this.scrubberElement.getBoundingClientRect();
-        const x = event.targetTouches[0].pageX - rect.left;
-        const y = event.targetTouches[0].pageY - rect.top;
-        this.grabScrubber(x, y);
+      this.scrubberElement.addEventListener('touchstart', () => {
+        this.grabScrubber();
       });
 
       if (this.useControls) {
@@ -351,16 +342,10 @@ export class Slider {
     this.updateTrack();
   }
 
-  grabScrubber(xOffset, yOffset) {
+  grabScrubber() {
     if (this.readonlyState) {
       return;
     }
-
-    this.scrubberGrabPos = {
-      x: xOffset,
-      y: yOffset,
-    };
-
     this.scrubberGrabbed = true;
     this.scrubberInnerElement.classList.add('pressed');
   }
@@ -478,9 +463,6 @@ export class Slider {
     return (
       <div class={`sdds-slider-wrapper ${this.readonlyState ? 'read-only' : ''}`}>
         <input
-          ref={(el) => {
-            this.nativeRangeInputElement = el as HTMLInputElement;
-          }}
           class="sdds-slider-native-element"
           type="range"
           value={this.value}
@@ -527,12 +509,7 @@ export class Slider {
           <div class="sdds-slider-inner">
             {this.tickValues.length > 0 && (
               <div class="sdds-slider__value-dividers-wrapper">
-                <div
-                  ref={(el) => {
-                    this.dividersElement = el as HTMLElement;
-                  }}
-                  class="sdds-slider__value-dividers"
-                >
+                <div class="sdds-slider__value-dividers">
                   {this.tickValues.map((value) => (
                     <div class="sdds-slider__value-divider">
                       {this.showTickNumbers && <span>{value}</span>}

--- a/tegel/src/components/slider/slider.tsx
+++ b/tegel/src/components/slider/slider.tsx
@@ -172,15 +172,23 @@ export class Slider {
     this.supposedValueSlot = -1;
 
     if (this.useSnapping && numTicks > 0) {
-      const v = Math.round(this.getTrackWidth() / (numTicks + 1));
-      localLeft = Math.round(localLeft / v) * v;
+      const trackWidth = this.getTrackWidth();
+      const distanceBetweenTicks = Math.round(trackWidth / (numTicks + 1));
+      localLeft = Math.round(localLeft / distanceBetweenTicks) * distanceBetweenTicks;
 
-      this.supposedValueSlot = Math.round(localLeft / v);
+      let scrubberPositionPX = 0;
+      if (localLeft >= 0 && localLeft <= trackWidth) {
+        scrubberPositionPX = localLeft;
+      } else if (localLeft > trackWidth) {
+        scrubberPositionPX = trackWidth;
+      } else if (localLeft < 0) {
+        scrubberPositionPX = 0;
+      }
+      this.supposedValueSlot = Math.round(scrubberPositionPX / distanceBetweenTicks);
     }
 
     this.scrubberLeft = this.constrainScrubber(localLeft);
     this.scrubberElement.style.left = `${this.scrubberLeft}px`;
-
     this.updateValue();
     this.updateTrack();
   }
@@ -200,10 +208,19 @@ export class Slider {
     this.supposedValueSlot = -1;
 
     if (this.useSnapping && numTicks > 0) {
-      const v = Math.round(this.getTrackWidth() / (numTicks + 1));
-      localLeft = Math.round(localLeft / v) * v;
+      const trackWidth = this.getTrackWidth();
+      const distanceBetweenTicks = Math.round(trackWidth / (numTicks + 1));
+      localLeft = Math.round(localLeft / distanceBetweenTicks) * distanceBetweenTicks;
 
-      this.supposedValueSlot = Math.round(localLeft / v);
+      let scrubberPositionPX = 0;
+      if (localLeft >= 0 && localLeft <= trackWidth) {
+        scrubberPositionPX = localLeft;
+      } else if (localLeft > trackWidth) {
+        scrubberPositionPX = trackWidth;
+      } else if (localLeft < 0) {
+        scrubberPositionPX = 0;
+      }
+      this.supposedValueSlot = Math.round(scrubberPositionPX / distanceBetweenTicks);
     }
 
     this.scrubberLeft = this.constrainScrubber(localLeft);
@@ -216,7 +233,6 @@ export class Slider {
   updateTrack() {
     const trackWidth = this.getTrackWidth();
     const percentageFilled = (this.scrubberLeft / trackWidth) * 100;
-
     this.trackFillElement.style.width = `${percentageFilled}%`;
   }
 
@@ -497,7 +513,6 @@ export class Slider {
             this.wrapperElement = el as HTMLElement;
           }}
         >
-
           <label class={this.showTickNumbers && 'offset'}>{this.label}</label>
 
           {this.useInput && (
@@ -525,8 +540,6 @@ export class Slider {
           )}
 
           <div class="sdds-slider-inner">
-            
-
             {this.tickValues.length > 0 && (
               <div class="sdds-slider__value-dividers-wrapper">
                 <div

--- a/tegel/src/components/slider/slider.tsx
+++ b/tegel/src/components/slider/slider.tsx
@@ -166,31 +166,7 @@ export class Slider {
       return;
     }
 
-    const numTicks = parseInt(this.ticks);
-    const trackRect = this.trackElement.getBoundingClientRect();
-    let localLeft = event.clientX - trackRect.left;
-    this.supposedValueSlot = -1;
-
-    if (this.useSnapping && numTicks > 0) {
-      const trackWidth = this.getTrackWidth();
-      const distanceBetweenTicks = Math.round(trackWidth / (numTicks + 1));
-      localLeft = Math.round(localLeft / distanceBetweenTicks) * distanceBetweenTicks;
-
-      let scrubberPositionPX = 0;
-      if (localLeft >= 0 && localLeft <= trackWidth) {
-        scrubberPositionPX = localLeft;
-      } else if (localLeft > trackWidth) {
-        scrubberPositionPX = trackWidth;
-      } else if (localLeft < 0) {
-        scrubberPositionPX = 0;
-      }
-      this.supposedValueSlot = Math.round(scrubberPositionPX / distanceBetweenTicks);
-    }
-
-    this.scrubberLeft = this.constrainScrubber(localLeft);
-    this.scrubberElement.style.left = `${this.scrubberLeft}px`;
-    this.updateValue();
-    this.updateTrack();
+    this.scrubberCore(event);
   }
 
   @Listen('touchmove', { target: 'window' })
@@ -201,9 +177,19 @@ export class Slider {
       return;
     }
 
+    this.scrubberCore(event);
+  }
+
+  scrubberCore(event) {
+    console.log(`Event is: ${event.type}`);
     const numTicks = parseInt(this.ticks);
     const trackRect = this.trackElement.getBoundingClientRect();
-    let localLeft = event.touches[0].clientX - trackRect.left;
+    let localLeft = 0;
+    if (event.type === 'mousemove') {
+      localLeft = event.clientX - trackRect.left;
+    } else if (event.type === 'touchmove') {
+      localLeft = event.touches[0].clientX - trackRect.left;
+    } else console.warn('Slider component: Unsupported event!');
 
     this.supposedValueSlot = -1;
 


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Fixing issue reported in Development support.
A slider with "Snap to ticks" enabled and "Show ticks" ends up with an undefined value if the mouse is pulled way to the right of the slider. Check the main branch and compare it with this PR.

**Solving issue**  
Fixes: DTS-1551

**How to test**  
1. Open the link for PR
2. Check the Slider component
3. Make sure to have "Show ticks" and "Snap to ticks"
4. Drag the mouse to the far right, the value needs to remain on the max value, not going to undefined.
5. To see the issue, check the main branch and test it.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events


**Additional context**  
1. Fix is done for both @scania/tegel and @scania/components
2. There is another bug discovered with keyboard left/right arrows and "Show ticks" and "Snap to ticks" - Working on it in another PR.
