### PR TITLE
feat(header,side-menu): fix dark mode color issues

### DIFF
--- a/tegel/src/components/header/header-vars.scss
+++ b/tegel/src/components/header/header-vars.scss
@@ -214,7 +214,7 @@
 
   // App launcher - Grid menu
   --sdds-header-app-launcher-grid-color: var(--sdds-grey-50);
-  --sdds-header-app-launcher-grid-hover-background: var(--sdds-grey-500);
+  --sdds-header-app-launcher-grid-hover-background: var(--sdds-grey-700);
 
   // /* MOBILE AND TABLET */
   --sdds-header-mobile-nav-center-background: var(--sdds-grey-958);

--- a/tegel/src/components/header/header-vars.scss
+++ b/tegel/src/components/header/header-vars.scss
@@ -26,6 +26,9 @@
   --sdds-nav-dropdown-item-background: var(--sdds-white);
   --sdds-nav-dropdown-item-border-color: var(--sdds-grey-300);
   --sdds-header-nav-item-dropdown-opened-background: var(--sdds-white);
+  --sdds-header-nav-item-dropdown-opened-background-hover: var(--sdds-grey-100);
+  --sdds-header-nav-item-dropdown-opened-background-selected: var(--sdds-grey-100);
+  --sdds-header-nav-item-dropdown-opened-background-active: var(--sdds-grey-300);
   --sdds-header-nav-item-dropdown-opened-color: var(--sdds-grey-958);
   --sdds-header-nav-item-dropdown-hover-color: var(--sdds-grey-300);
 
@@ -138,6 +141,9 @@
   --sdds-nav-dropdown-item-background: var(--sdds-grey-800);
   --sdds-nav-dropdown-item-border-color: var(--sdds-grey-700);
   --sdds-header-nav-item-dropdown-opened-background: var(--sdds-grey-958);
+  --sdds-header-nav-item-dropdown-opened-background-hover: var(--sdds-grey-868);
+  --sdds-header-nav-item-dropdown-opened-background-selected: var(--sdds-grey-868);
+  --sdds-header-nav-item-dropdown-opened-background-active: var(--sdds-grey-800);
   --sdds-header-nav-item-dropdown-opened-color: var(--sdds-white);
 
   // sdds-nav__basic-element-style

--- a/tegel/src/components/header/header-vars.scss
+++ b/tegel/src/components/header/header-vars.scss
@@ -94,6 +94,10 @@
   --sdds-header-app-launcher-item-background-hover: var(--sdds-grey-100);
   --sdds-header-app-launcher-item-color: var(--sdds-grey-700);
 
+  // App launcher - Grid menu
+  --sdds-header-app-launcher-grid--color: var(--sdds-grey-800);
+  --sdds-header-app-launcher-grid-hover-background: var(--sdds-grey-100);
+
   /* MOBILE AND TABLET */
   --sdds-header-mobile-menu-background: var(--sdds-white);
   --sdds-header-mobile-menu-item-background: var(--sdds-white);
@@ -203,9 +207,14 @@
   --sdds-header-app-launcher-item-border-color: var(--sdds-grey-700);
   --sdds-header-app-launcher-category-title-background: var(--sdds-grey-800);
   --sdds-header-app-launcher-category-title-color: var(--sdds-grey-500);
+  --sdds-header-app-launcher-grid-category-title-color: var(--sdds-grey-500);
   --sdds-header-app-launcher-item-background: var(--sdds-grey-800);
   --sdds-header-app-launcher-item-background-hover: var(--sdds-grey-700);
   --sdds-header-app-launcher-item-color: var(--sdds-grey-50);
+
+  // App launcher - Grid menu
+  --sdds-header-app-launcher-grid-color: var(--sdds-grey-50);
+  --sdds-header-app-launcher-grid-hover-background: var(--sdds-grey-500);
 
   // /* MOBILE AND TABLET */
   --sdds-header-mobile-nav-center-background: var(--sdds-grey-958);

--- a/tegel/src/components/header/header-vars.scss
+++ b/tegel/src/components/header/header-vars.scss
@@ -137,7 +137,7 @@
   --sdds-header-nav-item-background-active: var(--sdds-blue-800);
   --sdds-nav-dropdown-item-background: var(--sdds-grey-800);
   --sdds-nav-dropdown-item-border-color: var(--sdds-grey-700);
-  --sdds-header-nav-item-dropdown-opened-background: var(--sdds-grey-800);
+  --sdds-header-nav-item-dropdown-opened-background: var(--sdds-grey-958);
   --sdds-header-nav-item-dropdown-opened-color: var(--sdds-white);
 
   // sdds-nav__basic-element-style
@@ -184,7 +184,7 @@
   --sdds-header-avatar-subtitle-color: var(--sdds-grey-500);
   --sdds-header-avatar-title-color: var(--sdds-grey-50);
   --sdds-header-avatar-item-background-hover: var(--sdds-grey-700);
-  --sdds-header-avatar-item-color: var(--sdds-grey-50);
+  --sdds-header-avatar-item-color: var(--sdds-grey-500);
   --sdds-header-avatar-item-btn-background: var(--sdds-grey-800);
 
   // /* App Launcher */

--- a/tegel/src/components/header/header-vars.scss
+++ b/tegel/src/components/header/header-vars.scss
@@ -31,6 +31,7 @@
   --sdds-header-nav-item-dropdown-opened-background-active: var(--sdds-grey-300);
   --sdds-header-nav-item-dropdown-opened-color: var(--sdds-grey-958);
   --sdds-header-nav-item-dropdown-hover-color: var(--sdds-grey-300);
+  --sdds-header-item-hover: var(--sdds-blue-700);
 
   // sdds-nav__basic-element-style
   --sdds-header--basic-element-border: var(--sdds-blue-700);
@@ -145,6 +146,7 @@
   --sdds-header-nav-item-dropdown-opened-background-selected: var(--sdds-grey-868);
   --sdds-header-nav-item-dropdown-opened-background-active: var(--sdds-grey-800);
   --sdds-header-nav-item-dropdown-opened-color: var(--sdds-white);
+  --sdds-header-item-hover: var(--sdds-blue-800);
 
   // sdds-nav__basic-element-style
   --sdds-header--basic-element-border: var(--sdds-blue-700);

--- a/tegel/src/components/header/webcomponent/header-dropdown-list-item/header-dropdown-list-item.scss
+++ b/tegel/src/components/header/webcomponent/header-dropdown-list-item/header-dropdown-list-item.scss
@@ -21,7 +21,7 @@
       width: 100%;
       font: var(--sdds-detail-02);
       letter-spacing: var(--sdds-detail-02-ls);
-      background-color: var(--sdds-header-nav-item-dropdown-opened-background);
+      background-color: var(--sdds-nav-dropdown-item-background);
       color: var(--sdds-header-nav-item-dropdown-opened-color);
     }
 

--- a/tegel/src/components/header/webcomponent/header-hamburger/header-hamburger.scss
+++ b/tegel/src/components/header/webcomponent/header-hamburger/header-hamburger.scss
@@ -11,7 +11,7 @@
     position: relative;
     margin-left: -6px;
     left: 3px;
-    transition: all 0.2s ease-in-out;
+    transition: background 0.2s ease-in-out, color 0.2s ease-in-out;
   }
 }
 

--- a/tegel/src/components/header/webcomponent/header-item/header-item-global.scss
+++ b/tegel/src/components/header/webcomponent/header-item/header-item-global.scss
@@ -2,7 +2,7 @@
   position: relative;
   margin-left: -6px;
   left: 3px;
-  transition: all 0.2s ease-in-out;
+  transition: background 0.2s ease-in-out, color 0.2s ease-in-out;
 }
 
 .__sdds-header-item-image {
@@ -12,5 +12,5 @@
   width: 34px;
   height: 34px;
   border-radius: 50%;
-  transition: all 0.2s ease-in-out;
+  transition: background 0.2s ease-in-out, color 0.2s ease-in-out;
 }

--- a/tegel/src/components/header/webcomponent/header-item/header-item.scss
+++ b/tegel/src/components/header/webcomponent/header-item/header-item.scss
@@ -20,7 +20,7 @@
 
   ::slotted(button:hover),
   ::slotted(a:hover) {
-    background-color: var(sdds-grey-800);
+    background-color: var(--sdds-header-item-hover);
   }
 
   ::slotted(button:focus-visible),

--- a/tegel/src/components/header/webcomponent/header-item/header-item.scss
+++ b/tegel/src/components/header/webcomponent/header-item/header-item.scss
@@ -20,7 +20,7 @@
 
   ::slotted(button:hover),
   ::slotted(a:hover) {
-    background-color: var(--sdds-header--basic-element-background-hover);
+    background-color: var(sdds-grey-800);
   }
 
   ::slotted(button:focus-visible),
@@ -40,7 +40,7 @@
   .component-selected:not(.component-active) {
     ::slotted(button),
     ::slotted(a) {
-      background-color: var(--sdds-header--basic-element-background-selected);
+      background-color: var(sdds-grey-800);
       padding-top: 4px;
       border-bottom-style: solid;
       border-bottom-width: 4px;

--- a/tegel/src/components/header/webcomponent/header-item/header-item.scss
+++ b/tegel/src/components/header/webcomponent/header-item/header-item.scss
@@ -40,7 +40,7 @@
   .component-selected:not(.component-active) {
     ::slotted(button),
     ::slotted(a) {
-      background-color: var(sdds-grey-800);
+      background-color: var(--sdds-header--basic-element-background-selected);
       padding-top: 4px;
       border-bottom-style: solid;
       border-bottom-width: 4px;

--- a/tegel/src/components/header/webcomponent/header-launcher-grid-item/header-launcher-grid-item.scss
+++ b/tegel/src/components/header/webcomponent/header-launcher-grid-item/header-launcher-grid-item.scss
@@ -23,14 +23,14 @@
     font: var(--sdds-detail-05);
     letter-spacing: var(--sdds-detail-05-ls);
     background-color: var(--sdds-header-app-launcher-menu-bg);
-    color: var(--sdds-grey-800);
+    color: var(--sdds-header-app-launcher-grid-color);
     border-radius: 4px;
     transition: background-color 150ms ease;
   }
 
   ::slotted(a:hover),
   ::slotted(button:hover) {
-    background-color: var(--sdds-grey-100);
+    background-color: var(--sdds-header-app-launcher-grid-hover-background);
     cursor: pointer;
   }
 

--- a/tegel/src/components/side-menu/side-menu-vars.scss
+++ b/tegel/src/components/side-menu/side-menu-vars.scss
@@ -38,7 +38,7 @@
   --sdds-sidebar-item-state-selected: var(--sdds-grey-868);
   --sdds-sidebar-side-menu: var(--sdds-grey-958);
   --sdds-sidebar-side-menu-border-right: var(--sdds-grey-868);
-  --sdds-sidebar-side-menu-background-cover: var(--sdds-black);
+  --sdds-sidebar-side-menu-background-cover: var(--sdds-grey-958);
   --sdds-sidebar-side-menu-mobile-header-border-bottom: var(--sdds-grey-868);
   --sdds-sidebar-side-menu-bottom-menu-background: var(--sdds-grey-958);
   --sdds-sidebar-side-menu-bottom-menu-border-top: var(--sdds-grey-868);

--- a/tegel/src/components/side-menu/side-menu-vars.scss
+++ b/tegel/src/components/side-menu/side-menu-vars.scss
@@ -6,6 +6,7 @@
   --sdds-sidebar-item-state-border-focus: var(--sdds-blue-400);
   --sdds-sidebar-item-state-hover: var(--sdds-grey-100);
   --sdds-sidebar-item-state-active: var(--sdds-grey-300);
+  --sdds-sidemenu-item-state-active: var(--sdds-grey-300);
   --sdds-sidebar-item-state-selected: var(--sdds-grey-100);
 
   // TODO - Not sure why this was black before?
@@ -35,6 +36,7 @@
   --sdds-sidebar-item-state-border-focus: var(--sdds-blue-400);
   --sdds-sidebar-item-state-hover: var(--sdds-grey-868);
   --sdds-sidebar-item-state-active: var(--sdds-grey-800);
+  --sdds-sidemenu-item-state-active: var(--sdds-grey-800);
   --sdds-sidebar-item-state-selected: var(--sdds-grey-868);
   --sdds-sidebar-side-menu: var(--sdds-grey-958);
   --sdds-sidebar-side-menu-border-right: var(--sdds-grey-868);

--- a/tegel/src/components/side-menu/webcomponent/side-menu-dropdown-list-item/side-menu-dropdown-list-item.scss
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-dropdown-list-item/side-menu-dropdown-list-item.scss
@@ -29,7 +29,13 @@
 
     ::slotted(a:hover),
     ::slotted(button:hover) {
-      background-color: var(--sdds-grey-868);
+      background-color: var(--sdds-header-nav-item-dropdown-opened-background-hover);
+      cursor: pointer;
+    }
+
+    ::slotted(a:active),
+    ::slotted(button:active) {
+      background-color: var(--sdds-header-nav-item-dropdown-opened-background-active) !important;
       cursor: pointer;
     }
 
@@ -43,7 +49,9 @@
     ::slotted(button) {
       border-left: 4px solid var(--sdds-nav-item-border-color-active);
       padding-left: 20px;
-      background-color: var(--sdds-grey-868);
+      background-color: var(
+        --sdds-header-nav-item-dropdown-opened-background-selected
+      ); //var(--sdds-grey-868);
     }
   }
 

--- a/tegel/src/components/side-menu/webcomponent/side-menu-dropdown-list-item/side-menu-dropdown-list-item.scss
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-dropdown-list-item/side-menu-dropdown-list-item.scss
@@ -29,7 +29,7 @@
 
     ::slotted(a:hover),
     ::slotted(button:hover) {
-      background-color: var(--sdds-nav-item-background-hover);
+      background-color: var(--sdds-grey-868);
       cursor: pointer;
     }
 
@@ -43,7 +43,7 @@
     ::slotted(button) {
       border-left: 4px solid var(--sdds-nav-item-border-color-active);
       padding-left: 20px;
-      background-color: var(--sdds-nav-item-background-selected);
+      background-color: var(--sdds-grey-868);
     }
   }
 

--- a/tegel/src/components/side-menu/webcomponent/side-menu-dropdown/side-menu-dropdown.scss
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-dropdown/side-menu-dropdown.scss
@@ -28,7 +28,7 @@
       position: absolute;
       left: var(--side-menu-width);
       box-shadow: var(--sdds-nav-dropdown-menu-box);
-      background-color: var(--sdds-header-app-launcher-menu-background);
+      background-color: var(--sdds-grey-958);
 
       .heading-collapsed {
         all: unset;

--- a/tegel/src/components/side-menu/webcomponent/side-menu-item/side-menu-item.scss
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-item/side-menu-item.scss
@@ -38,7 +38,7 @@
     &:active {
       ::slotted(a),
       ::slotted(button) {
-        background-color: var(--sdds-grey-800);
+        background-color: var(--sdds-sidemenu-item-state-active);
       }
     }
 

--- a/tegel/src/components/side-menu/webcomponent/side-menu-item/side-menu-item.scss
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-item/side-menu-item.scss
@@ -20,6 +20,7 @@
       font: var(--sdds-headline-07);
       letter-spacing: var(--sdds-headline-07-ls);
       color: var(--sdds-sidebar-side-menu-single-item-color);
+      cursor: pointer;
     }
 
     ::slotted(a:focus-visible),
@@ -30,8 +31,14 @@
     &:hover {
       ::slotted(a),
       ::slotted(button) {
-        cursor: pointer;
         background-color: var(--sdds-sidebar-item-state-hover);
+      }
+    }
+
+    &:active {
+      ::slotted(a),
+      ::slotted(button) {
+        background-color: var(--sdds-grey-800);
       }
     }
 


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Fixes darkmode color issues in header and sidemenu.

**Solving issue**  
Fixes: #DTS-717

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
