### PR TITLE
feat(side-menu): make the collapse event cancelable

### DIFF
--- a/tegel/src/components/side-menu/webcomponent/readme.md
+++ b/tegel/src/components/side-menu/webcomponent/readme.md
@@ -40,15 +40,15 @@ Example:
 | Property     | Attribute    | Description                                                                     | Type      | Default |
 | ------------ | ------------ | ------------------------------------------------------------------------------- | --------- | ------- |
 | `collapsed`  | `collapsed`  | If the side menu is collapsed. Only a persistent desktop menu can be collapsed. | `boolean` | `false` |
-| `open`       | `open`       | If the side menu is open or not.                                                | `boolean` | `false` |
+| `open`       | `open`       | Applicable only for mobile menu usage. If the side menu is open or not.         | `boolean` | `false` |
 | `persistent` | `persistent` | If the side menu should always be shown on desktop screens to the side.         | `boolean` | `false` |
 
 
 ## Events
 
-| Event                   | Description                                     | Type                          |
-| ----------------------- | ----------------------------------------------- | ----------------------------- |
-| `sddsSideMenuCollapsed` | Broadcasts collapsed state to child components. | `CustomEvent<CollapsedEvent>` |
+| Event          | Description                                            | Type                                   |
+| -------------- | ------------------------------------------------------ | -------------------------------------- |
+| `sddsCollapse` | Event that is emitted when the side menu is collapsed. | `CustomEvent<{ collapsed: boolean; }>` |
 
 
 ----------------------------------------------

--- a/tegel/src/components/side-menu/webcomponent/readme.md
+++ b/tegel/src/components/side-menu/webcomponent/readme.md
@@ -37,11 +37,11 @@ Example:
 
 ## Properties
 
-| Property     | Attribute    | Description                                                                     | Type      | Default |
-| ------------ | ------------ | ------------------------------------------------------------------------------- | --------- | ------- |
-| `collapsed`  | `collapsed`  | If the side menu is collapsed. Only a persistent desktop menu can be collapsed. | `boolean` | `false` |
-| `open`       | `open`       | Applicable only for mobile menu usage. If the side menu is open or not.         | `boolean` | `false` |
-| `persistent` | `persistent` | If the side menu should always be shown on desktop screens to the side.         | `boolean` | `false` |
+| Property     | Attribute    | Description                                                                                                                                                                                       | Type      | Default |
+| ------------ | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------- |
+| `collapsed`  | `collapsed`  | If the side menu is collapsed. Only a persistent desktop menu can be collapsed. NOTE: Only use this if you have prevented the automatic collapsing with preventDefault on the sddsCollapse event. | `boolean` | `false` |
+| `open`       | `open`       | Applicable only for mobile. If the side menu is open or not.                                                                                                                                      | `boolean` | `false` |
+| `persistent` | `persistent` | Applicable only for desktop. If the side menu should always be shown.                                                                                                                             | `boolean` | `false` |
 
 
 ## Events

--- a/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/readme.md
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/readme.md
@@ -11,6 +11,13 @@ Example:
 <!-- Auto Generated Below -->
 
 
+## Events
+
+| Event          | Description                                                    | Type                                   |
+| -------------- | -------------------------------------------------------------- | -------------------------------------- |
+| `sddsCollapse` | Event when is broadcasted when the collapse button is clicked. | `CustomEvent<{ collapsed: boolean; }>` |
+
+
 ## Dependencies
 
 ### Depends on

--- a/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/readme.md
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/readme.md
@@ -13,9 +13,9 @@ Example:
 
 ## Events
 
-| Event          | Description                                                    | Type                                   |
-| -------------- | -------------------------------------------------------------- | -------------------------------------- |
-| `sddsCollapse` | Event when is broadcasted when the collapse button is clicked. | `CustomEvent<{ collapsed: boolean; }>` |
+| Event          | Description                                                                                                                                                      | Type                                   |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| `sddsCollapse` | Event that is broadcasted when the collapse button is clicked. Prevent it to disable automatic collapsing, and set the collapsed prop on the side menu yourself. | `CustomEvent<{ collapsed: boolean; }>` |
 
 
 ## Dependencies

--- a/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.scss
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.scss
@@ -23,10 +23,6 @@
       position: absolute;
       left: 50%;
     }
-
-    .test {
-      display: none;
-    }
   }
 }
 

--- a/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.scss
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.scss
@@ -23,6 +23,10 @@
       position: absolute;
       left: 50%;
     }
+
+    .test {
+      display: none;
+    }
   }
 }
 

--- a/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.tsx
@@ -13,7 +13,8 @@ export class SideMenuCollapseButton {
 
   private sideMenuEl: HTMLSddsSideMenuElement;
 
-  /** Event that is broadcasted when the collapsed state changes. */
+  /** Event that is broadcasted when the collapse button is clicked.
+   * Prevent it to disable automatic collapsing, and set the collapsed prop on the side menu yourself. */
   @Event({
     eventName: 'sddsCollapse',
     bubbles: true,
@@ -22,7 +23,7 @@ export class SideMenuCollapseButton {
   })
   sddsCollapse: EventEmitter<CollapseEvent>;
 
-  /** @internal Event when is broadcasted when the collpse button is clicked, contains the future collapsed state of the side menu. */
+  /** @internal Event that is broadcasted when the internal collapse state changes. Contains the future of the collapse state. */
   @Event({
     eventName: 'internalSddsCollapse',
     bubbles: true,

--- a/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.tsx
@@ -45,14 +45,12 @@ export class SideMenuCollapseButton {
       this.internalSddsCollapse.emit({
         collapsed: this.collapsed,
       });
-      this.collapsed = !this.collapsed;
     }
   };
 
-  @Listen('InternalSddsSideMenuPropChange', { target: 'body' })
-  collapsedSideMenuEventHandler() {
-    this.collapsed = this.sideMenuEl.collapsed;
-    console.log('propschange', this.collapsed);
+  @Listen('internalSddsSideMenuPropChange', { target: 'body' })
+  collapsedSideMenuEventHandeler(event: CustomEvent<CollapseEvent>) {
+    this.collapsed = event.detail.collapsed;
   }
 
   connectedCallback() {

--- a/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.tsx
@@ -45,12 +45,14 @@ export class SideMenuCollapseButton {
       this.internalSddsCollapse.emit({
         collapsed: this.collapsed,
       });
+      this.collapsed = !this.collapsed;
     }
   };
 
   @Listen('InternalSddsSideMenuPropChange', { target: 'body' })
   collapsedSideMenuEventHandler() {
     this.collapsed = this.sideMenuEl.collapsed;
+    console.log('propschange', this.collapsed);
   }
 
   connectedCallback() {

--- a/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.tsx
@@ -43,12 +43,14 @@ export class SideMenuCollapseButton {
       this.internalSddsCollapse.emit({
         collapsed: !this.collapsed,
       });
+      this.collapsed = !this.collapsed;
     }
   };
 
   @Listen('InternalSddsSideMenuPropChange', { target: 'body' })
   collapsedSideMenuEventHandler() {
     this.collapsed = this.sideMenuEl.collapsed;
+    console.log('propschange', this.collapsed);
   }
 
   connectedCallback() {

--- a/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.tsx
@@ -17,7 +17,7 @@ export class SideMenuCollapseButton {
    * Prevent it to disable automatic collapsing, and set the collapsed prop on the side menu yourself. */
   @Event({
     eventName: 'sddsCollapse',
-    bubbles: true,
+    bubbles: false,
     cancelable: true,
     composed: true,
   })
@@ -60,7 +60,13 @@ export class SideMenuCollapseButton {
 
   render() {
     return (
-      <Host role="button" tabindex="0">
+      <Host
+        role="button"
+        tabindex="0"
+        onClick={() => {
+          this.handleClick();
+        }}
+      >
         <div
           class={{
             'wrapper': true,
@@ -72,11 +78,7 @@ export class SideMenuCollapseButton {
               button: true,
             }}
           >
-            <a
-              onClick={() => {
-                this.handleClick();
-              }}
-            >
+            <a>
               <svg
                 class="icon"
                 slot="icon"

--- a/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.tsx
@@ -46,9 +46,9 @@ export class SideMenuCollapseButton {
     }
   };
 
-  @Listen('internalSddsCollapse', { target: 'body' })
-  collapsedSideMenuEventHandler(event: CustomEvent<CollapseEvent>) {
-    this.collapsed = event.detail.collapsed;
+  @Listen('InternalSddsSideMenuPropChange', { target: 'body' })
+  collapsedSideMenuEventHandler() {
+    this.collapsed = this.sideMenuEl.collapsed;
   }
 
   connectedCallback() {

--- a/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.tsx
@@ -48,9 +48,9 @@ export class SideMenuCollapseButton {
     }
   };
 
-  @Listen('internalSddsCollapse', { target: 'body' })
-  collapsedSideMenuEventHandler(event: CustomEvent<CollapseEvent>) {
-    this.collapsed = event.detail.collapsed;
+  @Listen('InternalSddsSideMenuPropChange', { target: 'body' })
+  collapsedSideMenuEventHandler() {
+    this.collapsed = this.sideMenuEl.collapsed;
   }
 
   connectedCallback() {

--- a/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.tsx
@@ -48,8 +48,8 @@ export class SideMenuCollapseButton {
     }
   };
 
-  @Listen('internalSddsSideMenuPropChange', { target: 'body' })
-  collapsedSideMenuEventHandeler(event: CustomEvent<CollapseEvent>) {
+  @Listen('internalSddsCollapse', { target: 'body' })
+  collapsedSideMenuEventHandler(event: CustomEvent<CollapseEvent>) {
     this.collapsed = event.detail.collapsed;
   }
 

--- a/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.tsx
@@ -40,17 +40,16 @@ export class SideMenuCollapseButton {
     /** If the public event was not prevented. */
     if (!sddsCollapseEvent.defaultPrevented) {
       /** Emit internal event that is listened to by other side-menu components */
-      this.internalSddsCollapse.emit({
-        collapsed: !this.collapsed,
-      });
       this.collapsed = !this.collapsed;
+      this.internalSddsCollapse.emit({
+        collapsed: this.collapsed,
+      });
     }
   };
 
-  @Listen('InternalSddsSideMenuPropChange', { target: 'body' })
-  collapsedSideMenuEventHandler() {
-    this.collapsed = this.sideMenuEl.collapsed;
-    console.log('propschange', this.collapsed);
+  @Listen('internalSddsSideMenuPropChange', { target: 'body' })
+  collapsedSideMenuEventHandeler(event: CustomEvent<CollapseEvent>) {
+    this.collapsed = event.detail.collapsed;
   }
 
   connectedCallback() {

--- a/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.tsx
@@ -13,7 +13,7 @@ export class SideMenuCollapseButton {
 
   private sideMenuEl: HTMLSddsSideMenuElement;
 
-  /** Event when is broadcasted when the collapse button is clicked. */
+  /** Event that is broadcasted when the collapsed state changes. */
   @Event({
     eventName: 'sddsCollapse',
     bubbles: true,

--- a/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-collapse-button/side-menu-collapse-button.tsx
@@ -49,7 +49,7 @@ export class SideMenuCollapseButton {
   };
 
   @Listen('internalSddsSideMenuPropChange', { target: 'body' })
-  collapsedSideMenuEventHandeler(event: CustomEvent<CollapseEvent>) {
+  collapseSideMenuEventHandler(event: CustomEvent<CollapseEvent>) {
     this.collapsed = event.detail.collapsed;
   }
 

--- a/tegel/src/components/side-menu/webcomponent/side-menu-dropdown-list-item/side-menu-dropdown-list-item.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-dropdown-list-item/side-menu-dropdown-list-item.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, h, Host, Listen, Prop, State } from '@stencil/core';
-import { CollapsedEvent } from '../side-menu';
+import { CollapseEvent } from '../side-menu';
 
 @Component({
   tag: 'sdds-side-menu-dropdown-list-item',
@@ -18,14 +18,13 @@ export class SideMenuDropdownListItem {
 
   private sideMenuEl: HTMLSddsSideMenuElement;
 
-  @Listen('sddsSideMenuCollapsed', { target: 'body' })
-  collapsedSideMenuEventHandeler(event: CustomEvent<CollapsedEvent>) {
+  @Listen('internalSddsCollapse', { target: 'body' })
+  collapsedSideMenuEventHandeler(event: CustomEvent<CollapseEvent>) {
     this.collapsed = event.detail.collapsed;
   }
 
   connectedCallback() {
     this.sideMenuEl = this.host.closest('sdds-side-menu');
-    this.collapsed = this.sideMenuEl.collapsed;
   }
 
   componentDidLoad() {

--- a/tegel/src/components/side-menu/webcomponent/side-menu-dropdown-list-item/side-menu-dropdown-list-item.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-dropdown-list-item/side-menu-dropdown-list-item.tsx
@@ -18,7 +18,7 @@ export class SideMenuDropdownListItem {
 
   private sideMenuEl: HTMLSddsSideMenuElement;
 
-  @Listen('internalSddsSideMenuPropChange', { target: 'body' })
+  @Listen('internalSddsCollapse', { target: 'body' })
   collapsedSideMenuEventHandeler(event: CustomEvent<CollapseEvent>) {
     this.collapsed = event.detail.collapsed;
   }

--- a/tegel/src/components/side-menu/webcomponent/side-menu-dropdown-list-item/side-menu-dropdown-list-item.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-dropdown-list-item/side-menu-dropdown-list-item.tsx
@@ -18,7 +18,7 @@ export class SideMenuDropdownListItem {
 
   private sideMenuEl: HTMLSddsSideMenuElement;
 
-  @Listen('internalSddsCollapse', { target: 'body' })
+  @Listen('internalSddsSideMenuPropChange', { target: 'body' })
   collapsedSideMenuEventHandeler(event: CustomEvent<CollapseEvent>) {
     this.collapsed = event.detail.collapsed;
   }

--- a/tegel/src/components/side-menu/webcomponent/side-menu-dropdown-list-item/side-menu-dropdown-list-item.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-dropdown-list-item/side-menu-dropdown-list-item.tsx
@@ -19,7 +19,7 @@ export class SideMenuDropdownListItem {
   private sideMenuEl: HTMLSddsSideMenuElement;
 
   @Listen('internalSddsSideMenuPropChange', { target: 'body' })
-  collapsedSideMenuEventHandeler(event: CustomEvent<CollapseEvent>) {
+  collapseSideMenuEventHandler(event: CustomEvent<CollapseEvent>) {
     this.collapsed = event.detail.collapsed;
   }
 

--- a/tegel/src/components/side-menu/webcomponent/side-menu-dropdown-list/side-menu-dropdown-list.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-dropdown-list/side-menu-dropdown-list.tsx
@@ -13,7 +13,7 @@ export class SideMenuDropdownList {
 
   private sideMenuEl: HTMLSddsSideMenuElement;
 
-  @Listen('internalSddsSideMenuPropChange', { target: 'body' })
+  @Listen('internalSddsCollapse', { target: 'body' })
   collapsedSideMenuEventHandler(event: CustomEvent<CollapseEvent>) {
     this.collapsed = event.detail.collapsed;
   }

--- a/tegel/src/components/side-menu/webcomponent/side-menu-dropdown-list/side-menu-dropdown-list.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-dropdown-list/side-menu-dropdown-list.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, h, Listen, Element, State } from '@stencil/core';
-import { CollapsedEvent } from '../side-menu';
+import { CollapseEvent } from '../side-menu';
 
 @Component({
   tag: 'sdds-side-menu-dropdown-list',
@@ -13,14 +13,13 @@ export class SideMenuDropdownList {
 
   private sideMenuEl: HTMLSddsSideMenuElement;
 
-  @Listen('sddsSideMenuCollapsed', { target: 'body' })
-  collapsedSideMenuEventHandler(event: CustomEvent<CollapsedEvent>) {
+  @Listen('internalSddsCollapse', { target: 'body' })
+  collapsedSideMenuEventHandler(event: CustomEvent<CollapseEvent>) {
     this.collapsed = event.detail.collapsed;
   }
 
   connectedCallback() {
     this.sideMenuEl = this.host.closest('sdds-side-menu');
-    this.collapsed = this.sideMenuEl.collapsed;
   }
 
   render() {

--- a/tegel/src/components/side-menu/webcomponent/side-menu-dropdown-list/side-menu-dropdown-list.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-dropdown-list/side-menu-dropdown-list.tsx
@@ -13,7 +13,7 @@ export class SideMenuDropdownList {
 
   private sideMenuEl: HTMLSddsSideMenuElement;
 
-  @Listen('internalSddsCollapse', { target: 'body' })
+  @Listen('internalSddsSideMenuPropChange', { target: 'body' })
   collapsedSideMenuEventHandler(event: CustomEvent<CollapseEvent>) {
     this.collapsed = event.detail.collapsed;
   }

--- a/tegel/src/components/side-menu/webcomponent/side-menu-dropdown/side-menu-dropdown.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-dropdown/side-menu-dropdown.tsx
@@ -27,7 +27,7 @@ export class SideMenuDropdown {
 
   private sideMenuEl: HTMLSddsSideMenuElement;
 
-  @Listen('internalSddsSideMenuPropChange', { target: 'body' })
+  @Listen('internalSddsCollapse', { target: 'body' })
   collapsedSideMenuEventHandler(event: CustomEvent<CollapseEvent>) {
     this.collapsed = event.detail.collapsed;
   }

--- a/tegel/src/components/side-menu/webcomponent/side-menu-dropdown/side-menu-dropdown.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-dropdown/side-menu-dropdown.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Fragment, h, Host, Listen, Prop, State } from '@stencil/core';
-import { CollapsedEvent } from '../side-menu';
+import { CollapseEvent } from '../side-menu';
 
 @Component({
   tag: 'sdds-side-menu-dropdown',
@@ -27,8 +27,8 @@ export class SideMenuDropdown {
 
   private sideMenuEl: HTMLSddsSideMenuElement;
 
-  @Listen('sddsSideMenuCollapsed', { target: 'body' })
-  collapsedSideMenuEventHandler(event: CustomEvent<CollapsedEvent>) {
+  @Listen('internalSddsCollapse', { target: 'body' })
+  collapsedSideMenuEventHandler(event: CustomEvent<CollapseEvent>) {
     this.collapsed = event.detail.collapsed;
   }
 
@@ -72,7 +72,6 @@ export class SideMenuDropdown {
 
   connectedCallback() {
     this.sideMenuEl = this.host.closest('sdds-side-menu');
-    this.collapsed = this.sideMenuEl.collapsed;
     this.open = this.defaultOpen;
   }
 

--- a/tegel/src/components/side-menu/webcomponent/side-menu-dropdown/side-menu-dropdown.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-dropdown/side-menu-dropdown.tsx
@@ -27,7 +27,7 @@ export class SideMenuDropdown {
 
   private sideMenuEl: HTMLSddsSideMenuElement;
 
-  @Listen('internalSddsCollapse', { target: 'body' })
+  @Listen('internalSddsSideMenuPropChange', { target: 'body' })
   collapsedSideMenuEventHandler(event: CustomEvent<CollapseEvent>) {
     this.collapsed = event.detail.collapsed;
   }

--- a/tegel/src/components/side-menu/webcomponent/side-menu-item/side-menu-item.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-item/side-menu-item.tsx
@@ -68,7 +68,7 @@ export class SddsSideMenuItem {
     this.slotEl.addEventListener('slotchange', this.updateSlottedElements);
   }
 
-  @Listen('internalSddsCollapse', { target: 'body' })
+  @Listen('internalSddsSideMenuPropChange', { target: 'body' })
   collapsedSideMenuEventHandeler(event: CustomEvent<CollapseEvent>) {
     this.collapsed = event.detail.collapsed;
     this.updateSlottedElements();

--- a/tegel/src/components/side-menu/webcomponent/side-menu-item/side-menu-item.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-item/side-menu-item.tsx
@@ -69,7 +69,7 @@ export class SddsSideMenuItem {
   }
 
   @Listen('internalSddsSideMenuPropChange', { target: 'body' })
-  collapsedSideMenuEventHandeler(event: CustomEvent<CollapseEvent>) {
+  collapseSideMenuEventHandler(event: CustomEvent<CollapseEvent>) {
     this.collapsed = event.detail.collapsed;
     this.updateSlottedElements();
   }

--- a/tegel/src/components/side-menu/webcomponent/side-menu-item/side-menu-item.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-item/side-menu-item.tsx
@@ -1,5 +1,5 @@
 import { Component, h, Host, Element, Listen, Prop, State } from '@stencil/core';
-import { CollapsedEvent } from '../side-menu';
+import { CollapseEvent } from '../side-menu';
 import { dfs } from '../../../../utils/utils';
 
 @Component({
@@ -60,7 +60,6 @@ export class SddsSideMenuItem {
     // closest() will return null if side-menu-item is inside a shadowRoot that
     // does not contain a side-menu. This is the case for the side-menu-dropdown.
     this.sideMenuEl = this.host.closest('sdds-side-menu');
-    this.collapsed = this.sideMenuEl?.collapsed;
   }
 
   componentDidLoad() {
@@ -69,8 +68,8 @@ export class SddsSideMenuItem {
     this.slotEl.addEventListener('slotchange', this.updateSlottedElements);
   }
 
-  @Listen('sddsSideMenuCollapsed', { target: 'body' })
-  collapsedSideMenuEventHandeler(event: CustomEvent<CollapsedEvent>) {
+  @Listen('internalSddsCollapse', { target: 'body' })
+  collapsedSideMenuEventHandeler(event: CustomEvent<CollapseEvent>) {
     this.collapsed = event.detail.collapsed;
     this.updateSlottedElements();
   }

--- a/tegel/src/components/side-menu/webcomponent/side-menu-item/side-menu-item.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-item/side-menu-item.tsx
@@ -68,7 +68,7 @@ export class SddsSideMenuItem {
     this.slotEl.addEventListener('slotchange', this.updateSlottedElements);
   }
 
-  @Listen('internalSddsSideMenuPropChange', { target: 'body' })
+  @Listen('internalSddsCollapse', { target: 'body' })
   collapsedSideMenuEventHandeler(event: CustomEvent<CollapseEvent>) {
     this.collapsed = event.detail.collapsed;
     this.updateSlottedElements();

--- a/tegel/src/components/side-menu/webcomponent/side-menu-webcomponent.stories.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-webcomponent.stories.tsx
@@ -199,10 +199,15 @@ const Template = ({ persistent, collapsible }) =>
         <p><i>Note: The side menu is sticky, and should not scroll with the main content of the page.</i></p>
 
         <p><i>Note: The collapse button is optional.</i></p>
+        <button id="test">Test</button>
       </main>
     </div>
   </div>
   <script>
+  sideMenu = document.querySelector('sdds-side-menu')
+        document.querySelector('#test').addEventListener('click', ()=> {
+          sideMenu.collapsed = !sideMenu.collapsed;
+        })
     document.addEventListener('sddsCollapse', (event) => {
       console.log(event)
     })

--- a/tegel/src/components/side-menu/webcomponent/side-menu-webcomponent.stories.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-webcomponent.stories.tsx
@@ -197,10 +197,15 @@ const Template = ({ persistent, collapsible }) =>
         <p><i>Note: The side menu is sticky, and should not scroll with the main content of the page.</i></p>
 
         <p><i>Note: The collapse button is optional.</i></p>
+        <button id="test">Test</button>
       </main>
     </div>
   </div>
   <script>
+  sideMenu = document.querySelector('sdds-side-menu')
+        document.querySelector('#test').addEventListener('click', ()=> {
+          sideMenu.collapsed = !sideMenu.collapsed;
+        })
     document.addEventListener('sddsCollapse', (event) => {
       console.log(event)
     })

--- a/tegel/src/components/side-menu/webcomponent/side-menu-webcomponent.stories.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-webcomponent.stories.tsx
@@ -197,7 +197,6 @@ const Template = ({ persistent, collapsible }) =>
         <p><i>Note: The side menu is sticky, and should not scroll with the main content of the page.</i></p>
 
         <p><i>Note: The collapse button is optional.</i></p>
-        <button id="test">Test</button>
       </main>
     </div>
   </div>

--- a/tegel/src/components/side-menu/webcomponent/side-menu-webcomponent.stories.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-webcomponent.stories.tsx
@@ -89,8 +89,9 @@ const Template = ({ persistent, collapsible }) =>
       display: flex;
       flex-grow: 1;
     }
-    ${persistent
-      ? `
+    ${
+      persistent
+        ? `
         /* the lg breakpoint is used here to match the breakpoint used in the header */
     @media (min-width: 992px) {
       #demo-side-menu {
@@ -101,7 +102,7 @@ const Template = ({ persistent, collapsible }) =>
         left: 0px;
       }
     }`
-      : ''
+        : ''
     }
     /* If an extra button in the header is required except on */
     /* very narrow screens, you can use classes like these: */
@@ -181,12 +182,13 @@ const Template = ({ persistent, collapsible }) =>
           </button>
         </sdds-side-menu-item>
 
-        ${collapsible
-      ? `<sdds-side-menu-collapse-button slot="sticky-end">
+        ${
+          collapsible
+            ? `<sdds-side-menu-collapse-button slot="sticky-end">
           Collapse  
         </sdds-side-menu-collapse-button>`
-      : ''
-    }
+            : ''
+        }
 
       </sdds-side-menu>
 
@@ -197,16 +199,17 @@ const Template = ({ persistent, collapsible }) =>
         <p><i>Note: The side menu is sticky, and should not scroll with the main content of the page.</i></p>
 
         <p><i>Note: The collapse button is optional.</i></p>
-        <button id="test">Test</button>
+        <button id="test">Toggle the collapsed state pragramatically</button>
       </main>
     </div>
   </div>
   <script>
-  sideMenu = document.querySelector('sdds-side-menu')
-        document.querySelector('#test').addEventListener('click', ()=> {
-          sideMenu.collapsed = !sideMenu.collapsed;
-        })
-    document.addEventListener('sddsCollapse', (event) => {
+    sideMenu = document.querySelector('sdds-side-menu')
+    document.querySelector('#test').addEventListener('click', ()=> {
+      sideMenu.collapsed = !sideMenu.collapsed;
+    })
+
+    document.querySelector('sdds-side-menu-collapse-button').addEventListener('sddsCollapse', (event) => {
       console.log(event)
     })
   </script>

--- a/tegel/src/components/side-menu/webcomponent/side-menu-webcomponent.stories.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-webcomponent.stories.tsx
@@ -199,7 +199,6 @@ const Template = ({ persistent, collapsible }) =>
         <p><i>Note: The side menu is sticky, and should not scroll with the main content of the page.</i></p>
 
         <p><i>Note: The collapse button is optional.</i></p>
-        <button id="test">Test</button>
       </main>
     </div>
   </div>

--- a/tegel/src/components/side-menu/webcomponent/side-menu-webcomponent.stories.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-webcomponent.stories.tsx
@@ -184,7 +184,9 @@ const Template = ({ persistent, collapsible }) =>
 
         ${
           collapsible
-            ? `<sdds-side-menu-collapse-button slot="sticky-end" onclick="demoSideMenu.collapsed = !demoSideMenu.collapsed;"></sdds-side-menu-collapse-button>`
+            ? `<sdds-side-menu-collapse-button slot="sticky-end">
+          Collapse  
+        </sdds-side-menu-collapse-button>`
             : ''
         }
 
@@ -197,10 +199,15 @@ const Template = ({ persistent, collapsible }) =>
         <p><i>Note: The side menu is sticky, and should not scroll with the main content of the page.</i></p>
 
         <p><i>Note: The collapse button is optional.</i></p>
-        
+        <button id="test">Test</button>
       </main>
     </div>
   </div>
+  <script>
+    document.addEventListener('sddsCollapse', (event) => {
+      console.log(event)
+    })
+  </script>
   `,
   );
 

--- a/tegel/src/components/side-menu/webcomponent/side-menu-webcomponent.stories.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-webcomponent.stories.tsx
@@ -199,7 +199,7 @@ const Template = ({ persistent, collapsible }) =>
         <p><i>Note: The side menu is sticky, and should not scroll with the main content of the page.</i></p>
 
         <p><i>Note: The collapse button is optional.</i></p>
-        <button id="test">Toggle the collapsed state pragramatically</button>
+        <button id="test">Toggle the collapsed state programatically</button>
       </main>
     </div>
   </div>

--- a/tegel/src/components/side-menu/webcomponent/side-menu-webcomponent.stories.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu-webcomponent.stories.tsx
@@ -89,9 +89,8 @@ const Template = ({ persistent, collapsible }) =>
       display: flex;
       flex-grow: 1;
     }
-    ${
-      persistent
-        ? `
+    ${persistent
+      ? `
         /* the lg breakpoint is used here to match the breakpoint used in the header */
     @media (min-width: 992px) {
       #demo-side-menu {
@@ -102,7 +101,7 @@ const Template = ({ persistent, collapsible }) =>
         left: 0px;
       }
     }`
-        : ''
+      : ''
     }
     /* If an extra button in the header is required except on */
     /* very narrow screens, you can use classes like these: */
@@ -182,13 +181,12 @@ const Template = ({ persistent, collapsible }) =>
           </button>
         </sdds-side-menu-item>
 
-        ${
-          collapsible
-            ? `<sdds-side-menu-collapse-button slot="sticky-end">
+        ${collapsible
+      ? `<sdds-side-menu-collapse-button slot="sticky-end">
           Collapse  
         </sdds-side-menu-collapse-button>`
-            : ''
-        }
+      : ''
+    }
 
       </sdds-side-menu>
 
@@ -204,10 +202,6 @@ const Template = ({ persistent, collapsible }) =>
     </div>
   </div>
   <script>
-  sideMenu = document.querySelector('sdds-side-menu')
-        document.querySelector('#test').addEventListener('click', ()=> {
-          sideMenu.collapsed = !sideMenu.collapsed;
-        })
     document.addEventListener('sddsCollapse', (event) => {
       console.log(event)
     })

--- a/tegel/src/components/side-menu/webcomponent/side-menu.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu.tsx
@@ -16,6 +16,14 @@ export type CollapseEvent = {
   collapsed: boolean;
 };
 
+type Props = {
+  collapsed: boolean;
+};
+
+export type InternalSddsSideMenuPropChange = {
+  changed: Array<keyof Props>;
+} & Partial<Props>;
+
 const GRID_LG_BREAKPOINT = '992px';
 const OPENING_ANIMATION_DURATION = 400;
 const INITIALIZE_ANIMATION_DELAY = 500;
@@ -94,7 +102,11 @@ export class SddsSideMenu {
   @Watch('collapsed')
   onCollapsedChange(newVal: boolean) {
     /** Emits the internal collapse event when the prop has changed. */
-    this.internalSddsSideMenuPropChange.emit();
+    this.internalSddsSideMenuPropChange.emit({
+      changed: ['collapsed'],
+      collapsed: newVal,
+    });
+
     this.isCollapsed = newVal;
   }
 
@@ -131,7 +143,7 @@ export class SddsSideMenu {
     cancelable: false,
     composed: true,
   })
-  internalSddsSideMenuPropChange: EventEmitter;
+  internalSddsSideMenuPropChange: EventEmitter<InternalSddsSideMenuPropChange>;
 
   @Listen('internalSddsCollapse', { target: 'body' })
   collapsedSideMenuEventHandler(event: CustomEvent<CollapseEvent>) {

--- a/tegel/src/components/side-menu/webcomponent/side-menu.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu.tsx
@@ -16,6 +16,14 @@ export type CollapseEvent = {
   collapsed: boolean;
 };
 
+type Props = {
+  collapsed: boolean;
+};
+
+export type InternalSddsSideMenuPropChange = {
+  changed: Array<keyof Props>;
+} & Partial<Props>;
+
 const GRID_LG_BREAKPOINT = '992px';
 const OPENING_ANIMATION_DURATION = 400;
 const INITIALIZE_ANIMATION_DELAY = 500;
@@ -93,7 +101,11 @@ export class SddsSideMenu {
   @Watch('collapsed')
   onCollapsedChange(newVal: boolean) {
     /** Emits the internal collapse event when the prop has changed. */
-    this.internalSddsSideMenuPropChange.emit();
+    this.internalSddsSideMenuPropChange.emit({
+      changed: ['collapsed'],
+      collapsed: newVal,
+    });
+
     this.isCollapsed = newVal;
   }
 
@@ -130,7 +142,7 @@ export class SddsSideMenu {
     cancelable: false,
     composed: true,
   })
-  internalSddsSideMenuPropChange: EventEmitter;
+  internalSddsSideMenuPropChange: EventEmitter<InternalSddsSideMenuPropChange>;
 
   @Listen('internalSddsCollapse', { target: 'body' })
   collapsedSideMenuEventHandler(event: CustomEvent<CollapseEvent>) {

--- a/tegel/src/components/side-menu/webcomponent/side-menu.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu.tsx
@@ -36,13 +36,14 @@ const INITIALIZE_ANIMATION_DELAY = 500;
 export class SddsSideMenu {
   @Element() host: HTMLSddsSideMenuElement;
 
-  /** Applicable only for mobile menu usage. If the side menu is open or not. */
+  /** Applicable only for mobile. If the side menu is open or not. */
   @Prop({ reflect: true }) open: boolean = false;
 
-  /** If the side menu should always be shown on desktop screens to the side. */
+  /** Applicable only for desktop. If the side menu should always be shown. */
   @Prop({ reflect: true }) persistent: boolean = false;
 
-  /** If the side menu is collapsed. Only a persistent desktop menu can be collapsed. */
+  /** If the side menu is collapsed. Only a persistent desktop menu can be collapsed.
+   * NOTE: Only use this if you have prevented the automatic collapsing with preventDefault on the sddsCollapse event. */
   @Prop({ reflect: true }) collapsed: boolean = false;
 
   @State() isUpperSlotEmpty: boolean = false;

--- a/tegel/src/components/side-menu/webcomponent/side-menu.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu.tsx
@@ -36,7 +36,7 @@ const INITIALIZE_ANIMATION_DELAY = 500;
 export class SddsSideMenu {
   @Element() host: HTMLSddsSideMenuElement;
 
-  /** Applicable only for mobile menu usage. If the side menu is open or not. */
+  /** Applicable only for mobile. If the side menu is open or not. */
   @Prop({ reflect: true }) open: boolean = false;
 
   /** Applicable only for desktop. If the side menu should always be shown. */

--- a/tegel/src/components/side-menu/webcomponent/side-menu.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu.tsx
@@ -16,14 +16,6 @@ export type CollapseEvent = {
   collapsed: boolean;
 };
 
-type Props = {
-  collapsed: boolean;
-};
-
-export type InternalSddsSideMenuPropChange = {
-  changed: Array<keyof Props>;
-} & Partial<Props>;
-
 const GRID_LG_BREAKPOINT = '992px';
 const OPENING_ANIMATION_DURATION = 400;
 const INITIALIZE_ANIMATION_DELAY = 500;
@@ -36,7 +28,25 @@ const INITIALIZE_ANIMATION_DELAY = 500;
 export class SddsSideMenu {
   @Element() host: HTMLSddsSideMenuElement;
 
-  /** Applicable only for mobile. If the side menu is open or not. */
+  /** Event that is emitted when the side menu is collapsed. */
+  @Event({
+    eventName: 'sddsCollapse',
+    bubbles: true,
+    composed: true,
+    cancelable: true,
+  })
+  sddsCollapse: EventEmitter<CollapseEvent>;
+
+  /** @internal Broadcasts collapsed state to child components. */
+  @Event({
+    eventName: 'internalSddsCollapse',
+    bubbles: true,
+    cancelable: false,
+    composed: true,
+  })
+  internalSddsCollapse: EventEmitter<CollapseEvent>;
+
+  /** Applicable only for mobile menu usage. If the side menu is open or not. */
   @Prop({ reflect: true }) open: boolean = false;
 
   /** Applicable only for desktop. If the side menu should always be shown. */
@@ -102,11 +112,9 @@ export class SddsSideMenu {
   @Watch('collapsed')
   onCollapsedChange(newVal: boolean) {
     /** Emits the internal collapse event when the prop has changed. */
-    this.internalSddsSideMenuPropChange.emit({
-      changed: ['collapsed'],
+    this.internalSddsCollapse.emit({
       collapsed: newVal,
     });
-
     this.isCollapsed = newVal;
   }
 
@@ -117,33 +125,6 @@ export class SddsSideMenu {
       firstFocusableElement.focus();
     }
   }
-
-  /** Event that is emitted when the side menu is collapsed. */
-  @Event({
-    eventName: 'sddsCollapse',
-    bubbles: true,
-    composed: true,
-    cancelable: true,
-  })
-  sddsCollapse: EventEmitter<CollapseEvent>;
-
-  /** @internal Broadcasts collapsed state to child components. */
-  @Event({
-    eventName: 'internalSddsCollapse',
-    bubbles: true,
-    cancelable: false,
-    composed: true,
-  })
-  internalSddsCollapse: EventEmitter<CollapseEvent>;
-
-  /** @internal Broadcasts collapsed state to child components. */
-  @Event({
-    eventName: 'internalSddsSideMenuPropChange',
-    bubbles: true,
-    cancelable: false,
-    composed: true,
-  })
-  internalSddsSideMenuPropChange: EventEmitter<InternalSddsSideMenuPropChange>;
 
   @Listen('internalSddsCollapse', { target: 'body' })
   collapsedSideMenuEventHandler(event: CustomEvent<CollapseEvent>) {

--- a/tegel/src/components/side-menu/webcomponent/side-menu.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu.tsx
@@ -28,24 +28,6 @@ const INITIALIZE_ANIMATION_DELAY = 500;
 export class SddsSideMenu {
   @Element() host: HTMLSddsSideMenuElement;
 
-  /** Event that is emitted when the side menu is collapsed. */
-  @Event({
-    eventName: 'sddsCollapse',
-    bubbles: true,
-    composed: true,
-    cancelable: true,
-  })
-  sddsCollapse: EventEmitter<CollapseEvent>;
-
-  /** @internal Broadcasts collapsed state to child components. */
-  @Event({
-    eventName: 'internalSddsCollapse',
-    bubbles: true,
-    cancelable: false,
-    composed: true,
-  })
-  internalSddsCollapse: EventEmitter<CollapseEvent>;
-
   /** Applicable only for mobile menu usage. If the side menu is open or not. */
   @Prop({ reflect: true }) open: boolean = false;
 
@@ -111,9 +93,7 @@ export class SddsSideMenu {
   @Watch('collapsed')
   onCollapsedChange(newVal: boolean) {
     /** Emits the internal collapse event when the prop has changed. */
-    this.internalSddsCollapse.emit({
-      collapsed: newVal,
-    });
+    this.internalSddsSideMenuPropChange.emit();
     this.isCollapsed = newVal;
   }
 
@@ -124,6 +104,33 @@ export class SddsSideMenu {
       firstFocusableElement.focus();
     }
   }
+
+  /** Event that is emitted when the side menu is collapsed. */
+  @Event({
+    eventName: 'sddsCollapse',
+    bubbles: true,
+    composed: true,
+    cancelable: true,
+  })
+  sddsCollapse: EventEmitter<CollapseEvent>;
+
+  /** @internal Broadcasts collapsed state to child components. */
+  @Event({
+    eventName: 'internalSddsCollapse',
+    bubbles: true,
+    cancelable: false,
+    composed: true,
+  })
+  internalSddsCollapse: EventEmitter<CollapseEvent>;
+
+  /** @internal Broadcasts collapsed state to child components. */
+  @Event({
+    eventName: 'internalSddsSideMenuPropChange',
+    bubbles: true,
+    cancelable: false,
+    composed: true,
+  })
+  internalSddsSideMenuPropChange: EventEmitter;
 
   @Listen('internalSddsCollapse', { target: 'body' })
   collapsedSideMenuEventHandler(event: CustomEvent<CollapseEvent>) {

--- a/tegel/src/components/side-menu/webcomponent/side-menu.tsx
+++ b/tegel/src/components/side-menu/webcomponent/side-menu.tsx
@@ -28,24 +28,6 @@ const INITIALIZE_ANIMATION_DELAY = 500;
 export class SddsSideMenu {
   @Element() host: HTMLSddsSideMenuElement;
 
-  /** Event that is emitted when the side menu is collapsed. */
-  @Event({
-    eventName: 'sddsCollapse',
-    bubbles: true,
-    composed: true,
-    cancelable: true,
-  })
-  sddsCollapse: EventEmitter<CollapseEvent>;
-
-  /** @internal Broadcasts collapsed state to child components. */
-  @Event({
-    eventName: 'internalSddsCollapse',
-    bubbles: true,
-    cancelable: false,
-    composed: true,
-  })
-  internalSddsCollapse: EventEmitter<CollapseEvent>;
-
   /** Applicable only for mobile menu usage. If the side menu is open or not. */
   @Prop({ reflect: true }) open: boolean = false;
 
@@ -112,9 +94,7 @@ export class SddsSideMenu {
   @Watch('collapsed')
   onCollapsedChange(newVal: boolean) {
     /** Emits the internal collapse event when the prop has changed. */
-    this.internalSddsCollapse.emit({
-      collapsed: newVal,
-    });
+    this.internalSddsSideMenuPropChange.emit();
     this.isCollapsed = newVal;
   }
 
@@ -125,6 +105,33 @@ export class SddsSideMenu {
       firstFocusableElement.focus();
     }
   }
+
+  /** Event that is emitted when the side menu is collapsed. */
+  @Event({
+    eventName: 'sddsCollapse',
+    bubbles: true,
+    composed: true,
+    cancelable: true,
+  })
+  sddsCollapse: EventEmitter<CollapseEvent>;
+
+  /** @internal Broadcasts collapsed state to child components. */
+  @Event({
+    eventName: 'internalSddsCollapse',
+    bubbles: true,
+    cancelable: false,
+    composed: true,
+  })
+  internalSddsCollapse: EventEmitter<CollapseEvent>;
+
+  /** @internal Broadcasts collapsed state to child components. */
+  @Event({
+    eventName: 'internalSddsSideMenuPropChange',
+    bubbles: true,
+    cancelable: false,
+    composed: true,
+  })
+  internalSddsSideMenuPropChange: EventEmitter;
 
   @Listen('internalSddsCollapse', { target: 'body' })
   collapsedSideMenuEventHandler(event: CustomEvent<CollapseEvent>) {


### PR DESCRIPTION
**Describe pull-request**  
This PR makes the collapse event cancelable. To do this we emit one event 'sddsCollapse' that can be listened to and canceled by the user. If that event is not canceled we emit an 'internalSddsCollapse' that is listened to by other sdds-side-menu components. 

I also added a onClick event listener to the sdds-side-menu-collapse-button that handles the collapsing automatically if the users chooses to. If they want to control on their own they can cancel the event and toggle the collapased prop. The prop is being watched and emit the same 'internalSddsCollapse' event when it changes.

I also added a propschange event. But since this component only has one prop that is likely to change in runtime (collapsed) I didn't bother with any relevant props for now. I just emit the event, the collapse button listens to it and then checks it's parent again for the new value of collapsed.

In short:

- User can cancel the collapse event by listening for sddsCollapse, being emitted from the collapse-button
- User can still handle collapse by toggling the boolean prop 'collapse' on the sdds-side-menu (would need to prevent the event first though)
- Made the 'Collapse'-text a default slot so the user can translate it.

**NOTE**: please help me battle test the syncing between the sddsCollapse and internalSddsSideMenuPropChange events.

**Solving issue**  
Fixes: https://tegel.atlassian.net/browse/DTS-1105

**How to test**  
1. Go to storybook link below.
2. Check in Components -> Side Menu -> Web Component
3. Check the event being emitted when the collapse-button is clicked.
4. Checkout the branch.
5. Prevent the event and see it fail to collapse.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events
