### PR TITLE
feat(data table): event refactoring and removal of props

### DIFF
--- a/tegel/src/components/data-table/table-body-cell/table-body-cell.tsx
+++ b/tegel/src/components/data-table/table-body-cell/table-body-cell.tsx
@@ -56,10 +56,10 @@ export class TableBodyCell {
   // Listen to headKey from data-table-header-element
   @Listen('internalSddsHover', { target: 'body' })
   internalSddsHoverListener(event: CustomEvent<any>) {
-    const [receivedID, receivedKeyValue] = event.detail;
+    const { tableId, key } = event.detail;
 
-    if (this.tableId === receivedID) {
-      this.activeSorting = this.cellKey === receivedKeyValue;
+    if (tableId === this.tableId) {
+      this.activeSorting = this.cellKey === key;
     }
   }
 

--- a/tegel/src/components/data-table/table-body/readme.md
+++ b/tegel/src/components/data-table/table-body/readme.md
@@ -7,11 +7,10 @@
 
 ## Properties
 
-| Property                   | Attribute                    | Description                                                                                                                                                             | Type      | Default     |
-| -------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
-| `bodyData`                 | `body-data`                  | Prop to pass JSON string which enables automatic rendering of table rows and cells                                                                                      | `any`     | `undefined` |
-| `disableFilteringFunction` | `disable-filtering-function` | Disables inbuilt filtering logic, leaving user an option to create own filter functionality while listening to events from sdds-table-toolbar component for search term | `boolean` | `false`     |
-| `enableDummyData`          | `enable-dummy-data`          | Prop for showcase of rendering JSON in body-data, just for presentation purposes                                                                                        | `boolean` | `false`     |
+| Property          | Attribute           | Description                                                                        | Type      | Default     |
+| ----------------- | ------------------- | ---------------------------------------------------------------------------------- | --------- | ----------- |
+| `bodyData`        | `body-data`         | Prop to pass JSON string which enables automatic rendering of table rows and cells | `any`     | `undefined` |
+| `enableDummyData` | `enable-dummy-data` | Prop for showcase of rendering JSON in body-data, just for presentation purposes   | `boolean` | `false`     |
 
 
 ## Dependencies

--- a/tegel/src/components/data-table/table-body/readme.md
+++ b/tegel/src/components/data-table/table-body/readme.md
@@ -11,7 +11,6 @@
 | -------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
 | `bodyData`                 | `body-data`                  | Prop to pass JSON string which enables automatic rendering of table rows and cells                                                                                      | `any`     | `undefined` |
 | `disableFilteringFunction` | `disable-filtering-function` | Disables inbuilt filtering logic, leaving user an option to create own filter functionality while listening to events from sdds-table-toolbar component for search term | `boolean` | `false`     |
-| `disableSortingFunction`   | `disable-sorting-function`   | Disables inbuilt sorting logic, leaving user an option to create own sorting functionality while listening to events from sdds-header-cell component for sorting        | `boolean` | `false`     |
 | `enableDummyData`          | `enable-dummy-data`          | Prop for showcase of rendering JSON in body-data, just for presentation purposes                                                                                        | `boolean` | `false`     |
 
 

--- a/tegel/src/components/data-table/table-body/table-body.tsx
+++ b/tegel/src/components/data-table/table-body/table-body.tsx
@@ -264,24 +264,6 @@ export class TableBody {
 
   searchFunction(searchTerm) {
     if (!this.disableFilteringFunction) {
-      /*
-      // Logic for filtering JSON data on all columns
-      // Really nice solution, do not delete, might be needed in future
-      // Reason to go with upper one is not to lose selected state on checkboxes
-      if (searchTerm.length > 0) {
-        this.bodyDataManipulated = this.bodyDataOriginal.filter((option) =>
-          Object.keys(option).some(
-            (key) =>
-              String(option[key] ?? '')
-                .toLowerCase()
-                .indexOf(searchTerm) >= 0
-          )
-        );
-      } else {
-        this.bodyDataManipulated = this.bodyDataOriginal;
-      }
-  */
-
       // grab all rows in body
       const dataRowsFiltering = this.host.querySelectorAll('sdds-table-body-row');
 
@@ -338,11 +320,17 @@ export class TableBody {
     }
   }
 
-  // Listen to sddsFilter from tableToolbar component
-  @Listen('sddsFilter', { target: 'body' })
-  sddsFilterListener(event: CustomEvent<any>) {
-    if (this.tableId === event.detail[0]) {
-      this.searchFunction(event.detail[1]);
+  /** Listens to internalSddsFilter from tableToolbar component */
+  @Listen('internalSddsFilter', { target: 'body' })
+  sddsFilterListener(
+    event: CustomEvent<{
+      tableId: string;
+      query: string;
+    }>,
+  ) {
+    console.log('hejhå');
+    if (this.tableId === event.detail.tableId) {
+      this.searchFunction(event.detail.query);
     }
   }
 

--- a/tegel/src/components/data-table/table-body/table-body.tsx
+++ b/tegel/src/components/data-table/table-body/table-body.tsx
@@ -301,10 +301,8 @@ export class TableBody {
         this.tempPaginationDisable = false;
       }
 
-      // Check if pagination is ON in order to prevent showing all rows
-      if (this.enablePaginationTableBody) {
-        // TODO: EMIT PAGINATION
-      } else {
+      // If pagination is NOT enabled, we show all rows.
+      if (!this.enablePaginationTableBody) {
         dataRowsFiltering.forEach((item) => {
           item.classList.remove('sdds-table__row--hidden');
         });

--- a/tegel/src/components/data-table/table-body/table-body.tsx
+++ b/tegel/src/components/data-table/table-body/table-body.tsx
@@ -69,9 +69,6 @@ const relevantTableProps: InternalSddsTablePropChange['changed'] = [
   shadow: false,
 })
 export class TableBody {
-  /** Disables inbuilt filtering logic, leaving user an option to create own filter functionality while listening to events from sdds-table-toolbar component for search term */
-  @Prop() disableFilteringFunction: boolean = false;
-
   /** Prop to pass JSON string which enables automatic rendering of table rows and cells  */
   @Prop({ mutable: true }) bodyData: any;
 
@@ -263,60 +260,58 @@ export class TableBody {
   }
 
   searchFunction(searchTerm) {
-    if (!this.disableFilteringFunction) {
-      // grab all rows in body
-      const dataRowsFiltering = this.host.querySelectorAll('sdds-table-body-row');
+    // grab all rows in body
+    const dataRowsFiltering = this.host.querySelectorAll('sdds-table-body-row');
 
-      if (searchTerm.length > 0) {
-        if (this.enablePaginationTableBody) {
-          this.tempPaginationDisable = true;
-        }
+    if (searchTerm.length > 0) {
+      if (this.enablePaginationTableBody) {
+        this.tempPaginationDisable = true;
+      }
 
-        dataRowsFiltering.forEach((item) => {
-          const cells = item.querySelectorAll('sdds-body-cell');
-          const cellValuesArray = [];
+      dataRowsFiltering.forEach((item) => {
+        const cells = item.querySelectorAll('sdds-body-cell');
+        const cellValuesArray = [];
 
-          // go through cells and save cell-values in array
-          cells.forEach((cellItem) => {
-            const cellValue = cellItem.getAttribute('cell-value').toLowerCase();
-            cellValuesArray.push(cellValue);
-          });
-
-          // iterate over array of values and see if one matches search string
-          const matchCounter = cellValuesArray.find((element) => element.includes(searchTerm));
-
-          // if matches, show parent row, otherwise hide the row
-          if (matchCounter) {
-            item.classList.remove('sdds-table__row--hidden');
-          } else {
-            item.classList.add('sdds-table__row--hidden');
-          }
+        // go through cells and save cell-values in array
+        cells.forEach((cellItem) => {
+          const cellValue = cellItem.getAttribute('cell-value').toLowerCase();
+          cellValuesArray.push(cellValue);
         });
 
-        this.disableAllSorting = true;
-        this.internalSddsSortingChange.emit([this.tableId, this.disableAllSorting]);
+        // iterate over array of values and see if one matches search string
+        const matchCounter = cellValuesArray.find((element) => element.includes(searchTerm));
 
-        const dataRowsHidden = this.host.querySelectorAll('.sdds-table__row--hidden');
-
-        // If same, info message will be shown
-        this.showNoResultsMessage = dataRowsHidden.length === dataRowsFiltering.length;
-      } else {
-        if (this.enablePaginationTableBody) {
-          this.tempPaginationDisable = false;
-        }
-
-        // Check if pagination is ON in order to prevent showing all rows
-        if (this.enablePaginationTableBody) {
-          // TODO: EMIT PAGINATION
+        // if matches, show parent row, otherwise hide the row
+        if (matchCounter) {
+          item.classList.remove('sdds-table__row--hidden');
         } else {
-          dataRowsFiltering.forEach((item) => {
-            item.classList.remove('sdds-table__row--hidden');
-          });
+          item.classList.add('sdds-table__row--hidden');
         }
+      });
 
-        this.disableAllSorting = false;
-        this.internalSddsSortingChange.emit([this.tableId, this.disableAllSorting]);
+      this.disableAllSorting = true;
+      this.internalSddsSortingChange.emit([this.tableId, this.disableAllSorting]);
+
+      const dataRowsHidden = this.host.querySelectorAll('.sdds-table__row--hidden');
+
+      // If same, info message will be shown
+      this.showNoResultsMessage = dataRowsHidden.length === dataRowsFiltering.length;
+    } else {
+      if (this.enablePaginationTableBody) {
+        this.tempPaginationDisable = false;
       }
+
+      // Check if pagination is ON in order to prevent showing all rows
+      if (this.enablePaginationTableBody) {
+        // TODO: EMIT PAGINATION
+      } else {
+        dataRowsFiltering.forEach((item) => {
+          item.classList.remove('sdds-table__row--hidden');
+        });
+      }
+
+      this.disableAllSorting = false;
+      this.internalSddsSortingChange.emit([this.tableId, this.disableAllSorting]);
     }
   }
 

--- a/tegel/src/components/data-table/table-body/table-body.tsx
+++ b/tegel/src/components/data-table/table-body/table-body.tsx
@@ -72,9 +72,6 @@ export class TableBody {
   /** Disables inbuilt filtering logic, leaving user an option to create own filter functionality while listening to events from sdds-table-toolbar component for search term */
   @Prop() disableFilteringFunction: boolean = false;
 
-  /** Disables inbuilt sorting logic, leaving user an option to create own sorting functionality while listening to events from sdds-header-cell component for sorting */
-  @Prop() disableSortingFunction: boolean = false;
-
   /** Prop to pass JSON string which enables automatic rendering of table rows and cells  */
   @Prop({ mutable: true }) bodyData: any;
 
@@ -201,24 +198,22 @@ export class TableBody {
   };
 
   sortData(keyValue, sortingDirection) {
-    if (!this.disableSortingFunction) {
-      if (this.enableMultiselect) {
-        // Uncheck all checkboxes as state of checkbox is lost on sorting. Do it only in case multiSelect is True.
-        this.uncheckAll();
-      }
-
-      // use spread operator to make enable sorting and modifying array, same as using .slice()
-      this.bodyDataManipulated = [...this.bodyDataManipulated];
-      this.bodyDataManipulated.sort(TableBody.compareValues(keyValue, sortingDirection));
+    if (this.enableMultiselect) {
+      // Uncheck all checkboxes as state of checkbox is lost on sorting. Do it only in case multiSelect is True.
+      this.uncheckAll();
     }
+
+    // use spread operator to make enable sorting and modifying array, same as using .slice()
+    this.bodyDataManipulated = [...this.bodyDataManipulated];
+    this.bodyDataManipulated.sort(TableBody.compareValues(keyValue, sortingDirection));
   }
 
   // Listen to sortColumnData from data-table-header-element - TODO
-  @Listen('sddsSortChange', { target: 'body' })
+  @Listen('internalSddsSortChange', { target: 'body' })
   updateOptionsContent(event: CustomEvent<any>) {
-    const [receivedID, receivedKeyValue, receivedSortingDirection] = event.detail;
-    if (this.tableId === receivedID) {
-      this.sortData(receivedKeyValue, receivedSortingDirection);
+    const { tableId, key, sortingDirection } = event.detail;
+    if (this.tableId === tableId) {
+      this.sortData(key, sortingDirection);
     }
   }
 

--- a/tegel/src/components/data-table/table-body/table-body.tsx
+++ b/tegel/src/components/data-table/table-body/table-body.tsx
@@ -208,9 +208,9 @@ export class TableBody {
   // Listen to sortColumnData from data-table-header-element - TODO
   @Listen('internalSddsSortChange', { target: 'body' })
   updateOptionsContent(event: CustomEvent<any>) {
-    const { tableId, key, sortingDirection } = event.detail;
+    const { tableId, columnKey, sortingDirection } = event.detail;
     if (this.tableId === tableId) {
-      this.sortData(key, sortingDirection);
+      this.sortData(columnKey, sortingDirection);
     }
   }
 

--- a/tegel/src/components/data-table/table-body/table-body.tsx
+++ b/tegel/src/components/data-table/table-body/table-body.tsx
@@ -328,7 +328,6 @@ export class TableBody {
       query: string;
     }>,
   ) {
-    console.log('hejhå');
     if (this.tableId === event.detail.tableId) {
       this.searchFunction(event.detail.query);
     }

--- a/tegel/src/components/data-table/table-component-event-listeners.stories.tsx
+++ b/tegel/src/components/data-table/table-component-event-listeners.stories.tsx
@@ -141,19 +141,19 @@ const EventListenersTemplate = ({
   formatHtmlPreview(`
     <script>
       // Note: Script here is only for demo purposes
-      window.addEventListener('sddsFilter', e => {
-        document.getElementById('event-name-textarea').value = 'sddsFilter';
-        document.getElementById('event-value-textarea').value = e.detail;
+      window.addEventListener('sddsFilterChange', e => {
+        document.getElementById('event-name-textarea').value = 'sddsFilterChange';
+        document.getElementById('event-value-textarea').value = JSON.stringify(e.detail)
       });
 
       window.addEventListener('sddsSortChange', e => {
         document.getElementById('event-name-textarea').value = 'sddsSortChange';
-        document.getElementById('event-value-textarea').value = e.detail;
+        document.getElementById('event-value-textarea').value = JSON.stringify(e.detail);
       });
 
       window.addEventListener('sddsPageChange', e => {
         document.getElementById('event-name-textarea').value = 'sddsPageChange';
-        document.getElementById('event-value-textarea').value = e.detail;
+        document.getElementById('event-value-textarea').value = JSON.stringify(e.detail);
       });
     </script>
 
@@ -187,7 +187,7 @@ const EventListenersTemplate = ({
                   <sdds-body-cell cell-value="Test value 8" cell-key="mileage"></sdds-body-cell>
               </sdds-table-body-row>
           </sdds-table-body>
-        <sdds-table-footer enable-client-pagination client-max-pages="10"></sdds-table-footer>
+        <sdds-table-footer pagination max-pages="10"></sdds-table-footer>
   </sdds-table>
 
   <!-- Note: Code below is just for demo purposes -->
@@ -197,7 +197,6 @@ const EventListenersTemplate = ({
     <h6 class="sdds-u-mt1 sdds-u-mb0">Event name:</h6>
     <textarea id="event-name-textarea" rows="1" cols="50" readonly></textarea>
     <h6 class="sdds-u-mt0 sdds-u-mb0">Events value (aka detail)</h6>
-    <small>Event always sent an array of items, where first one is always an ID of tabel where event is emitted from</small>
     <br>
     <textarea id="event-value-textarea" rows="1" cols="50" readonly></textarea>
   </div>`);

--- a/tegel/src/components/data-table/table-component-filtering.stories.tsx
+++ b/tegel/src/components/data-table/table-component-filtering.stories.tsx
@@ -190,6 +190,12 @@ const FilteringTemplate = ({
                 : ''
             }
           </sdds-table-body>
-  </sdds-table>`);
+  </sdds-table>
+  
+  <script>
+    document.addEventListener('sddsFilter', (event) => {
+      console.log(event)
+    })
+  </script>`);
 
 export const Filtering = FilteringTemplate.bind({});

--- a/tegel/src/components/data-table/table-component-filtering.stories.tsx
+++ b/tegel/src/components/data-table/table-component-filtering.stories.tsx
@@ -193,7 +193,7 @@ const FilteringTemplate = ({
   </sdds-table>
   
   <script>
-    document.addEventListener('sddsFilter', (event) => {
+    document.addEventListener('sddsFilterChange', (event) => {
       console.log(event)
     })
   </script>`);

--- a/tegel/src/components/data-table/table-component-pagination.stories.tsx
+++ b/tegel/src/components/data-table/table-component-pagination.stories.tsx
@@ -174,7 +174,7 @@ const PaginationTemplate = ({
           </sdds-table-header>
           <sdds-table-body enable-dummy-data>
           </sdds-table-body>
-          <sdds-table-footer enable-pagination rows-per-page="${rowsPerPageControl}"></sdds-table-footer>
+          <sdds-table-footer pagination rows-per-page="${rowsPerPageControl}"></sdds-table-footer>
   </sdds-table>`);
 
 export const Pagination = PaginationTemplate.bind({});

--- a/tegel/src/components/data-table/table-component-pagination.stories.tsx
+++ b/tegel/src/components/data-table/table-component-pagination.stories.tsx
@@ -175,6 +175,15 @@ const PaginationTemplate = ({
           <sdds-table-body enable-dummy-data>
           </sdds-table-body>
           <sdds-table-footer pagination rows-per-page="${rowsPerPageControl}"></sdds-table-footer>
-  </sdds-table>`);
+  </sdds-table>
+  
+
+  <script>
+    document.addEventListener('sddsPageChange', (event) => {
+      console.log(event)
+    })
+  </script>
+  
+  `);
 
 export const Pagination = PaginationTemplate.bind({});

--- a/tegel/src/components/data-table/table-component-sorting.stories.tsx
+++ b/tegel/src/components/data-table/table-component-sorting.stories.tsx
@@ -211,6 +211,15 @@ const SortingTemplate = ({
           </sdds-table-header>
           <sdds-table-body enable-dummy-data>
           </sdds-table-body>
-  </sdds-table>`);
+  </sdds-table>
+  
+  
+  <script>
+
+    document.addEventListener('sddsSortChange', (event) => {
+      console.log(event)
+    })
+  
+  </script>`);
 
 export const Sorting = SortingTemplate.bind({});

--- a/tegel/src/components/data-table/table-footer/readme.md
+++ b/tegel/src/components/data-table/table-footer/readme.md
@@ -7,23 +7,34 @@
 
 ## Properties
 
-| Property                    | Attribute                     | Description                                                                                                                                                 | Type      | Default |
-| --------------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------- |
-| `clientMaxPages`            | `client-max-pages`            | Prop for client to set max number of pages                                                                                                                  | `number`  | `1`     |
-| `clientPaginationValue`     | `client-pagination-value`     | Prop for client to set current page number                                                                                                                  | `number`  | `1`     |
-| `clientSetColumnsNumber`    | `client-set-columns-number`   | In case that automatic count of columns does not work, user can manually set this one. Take in mind that expandable control is column too                   | `number`  | `null`  |
-| `disablePaginationFunction` | `disable-pagination-function` | Disables inbuilt pagination logic, leaving user an option to create own pagination functionality while listening to events from sdds-table-footer component | `boolean` | `false` |
-| `enableClientPagination`    | `enable-client-pagination`    | Prop to enable client controlled pagination                                                                                                                 | `boolean` | `false` |
-| `enablePagination`          | `enable-pagination`           | Enable pagination and show pagination controls                                                                                                              | `boolean` | `false` |
-| `rowsPerPage`               | `rows-per-page`               | Sets how many rows to display when pagination is enabled                                                                                                    | `number`  | `5`     |
+| Property                 | Attribute                   | Description                                                                                                                               | Type      | Default     |
+| ------------------------ | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
+| `clientSetColumnsNumber` | `client-set-columns-number` | In case that automatic count of columns does not work, user can manually set this one. Take in mind that expandable control is column too | `number`  | `null`      |
+| `maxPages`               | `max-pages`                 | Prop for client to set max number of pages.                                                                                               | `number`  | `undefined` |
+| `pagination`             | `pagination`                | Enable pagination and show pagination controls                                                                                            | `boolean` | `false`     |
+| `paginationValue`        | `pagination-value`          | Sets the pagination number.                                                                                                               | `number`  | `1`         |
+| `rowsPerPage`            | `rows-per-page`             | Sets how many rows to display when pagination is enabled.                                                                                 | `number`  | `5`         |
 
 
 ## Events
 
-| Event            | Description                                                                                                                                | Type               |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------ |
-| `sddsPageChange` | Event to send current page value back to sdds-table-body component, can also be listened to in order to implement custom pagination logic. | `CustomEvent<any>` |
+| Event            | Description                                                                                                                           | Type                                                         |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `sddsPageChange` | Event to send current page value to sdds-table-body component, can also be listened to in order to implement custom pagination logic. | `CustomEvent<{ tableId: string; paginationValue: number; }>` |
 
+
+## Dependencies
+
+### Depends on
+
+- [sdds-icon](../../icon)
+
+### Graph
+```mermaid
+graph TD;
+  sdds-table-footer --> sdds-icon
+  style sdds-table-footer fill:#f9f,stroke:#333,stroke-width:4px
+```
 
 ----------------------------------------------
 

--- a/tegel/src/components/data-table/table-footer/table-footer.tsx
+++ b/tegel/src/components/data-table/table-footer/table-footer.tsx
@@ -69,7 +69,7 @@ export class TableFooter {
   })
   sddsPageChange: EventEmitter<{
     tableId: string;
-    paginationValue: number; // Better naming?
+    paginationValue: number;
   }>;
 
   @Listen('internalSddsTablePropChange', { target: 'body' })
@@ -116,7 +116,8 @@ export class TableFooter {
       tableId: this.tableId,
       paginationValue: Number(this.inputElement.value) - 1,
     });
-    /* Decreate pgination value */
+    /** If pages and greater or equal to 2, decrease pagination value.
+     * This is to not get under 1 in pagination value.  */
     if (this.paginationValue >= 2) {
       this.paginationValue--;
     }
@@ -134,7 +135,8 @@ export class TableFooter {
       paginationValue: Number(this.inputElement.value) + 1,
     });
 
-    /* Increase pgination value */
+    /** If pages and greater or equal to the amount of pages, increase pagination value.
+     * This is to not get above the amount of pages in pagination value.  */
     if (this.paginationValue <= this.numberOfPages) {
       this.paginationValue++;
     }

--- a/tegel/src/components/data-table/table-footer/table-footer.tsx
+++ b/tegel/src/components/data-table/table-footer/table-footer.tsx
@@ -11,11 +11,7 @@ import {
 } from '@stencil/core';
 import { InternalSddsTablePropChange } from '../table/table';
 
-const relevantTableProps: InternalSddsTablePropChange['changed'] = [
-  'compactDesign',
-  'noMinWidth',
-  'verticalDividers',
-];
+const relevantTableProps: InternalSddsTablePropChange['changed'] = ['compactDesign'];
 
 function removeShakeAnimation(e: AnimationEvent & { target: HTMLElement }) {
   e.target.classList.remove('sdds-table__page-selector-input--shake');
@@ -28,25 +24,19 @@ function removeShakeAnimation(e: AnimationEvent & { target: HTMLElement }) {
 })
 export class TableFooter {
   /** Enable pagination and show pagination controls  */
-  @Prop({ reflect: true }) enablePagination: boolean = false;
+  @Prop({ reflect: true }) pagination: boolean = false;
 
-  /** Sets how many rows to display when pagination is enabled */
+  /** Sets how many rows to display when pagination is enabled. */
   @Prop({ reflect: true }) rowsPerPage: number = 5;
 
-  /** Prop to enable client controlled pagination  */
-  @Prop({ reflect: true }) enableClientPagination: boolean = false;
+  /** Sets the pagination number. */
+  @Prop({ reflect: true }) paginationValue: number = 1;
 
-  /** Prop for client to set current page number */
-  @Prop({ reflect: true }) clientPaginationValue: number = 1;
-
-  /** Prop for client to set max number of pages */
-  @Prop({ reflect: true }) clientMaxPages: number = 1;
+  /** Prop for client to set max number of pages. */
+  @Prop({ reflect: true }) maxPages: number;
 
   /** In case that automatic count of columns does not work, user can manually set this one. Take in mind that expandable control is column too */
   @Prop() clientSetColumnsNumber: number = null;
-
-  /** Disables inbuilt pagination logic, leaving user an option to create own pagination functionality while listening to events from sdds-table-footer component */
-  @Prop() disablePaginationFunction: boolean = false;
 
   /** State that memorize number of columns to display colSpan correctly - set from parent level */
   @State() columnsNumber: number = 0;
@@ -54,34 +44,33 @@ export class TableFooter {
   /** Total number of pages, number of the rows divided with number of rows per page */
   @State() numberOfPages: number = 0;
 
-  /** Initial value for pagination in input element */
-  @State() paginationValue: number = 1;
-
   /** Temporarily disable pagination - due to search - set from parent level */
   @State() tempPaginationDisable: boolean = false;
 
-  @State() verticalDividers: boolean = false;
-
+  /* Sets the footer to use compact design. */
   @State() compactDesign: boolean = false;
-
-  @State() noMinWidth: boolean = false;
-
-  @State() whiteBackground: boolean = false;
 
   @State() tableId: string = '';
 
   @Element() host: HTMLElement;
 
-  tableEl: HTMLSddsTableElement;
+  /* A reference for the input element used for pagination in the footer. */
+  private inputElement: HTMLInputElement;
 
-  /** @internal Event that footer sends out in order to receive other necessary information from other subcomponents */
+  /* The footers parent table. */
+  private tableEl: HTMLSddsTableElement;
+
+  /** Event to send current page value to sdds-table-body component, can also be listened to in order to implement custom pagination logic. */
   @Event({
-    eventName: 'internalSddsEnablePagination',
+    eventName: 'sddsPageChange',
     composed: true,
-    cancelable: false,
+    cancelable: true,
     bubbles: true,
   })
-  internalSddsEnablePagination: EventEmitter<any>;
+  sddsPageChange: EventEmitter<{
+    tableId: string;
+    paginationValue: number; // Better naming?
+  }>;
 
   @Listen('internalSddsTablePropChange', { target: 'body' })
   internalSddsPropChangeListener(event: CustomEvent<InternalSddsTablePropChange>) {
@@ -119,29 +108,43 @@ export class TableFooter {
     } else {
       this.columnsNumber = numberOfColumns;
     }
-
-    this.internalSddsEnablePagination.emit(this.tableId);
   }
 
-  paginationPrev = (event) => {
-    event.preventDefault();
-    // Enable lowering until 1st page
+  private previousPage = () => {
+    /* Emits pagination event. */
+    const pageChangEvent = this.sddsPageChange.emit({
+      tableId: this.tableId,
+      paginationValue: Number(this.inputElement.value) + 1,
+    });
+    /* If the change event is not prevented -> do pagination. */
+    if (pageChangEvent.defaultPrevented) {
+      /* Decrease the pagination until the first page. */
+      this.runPagination();
+    }
+    /* Decreate pgination value */
     if (this.paginationValue >= 2) {
       this.paginationValue--;
-      this.runPagination();
     }
   };
 
-  paginationNext = (event) => {
-    event.preventDefault();
-    // Enable increasing until the max number of pages
+  private nextPage = () => {
+    /* Emits pagination event. */
+    const pageChangEvent = this.sddsPageChange.emit({
+      tableId: this.tableId,
+      paginationValue: Number(this.inputElement.value) - 1,
+    });
+    /* If the change event is not prevented -> do pagination. */
+    if (!pageChangEvent.defaultPrevented) {
+      /* Increase the pagination until the last page. */
+      this.runPagination();
+    }
+    /* Increase pgination value */
     if (this.paginationValue <= this.numberOfPages) {
       this.paginationValue++;
-      this.runPagination();
     }
   };
 
-  paginationInputChange(event) {
+  private paginationInputChange(event) {
     const insertedValue = event.target.value;
 
     if (insertedValue > this.numberOfPages || insertedValue < 1) {
@@ -150,7 +153,13 @@ export class TableFooter {
     } else {
       this.paginationValue = event.target.value;
     }
-    this.runPagination();
+    const paginationEvent = this.sddsPageChange.emit({
+      tableId: this.tableId,
+      paginationValue: Number(this.inputElement.value) - 1,
+    });
+    if (!paginationEvent.defaultPrevented) {
+      this.runPagination();
+    }
   }
 
   @Listen('internalSddsPagination', { target: 'body' })
@@ -161,91 +170,45 @@ export class TableFooter {
   }
 
   runPagination = () => {
-    if (!this.disablePaginationFunction) {
-      // grab all rows in body
-      const dataRowsPagination = this.host.parentNode
-        .querySelector('sdds-table-body')
-        .querySelectorAll('.sdds-table__row');
+    // grab all rows in body
+    const dataRowsPagination = this.host.parentNode
+      .querySelector('sdds-table-body')
+      .querySelectorAll('.sdds-table__row');
 
-      dataRowsPagination.forEach((item, i) => {
-        // for making logic easier 1st result, 2nd result...
-        const index = i + 1;
+    dataRowsPagination.forEach((item, i) => {
+      // for making logic easier 1st result, 2nd result...
+      const index = i + 1;
 
-        if (this.tempPaginationDisable) {
-          this.paginationValue = 1;
+      if (this.tempPaginationDisable) {
+        this.paginationValue = 1;
+      } else {
+        const lastResult = this.rowsPerPage * this.paginationValue;
+        const firstResult = lastResult - this.rowsPerPage;
+
+        if (index > firstResult && index <= lastResult) {
+          item.classList.remove('sdds-table__row--hidden');
         } else {
-          const lastResult = this.rowsPerPage * this.paginationValue;
-          const firstResult = lastResult - this.rowsPerPage;
-
-          if (index > firstResult && index <= lastResult) {
-            item.classList.remove('sdds-table__row--hidden');
-          } else {
-            item.classList.add('sdds-table__row--hidden');
-          }
+          item.classList.add('sdds-table__row--hidden');
         }
-      });
-    }
+      }
+    });
   };
-
-  /* Client based functions below */
-
-  /** Event to send current page value back to sdds-table-body component, can also be listened to in order to implement custom pagination logic. */
-  @Event({
-    eventName: 'sddsPageChange',
-    composed: true,
-    cancelable: false,
-    bubbles: true,
-  })
-  sddsPageChange: EventEmitter<any>;
-
-  sendPaginationValue(value) {
-    this.sddsPageChange.emit([this.tableId, value]);
-  }
-
-  clientPaginationPrev = (event) => {
-    event.preventDefault();
-    // Enable lowering until 1st page
-    if (this.clientPaginationValue >= 2) {
-      this.clientPaginationValue--;
-      this.sendPaginationValue(this.clientPaginationValue);
-    }
-  };
-
-  clientPaginationNext = (event) => {
-    event.preventDefault();
-    // Enable increasing until the max number of pages
-    if (this.clientPaginationValue <= this.clientMaxPages) {
-      this.clientPaginationValue++;
-      this.sendPaginationValue(this.clientPaginationValue);
-    }
-  };
-
-  clientPaginationInputChange(event) {
-    const insertedValue = event.target.value;
-
-    if (insertedValue > this.clientMaxPages || insertedValue < 1) {
-      event.target.classList.add('sdds-table__page-selector-input--shake');
-      this.clientPaginationValue = event.target.max;
-    } else {
-      this.clientPaginationValue = event.target.value;
-    }
-    this.sendPaginationValue(this.clientPaginationValue);
-  }
 
   render() {
     return (
       <Host class={this.compactDesign ? 'sdds-table--compact' : ''}>
         <tr class="sdds-table__footer-row">
           <td class="sdds-table__footer-cell" colSpan={this.columnsNumber}>
-            {this.enablePagination && !this.enableClientPagination && (
+            {this.pagination && (
               <div class="sdds-table__pagination">
                 <div class="sdds-table__row-selector"></div>
                 <div class="sdds-table__page-selector">
                   <input
+                    ref={(element) => (this.inputElement = element)}
                     class="sdds-table__page-selector-input"
                     type="number"
                     min="1"
-                    max={this.numberOfPages}
+                    max={this.maxPages ?? this.numberOfPages}
                     value={this.paginationValue}
                     pattern="[0-9]+"
                     dir="rtl"
@@ -258,100 +221,22 @@ export class TableFooter {
                     of <span>{this.tempPaginationDisable ? 1 : this.numberOfPages}</span> pages
                   </p>
                   <button
+                    type="button"
                     class="sdds-table__footer-btn"
                     disabled={this.paginationValue <= 1 || this.tempPaginationDisable}
-                    onClick={(event) => this.paginationPrev(event)}
+                    onClick={() => this.previousPage()}
                   >
-                    <svg
-                      class="sdds-table__footer-btn-svg"
-                      fill="currentColor"
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 32 32"
-                    >
-                      <path
-                        fill-rule="evenodd"
-                        clip-rule="evenodd"
-                        d="M22.217 4.273a1 1 0 0 1 0 1.415l-9.888 9.888a.6.6 0 0 0 0 .848l9.888 9.888a1 1 0 0 1-1.414 1.415l-9.889-9.889a2.6 2.6 0 0 1 0-3.677l9.889-9.888a1 1 0 0 1 1.414 0Z"
-                      />
-                    </svg>
+                    <sdds-icon name="chevron_left" size="20px"></sdds-icon>
                   </button>
                   <button
+                    type="button"
                     class="sdds-table__footer-btn"
                     disabled={
                       this.paginationValue >= this.numberOfPages || this.tempPaginationDisable
                     }
-                    onClick={(event) => this.paginationNext(event)}
+                    onClick={() => this.nextPage()}
                   >
-                    <svg
-                      class="sdds-table__footer-btn-svg"
-                      fill="currentColor"
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 32 32"
-                    >
-                      <path
-                        fill-rule="evenodd"
-                        clip-rule="evenodd"
-                        d="M9.783 27.727a1 1 0 0 1 0-1.415l9.888-9.888a.6.6 0 0 0 0-.848L9.783 5.688a1 1 0 0 1 1.414-1.415l9.889 9.889a2.6 2.6 0 0 1 0 3.676l-9.889 9.889a1 1 0 0 1-1.414 0Z"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-            )}
-            {this.enableClientPagination && !this.enablePagination && (
-              <div class="sdds-table__pagination">
-                <div class="sdds-table__row-selector"></div>
-                <div class="sdds-table__page-selector">
-                  <input
-                    class="sdds-table__page-selector-input"
-                    type="number"
-                    min="1"
-                    max={this.clientMaxPages}
-                    value={this.clientPaginationValue}
-                    pattern="[0-9]+"
-                    dir="rtl"
-                    onChange={(event) => this.clientPaginationInputChange(event)}
-                    onFocusout={(event) => this.clientPaginationInputChange(event)}
-                    onAnimationEnd={removeShakeAnimation}
-                  />
-                  <p class="sdds-table__footer-text">
-                    of <span>{this.clientMaxPages}</span> pages
-                  </p>
-                  <button
-                    class="sdds-table__footer-btn"
-                    disabled={this.clientPaginationValue <= 1}
-                    onClick={(event) => this.clientPaginationPrev(event)}
-                  >
-                    <svg
-                      class="sdds-table__footer-btn-svg"
-                      fill="currentColor"
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 32 32"
-                    >
-                      <path
-                        fill-rule="evenodd"
-                        clip-rule="evenodd"
-                        d="M22.217 4.273a1 1 0 0 1 0 1.415l-9.888 9.888a.6.6 0 0 0 0 .848l9.888 9.888a1 1 0 0 1-1.414 1.415l-9.889-9.889a2.6 2.6 0 0 1 0-3.677l9.889-9.888a1 1 0 0 1 1.414 0Z"
-                      />
-                    </svg>
-                  </button>
-                  <button
-                    class="sdds-table__footer-btn"
-                    disabled={this.clientPaginationValue >= this.clientMaxPages}
-                    onClick={(event) => this.clientPaginationNext(event)}
-                  >
-                    <svg
-                      class="sdds-table__footer-btn-svg"
-                      fill="currentColor"
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 32 32"
-                    >
-                      <path
-                        fill-rule="evenodd"
-                        clip-rule="evenodd"
-                        d="M9.783 27.727a1 1 0 0 1 0-1.415l9.888-9.888a.6.6 0 0 0 0-.848L9.783 5.688a1 1 0 0 1 1.414-1.415l9.889 9.889a2.6 2.6 0 0 1 0 3.676l-9.889 9.889a1 1 0 0 1-1.414 0Z"
-                      />
-                    </svg>
+                    <sdds-icon name="chevron_right" size="20px"></sdds-icon>
                   </button>
                 </div>
               </div>

--- a/tegel/src/components/data-table/table-footer/table-footer.tsx
+++ b/tegel/src/components/data-table/table-footer/table-footer.tsx
@@ -112,35 +112,36 @@ export class TableFooter {
 
   private previousPage = () => {
     /* Emits pagination event. */
-    const pageChangEvent = this.sddsPageChange.emit({
+    const pageChangeEvent = this.sddsPageChange.emit({
       tableId: this.tableId,
-      paginationValue: Number(this.inputElement.value) + 1,
+      paginationValue: Number(this.inputElement.value) - 1,
     });
-    /* If the change event is not prevented -> do pagination. */
-    if (pageChangEvent.defaultPrevented) {
-      /* Decrease the pagination until the first page. */
-      this.runPagination();
-    }
     /* Decreate pgination value */
     if (this.paginationValue >= 2) {
       this.paginationValue--;
+    }
+    /* If the change event is not prevented -> do pagination. */
+    if (!pageChangeEvent.defaultPrevented) {
+      /* Decrease the pagination until the first page. */
+      this.runPagination();
     }
   };
 
   private nextPage = () => {
     /* Emits pagination event. */
-    const pageChangEvent = this.sddsPageChange.emit({
+    const pageChangeEvent = this.sddsPageChange.emit({
       tableId: this.tableId,
-      paginationValue: Number(this.inputElement.value) - 1,
+      paginationValue: Number(this.inputElement.value) + 1,
     });
-    /* If the change event is not prevented -> do pagination. */
-    if (!pageChangEvent.defaultPrevented) {
-      /* Increase the pagination until the last page. */
-      this.runPagination();
-    }
+
     /* Increase pgination value */
     if (this.paginationValue <= this.numberOfPages) {
       this.paginationValue++;
+    }
+    /* If the change event is not prevented -> do pagination. */
+    if (!pageChangeEvent.defaultPrevented) {
+      /* Increase the pagination until the last page. */
+      this.runPagination();
     }
   };
 
@@ -184,7 +185,6 @@ export class TableFooter {
       } else {
         const lastResult = this.rowsPerPage * this.paginationValue;
         const firstResult = lastResult - this.rowsPerPage;
-
         if (index > firstResult && index <= lastResult) {
           item.classList.remove('sdds-table__row--hidden');
         } else {

--- a/tegel/src/components/data-table/table-header-cell/readme.md
+++ b/tegel/src/components/data-table/table-header-cell/readme.md
@@ -18,9 +18,9 @@
 
 ## Events
 
-| Event            | Description                                                                                                                                                          | Type               |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
-| `sddsSortChange` | Sends unique table identifier,column key and sorting direction to the sdds-table-body component, can also be listened to in order to implement custom sorting logic. | `CustomEvent<any>` |
+| Event            | Description                                                                                                                                                          | Type                                                                                      |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `sddsSortChange` | Sends unique table identifier,column key and sorting direction to the sdds-table-body component, can also be listened to in order to implement custom sorting logic. | `CustomEvent<{ tableId: string; columnKey: string; sortingDirection: "asc" \| "desc"; }>` |
 
 
 ----------------------------------------------

--- a/tegel/src/components/data-table/table-header-cell/table-header-cell.tsx
+++ b/tegel/src/components/data-table/table-header-cell/table-header-cell.tsx
@@ -42,7 +42,7 @@ export class TableHeaderCell {
 
   @State() textAlignState: string;
 
-  @State() sortingDirection: 'asc' | 'desc';
+  @State() sortingDirection: 'asc' | 'desc' = 'asc';
 
   @State() sortedByMyKey: boolean = false;
 
@@ -73,7 +73,11 @@ export class TableHeaderCell {
     cancelable: true,
     bubbles: true,
   })
-  sddsSortChange: EventEmitter<any>;
+  sddsSortChange: EventEmitter<{
+    tableId: string;
+    columnKey: string;
+    sortingDirection: 'asc' | 'desc';
+  }>;
 
   /** @internal Sends unique table identifier,column key and sorting direction to the sdds-table-body component, can also be listened to in order to implement custom sorting logic. */
   @Event({
@@ -96,7 +100,7 @@ export class TableHeaderCell {
   })
   internalSddsSortChange: EventEmitter<{
     tableId: string;
-    key: string;
+    columnKey: string;
     sortingDirection: 'asc' | 'desc';
   }>;
 
@@ -199,11 +203,11 @@ export class TableHeaderCell {
     this.sortedByMyKey = true;
 
     /* Emit sort event */
-    const sddsSortEvent = this.sddsSortChange.emit([
-      this.tableId,
-      this.columnKey,
-      this.sortingDirection,
-    ]);
+    const sddsSortEvent = this.sddsSortChange.emit({
+      tableId: this.tableId,
+      columnKey: this.columnKey,
+      sortingDirection: this.sortingDirection,
+    });
 
     /**
      * Emits sortButtonClicked event which is listened to by all the header-cells.
@@ -219,7 +223,7 @@ export class TableHeaderCell {
       /* Emit internal sort event, which is listened to in table-body <- this does the actual sorting.  */
       this.internalSddsSortChange.emit({
         tableId: this.tableId,
-        key: this.columnKey,
+        columnKey: this.columnKey,
         sortingDirection: this.sortingDirection,
       });
     }

--- a/tegel/src/components/data-table/table-header-cell/table-header-cell.tsx
+++ b/tegel/src/components/data-table/table-header-cell/table-header-cell.tsx
@@ -42,7 +42,7 @@ export class TableHeaderCell {
 
   @State() textAlignState: string;
 
-  @State() sortingDirection: string = '';
+  @State() sortingDirection: 'asc' | 'desc';
 
   @State() sortedByMyKey: boolean = false;
 
@@ -70,10 +70,35 @@ export class TableHeaderCell {
   @Event({
     eventName: 'sddsSortChange',
     composed: true,
-    cancelable: false,
+    cancelable: true,
     bubbles: true,
   })
   sddsSortChange: EventEmitter<any>;
+
+  /** @internal Sends unique table identifier,column key and sorting direction to the sdds-table-body component, can also be listened to in order to implement custom sorting logic. */
+  @Event({
+    eventName: 'internalSortButtonClicked',
+    composed: true,
+    cancelable: false,
+    bubbles: true,
+  })
+  internalSortButtonClicked: EventEmitter<{
+    tableId: string;
+    key: string;
+  }>;
+
+  /** @internal Sends unique table identifier,column key and sorting direction to the sdds-table-body component, can also be listened to in order to implement custom sorting logic. */
+  @Event({
+    eventName: 'internalSddsSortChange',
+    composed: true,
+    cancelable: false,
+    bubbles: true,
+  })
+  internalSddsSortChange: EventEmitter<{
+    tableId: string;
+    key: string;
+    sortingDirection: 'asc' | 'desc';
+  }>;
 
   /** @internal Sends unique table identifier, column key and text align value so the body cells with same key take the same text alignment as header cell */
   @Event({
@@ -91,7 +116,10 @@ export class TableHeaderCell {
     cancelable: false,
     bubbles: true,
   })
-  internalSddsHover: EventEmitter<any>;
+  internalSddsHover: EventEmitter<{
+    tableId: string;
+    key: string;
+  }>;
 
   @Listen('internalSddsPropChange', { target: 'body' })
   internalSddsPropChangeListener(event: CustomEvent<InternalSddsTablePropChange>) {
@@ -116,16 +144,20 @@ export class TableHeaderCell {
     }
   }
 
-  // target is set to body so other instances of same component "listen" and react to the change
-  @Listen('sddsSortChange', { target: 'body' })
-  updateOptionsContent(event: CustomEvent<any>) {
-    if (this.tableId === event.detail[0]) {
-      // grab only value at position 1 as it is the "key"
-      if (this.columnKey !== event.detail[1]) {
+  @Listen('internalSortButtonClicked', { target: 'body' })
+  updateOptionsContent(
+    event: CustomEvent<{
+      tableId: string;
+      key: string;
+    }>,
+  ) {
+    const { tableId, key } = event.detail;
+    if (this.tableId === tableId) {
+      if (this.columnKey !== key) {
         this.sortedByMyKey = false;
         // To sync with CSS transition timing
         setTimeout(() => {
-          this.sortingDirection = '';
+          this.sortingDirection = null;
         }, 200);
       }
     }
@@ -156,7 +188,7 @@ export class TableHeaderCell {
       this.host.closest('sdds-table').getElementsByTagName('sdds-table-toolbar').length >= 1;
   }
 
-  sortButtonClick = (key) => {
+  sortButtonClick = () => {
     // Toggling direction of sorting as we only use one button for sorting
     if (this.sortingDirection !== 'asc') {
       this.sortingDirection = 'asc';
@@ -165,22 +197,43 @@ export class TableHeaderCell {
     }
     // Setting to true we can set enable CSS class for "active" state of column
     this.sortedByMyKey = true;
-    // Use array to send both key and sorting direction
-    this.sddsSortChange.emit([this.tableId, key, this.sortingDirection]);
+
+    /* Emit sort event */
+    const sddsSortEvent = this.sddsSortChange.emit([
+      this.tableId,
+      this.columnKey,
+      this.sortingDirection,
+    ]);
+
+    /**
+     * Emits sortButtonClicked event which is listened to by all the header-cells.
+     * This resets the sorting button in the header-cell that was not clicked.
+     */
+    this.internalSortButtonClicked.emit({
+      tableId: this.tableId,
+      key: this.columnKey,
+    });
+
+    /* If the user has not prevented the sort event. */
+    if (!sddsSortEvent.defaultPrevented) {
+      /* Emit internal sort event, which is listened to in table-body <- this does the actual sorting.  */
+      this.internalSddsSortChange.emit({
+        tableId: this.tableId,
+        key: this.columnKey,
+        sortingDirection: this.sortingDirection,
+      });
+    }
   };
 
   headerCellContent = () => {
     if (this.sortable && !this.disableSortingBtn) {
       return (
-        <button
-          class="sdds-table__header-button"
-          onClick={() => this.sortButtonClick(this.columnKey)}
-        >
+        <button class="sdds-table__header-button" onClick={() => this.sortButtonClick()}>
           <span class="sdds-table__header-button-text" style={{ textAlign: this.textAlignState }}>
             {this.columnTitle}
           </span>
 
-          {this.sortingDirection === '' && (
+          {this.sortingDirection === null && (
             <svg
               class="sdds-table__header-button-icon"
               fill="currentColor"
@@ -205,7 +258,7 @@ export class TableHeaderCell {
             </svg>
           )}
           {/* First icon is arrow down as first set direction is ascending, clicking it again rotates the icon as we set descending order */}
-          {this.sortingDirection !== '' && (
+          {this.sortingDirection && (
             <svg
               class={`sdds-table__header-button-icon ${
                 this.sortingDirection === 'desc' ? 'sdds-table__header-button-icon--rotate' : ''
@@ -232,7 +285,10 @@ export class TableHeaderCell {
   };
 
   onHeadCellHover = (key) => {
-    this.internalSddsHover.emit([this.tableId, key]);
+    this.internalSddsHover.emit({
+      tableId: this.tableId,
+      key,
+    });
   };
 
   render() {

--- a/tegel/src/components/data-table/table-toolbar/readme.md
+++ b/tegel/src/components/data-table/table-toolbar/readme.md
@@ -15,9 +15,9 @@
 
 ## Events
 
-| Event        | Description                                                                                                                             | Type               |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
-| `sddsFilter` | Used for sending users input to main parent <sdds-table> component, can also be listened to in order to implement custom sorting logic. | `CustomEvent<any>` |
+| Event        | Description                                                                                                                             | Type                                               |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `sddsFilter` | Used for sending users input to main parent <sdds-table> component, can also be listened to in order to implement custom sorting logic. | `CustomEvent<{ tableId: string; query: string; }>` |
 
 
 ----------------------------------------------

--- a/tegel/src/components/data-table/table-toolbar/readme.md
+++ b/tegel/src/components/data-table/table-toolbar/readme.md
@@ -15,9 +15,9 @@
 
 ## Events
 
-| Event        | Description                                                                                                                             | Type                                               |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| `sddsFilter` | Used for sending users input to main parent <sdds-table> component, can also be listened to in order to implement custom sorting logic. | `CustomEvent<{ tableId: string; query: string; }>` |
+| Event              | Description                                                                                                                             | Type                                               |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `sddsFilterChange` | Used for sending users input to main parent <sdds-table> component, can also be listened to in order to implement custom sorting logic. | `CustomEvent<{ tableId: string; query: string; }>` |
 
 
 ----------------------------------------------

--- a/tegel/src/components/data-table/table-toolbar/table-toolbar.tsx
+++ b/tegel/src/components/data-table/table-toolbar/table-toolbar.tsx
@@ -47,10 +47,25 @@ export class TableToolbar {
   @Event({
     eventName: 'sddsFilter',
     composed: true,
-    cancelable: false,
+    cancelable: true,
     bubbles: true,
   })
-  sddsFilter: EventEmitter<any>;
+  sddsFilter: EventEmitter<{
+    tableId: string;
+    query: string;
+  }>;
+
+  /** @internal Internal event to notify sdds-table-body that a filter/search has been made. */
+  @Event({
+    eventName: 'internalSddsFilter',
+    composed: true,
+    cancelable: true,
+    bubbles: true,
+  })
+  internalSddsFilter: EventEmitter<{
+    tableId: string;
+    query: string;
+  }>;
 
   @Listen('internalSddsTablePropChange', { target: 'body' })
   internalSddsPropChangeListener(event: CustomEvent<InternalSddsTablePropChange>) {
@@ -81,8 +96,19 @@ export class TableToolbar {
     const searchTerm = event.currentTarget.value.toLowerCase();
     const sddsTableSearchBar = event.currentTarget.parentElement;
 
-    this.sddsFilter.emit([this.tableId, searchTerm]);
+    const sddsFilterEvent = this.sddsFilter.emit({
+      tableId: this.tableId,
+      query: searchTerm,
+    });
 
+    if (!sddsFilterEvent.defaultPrevented) {
+      this.internalSddsFilter.emit({
+        tableId: this.tableId,
+        query: searchTerm,
+      });
+    }
+
+    // What does this do?
     if (searchTerm.length > 0) {
       sddsTableSearchBar.classList.add('sdds-table__searchbar--active');
     } else {

--- a/tegel/src/components/data-table/table-toolbar/table-toolbar.tsx
+++ b/tegel/src/components/data-table/table-toolbar/table-toolbar.tsx
@@ -108,7 +108,6 @@ export class TableToolbar {
       });
     }
 
-    // What does this do?
     if (searchTerm.length > 0) {
       sddsTableSearchBar.classList.add('sdds-table__searchbar--active');
     } else {

--- a/tegel/src/components/data-table/table-toolbar/table-toolbar.tsx
+++ b/tegel/src/components/data-table/table-toolbar/table-toolbar.tsx
@@ -45,12 +45,12 @@ export class TableToolbar {
 
   /** Used for sending users input to main parent <sdds-table> component, can also be listened to in order to implement custom sorting logic. */
   @Event({
-    eventName: 'sddsFilter',
+    eventName: 'sddsFilterChange',
     composed: true,
     cancelable: true,
     bubbles: true,
   })
-  sddsFilter: EventEmitter<{
+  sddsFilterChange: EventEmitter<{
     tableId: string;
     query: string;
   }>;
@@ -96,7 +96,7 @@ export class TableToolbar {
     const searchTerm = event.currentTarget.value.toLowerCase();
     const sddsTableSearchBar = event.currentTarget.parentElement;
 
-    const sddsFilterEvent = this.sddsFilter.emit({
+    const sddsFilterEvent = this.sddsFilterChange.emit({
       tableId: this.tableId,
       query: searchTerm,
     });

--- a/tegel/src/components/icon/readme.md
+++ b/tegel/src/components/icon/readme.md
@@ -31,6 +31,7 @@
  - [sdds-side-menu-dropdown](../side-menu/webcomponent/side-menu-dropdown)
  - [sdds-slider](../slider)
  - [sdds-stepper-item](../stepper/stepper-item)
+ - [sdds-table-footer](../data-table/table-footer)
  - [sdds-textarea](../textarea)
  - [sdds-textfield](../textfield)
  - [sdds-toast](../toast)
@@ -54,6 +55,7 @@ graph TD;
   sdds-side-menu-dropdown --> sdds-icon
   sdds-slider --> sdds-icon
   sdds-stepper-item --> sdds-icon
+  sdds-table-footer --> sdds-icon
   sdds-textarea --> sdds-icon
   sdds-textfield --> sdds-icon
   sdds-toast --> sdds-icon

--- a/tegel/src/stories/Migration/Migration.stories.mdx
+++ b/tegel/src/stories/Migration/Migration.stories.mdx
@@ -1413,3 +1413,76 @@ Change all instances the toast dismiss button like shown below:
   </div>
 </div>
 ```
+
+## Data table
+
+[Web Component](/docs/components-data-table-web-component--default)
+
+#### Renamed `enablePagination` prop to `pagination`.
+
+##### What action is required?
+
+```jsx
+// Old ❌
+<sdds-table >
+  <sdds-table-header>
+    //
+  </sdds-table-header>
+  <sdds-table-body enable-dummy-data>
+    //
+  </sdds-table-body>
+  <sdds-table-footer enable-pagination ></sdds-table-footer>
+</sdds-table>
+
+// New ✅
+<sdds-table >
+  <sdds-table-header>
+    //
+  </sdds-table-header>
+  <sdds-table-body enable-dummy-data>
+    //
+  </sdds-table-body>
+  <sdds-table-footer pagination ></sdds-table-footer>
+</sdds-table>
+```
+
+#### Removed `disableFilteringFunction`, `disableSortingFunction` and `enableClientPagination`.
+
+These props were previously available on the data table component to allow for users to implement
+their own filter/sort and pagination logic. Now we have removed these props, and instead made the
+events that these are emitting cencelable.
+
+The events are: 'sddsPageChange', 'sddsSortChange', 'sddsFilterChange'
+
+##### What action is required?
+
+```jsx
+// Old ❌
+<sdds-table >
+  <sdds-table-header>
+    //
+  </sdds-table-header>
+  <sdds-table-body enable-dummy-data>
+    //
+  </sdds-table-body>
+  <sdds-table-footer pagination enable-client-pagination rows-per-page="4"></sdds-table-footer>
+</sdds-table>
+
+// New ✅
+<sdds-table >
+  <sdds-table-header>
+    //
+  </sdds-table-header>
+  <sdds-table-body enable-dummy-data>
+    //
+  </sdds-table-body>
+  <sdds-table-footer pagination rows-per-page="4"></sdds-table-footer>
+</sdds-table>
+
+<script>
+  document.addEventListener('sddsPageChange', (event) => {
+    event.preventDefault()
+  })
+
+</script>
+```


### PR DESCRIPTION
**Describe pull-request**  
This PR refactors the events in the data-table. It also removes the following props: 
`disableFilteringFunction`, `disableSortingFunction` and `enableClientPagination`

It introduces the following events:  `sddsPageChange`, `sddsSortChange`, `sddsFilterChange`
These can be prevented by a user to achieve the same effect as the props above. 

This is more inline with how other components work.

Also added a section in the migration docs to outline the breaking changes.

**Solving issue**  
Fixes: https://tegel.atlassian.net/browse/DTS-1479

**How to test**  
1. Go to storybook link below
2. Check in Data Table -> Web Components -> Sorting, Filtering, Pagination
3. Trigger the event for the corresponding story and look in to console for a log of the event. 
4. Check out the branch
5. Add preventDefault() to the event and see it fail. 

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
