### PR TITLE
fix: changed sb ctrl from "label" to "label text"

### DIFF
--- a/tegel/src/components/dropdown/dropdown-native.stories.tsx
+++ b/tegel/src/components/dropdown/dropdown-native.stories.tsx
@@ -20,7 +20,8 @@ export default {
   argTypes: {
     modeVariant: {
       name: 'Mode variant',
-      description: 'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
+      description:
+        'Mode variant adjusts component colors to have better visibility depending on global mode and background.',
       control: {
         type: 'radio',
       },
@@ -45,7 +46,7 @@ export default {
       options: ['Large', 'Medium', 'Small'],
     },
     label: {
-      name: 'Label',
+      name: 'Label text',
       description: 'Sets a label text to help describe what the dropdown contains.',
       control: {
         type: 'text',
@@ -53,7 +54,8 @@ export default {
     },
     helper: {
       name: 'Helper text',
-      description: 'Sets a helper text to assist the user with additional information about the dropdown.',
+      description:
+        'Sets a helper text to assist the user with additional information about the dropdown.',
       control: {
         type: 'text',
       },
@@ -76,14 +78,7 @@ export default {
   },
 };
 
-const NativeTemplate = ({
-  modeVariant, 
-  state, 
-  size, 
-  label, 
-  helper, 
-  disabled 
-}) => {
+const NativeTemplate = ({ modeVariant, state, size, label, helper, disabled }) => {
   const sizeLookup = { Large: 'lg', Medium: 'md', Small: 'sm' };
   return formatHtmlPreview(`
   <style>
@@ -96,7 +91,9 @@ const NativeTemplate = ({
 <div class="demo-wrapper">
        <div class="sdds-dropdown ${size !== 'Large' ? `sdds-dropdown-${sizeLookup[size]}` : ''} ${
     state ? 'sdds-dropdown--error' : ''
-  } ${modeVariant === 'Inherit from parent' ? '' : `sdds-mode-variant-${modeVariant.toLowerCase()}`}">
+  } ${
+    modeVariant === 'Inherit from parent' ? '' : `sdds-mode-variant-${modeVariant.toLowerCase()}`
+  }">
        ${label !== '' ? `<span class="sdds-dropdown-label-outside">${label}</span> ` : ''}
        <select
        name="nativeDropdown"

--- a/tegel/src/components/header/webcomponent/header-item/readme.md
+++ b/tegel/src/components/header/webcomponent/header-item/readme.md
@@ -47,10 +47,10 @@ Note: Any aria attributes will be passed to the underlying button tag.
 
 ### Used by
 
+ - [sdds-header-brand-symbol](../header-brand-symbol)
  - [sdds-header-dropdown](../header-dropdown)
  - [sdds-header-hamburger](../header-hamburger)
  - [sdds-header-launcher-button](../header-launcher-button)
- - [sdds-header-brand-symbol](../header-logo)
 
 ### Depends on
 
@@ -60,10 +60,10 @@ Note: Any aria attributes will be passed to the underlying button tag.
 ```mermaid
 graph TD;
   sdds-header-item --> sdds-core-header-item
+  sdds-header-brand-symbol --> sdds-header-item
   sdds-header-dropdown --> sdds-header-item
   sdds-header-hamburger --> sdds-header-item
   sdds-header-launcher-button --> sdds-header-item
-  sdds-header-brand-symbol --> sdds-header-item
   style sdds-header-item fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/tegel/src/components/radio-button/radio-button-component.stories.tsx
+++ b/tegel/src/components/radio-button/radio-button-component.stories.tsx
@@ -21,7 +21,7 @@ export default {
   },
   argTypes: {
     label: {
-      name: 'Label',
+      name: 'Label text',
       description: 'Sets the label for the radio button.',
       controls: {
         type: 'text',

--- a/tegel/src/components/radio-button/radio-button.stories.tsx
+++ b/tegel/src/components/radio-button/radio-button.stories.tsx
@@ -19,7 +19,7 @@ export default {
   },
   argTypes: {
     label: {
-      name: 'Label',
+      name: 'Label text',
       description: 'Sets the label for the radio button.',
       control: {
         type: 'text',
@@ -42,7 +42,7 @@ export default {
   },
 };
 
-const Template = ({label, disabled}) =>
+const Template = ({ label, disabled }) =>
   formatHtmlPreview(`
   <style>
     .demo-fieldset-reset { 
@@ -72,4 +72,4 @@ const Template = ({label, disabled}) =>
   </fieldset>
   `);
 
-  export const Native = Template.bind({});
+export const Native = Template.bind({});

--- a/tegel/src/components/toggle/sdds-toggle.stories.tsx
+++ b/tegel/src/components/toggle/sdds-toggle.stories.tsx
@@ -39,7 +39,7 @@ export default {
       },
     },
     label: {
-      name: 'Label',
+      name: 'Label text',
       description: 'Sets the label for the toggles input element.',
       control: {
         type: 'text',

--- a/tegel/src/components/toggle/toggle.stories.tsx
+++ b/tegel/src/components/toggle/toggle.stories.tsx
@@ -34,7 +34,7 @@ export default {
       },
     },
     label: {
-      name: 'Label',
+      name: 'Label text',
       description: 'Sets the label for the toggles input element.',
       control: {
         type: 'text',


### PR DESCRIPTION
**Describe pull-request**  
Changed the sb controls that are controlling label text from "Label" to "Label text". Many components already had this. I did it to be more consistent and avoid mistakes in refactoring Figma

**How to test**  
_Add description how to test if possible_
1. Check effected components sb.

