### PR TITLE
fix(header-title): added overflow:hidden

### DIFF
--- a/tegel/src/components/header/webcomponent/header-brand-symbol/header-brand-symbol.scss
+++ b/tegel/src/components/header/webcomponent/header-brand-symbol/header-brand-symbol.scss
@@ -13,7 +13,7 @@
     background-repeat: no-repeat;
   }
 
-  @media (min-width: 521px) {
+  @media (min-width: 992px) {
     sdds-header-item {
       display: block;
     }

--- a/tegel/src/components/header/webcomponent/header-title/header-title.scss
+++ b/tegel/src/components/header/webcomponent/header-title/header-title.scss
@@ -9,6 +9,7 @@
   font-family: var(--sdds-font-family-headline);
   letter-spacing: normal;
   position: relative;
+  overflow: hidden;
 
   .component {
     // FIXME this doesnt work

--- a/tegel/src/components/header/webcomponent/header-title/header-title.scss
+++ b/tegel/src/components/header/webcomponent/header-title/header-title.scss
@@ -9,28 +9,16 @@
   font-family: var(--sdds-font-family-headline);
   letter-spacing: normal;
   position: relative;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   overflow: hidden;
 
-  .component {
-    // FIXME this doesnt work
-    ::after {
-      content: ' ';
-      display: block;
-      height: 100%;
-      width: 24px;
-      position: absolute;
-      top: 0;
-      right: 0;
-      background: linear-gradient(to right, transparent, var(--sdds-header-background));
-    }
-  }
-
   slot {
-    min-width: inherit;
     display: block;
     align-items: center;
     white-space: nowrap;
-    text-overflow: fade;
-    padding: 0 24px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    padding: 0 32px 0 16px;
   }
 }

--- a/tegel/src/patterns-stories/navigation/navigation-fewitems.stories.tsx
+++ b/tegel/src/patterns-stories/navigation/navigation-fewitems.stories.tsx
@@ -67,6 +67,11 @@ const Template = () =>
           display: block;
         }
       }
+      @media (min-width: 992px) {
+        .demo-lg-show {
+          display: block;
+        }
+      }
     </style>
 
 
@@ -77,7 +82,7 @@ const Template = () =>
         <sdds-header-hamburger id="demo-hamburger" onclick="demoSideMenu.open = true;demoHamburger.setAttribute('aria-expanded', true);" aria-label="Open application drawer" aria-haspopup="true" aria-expanded="false"></sdds-header-hamburger>
 
         <sdds-header-title>
-          Example: Few items
+          Example: Few items with longer text
         </sdds-header-title>
 
         <sdds-header-item>
@@ -162,7 +167,7 @@ const Template = () =>
 
         </sdds-header-launcher>
 
-        <sdds-header-dropdown slot="end" placement="end" no-dropdown-icon class="demo-hide demo-xs-show" selected>
+        <sdds-header-dropdown slot="end" placement="end" no-dropdown-icon class="demo-hide demo-lg-show" selected>
           <img slot="button-icon" src="https://www.svgrepo.com/show/384676/account-avatar-profile-user-6.svg" alt="User menu."/>
           <sdds-header-dropdown-list type="lg">
             <sdds-header-dropdown-list-user
@@ -225,7 +230,7 @@ const Template = () =>
           </button>
         </sdds-side-menu-item>
         
-        <sdds-side-menu-dropdown slot="end" class="demo-xs-hide" selected>
+        <sdds-side-menu-dropdown slot="end" class="demo-lg-hide" selected>
           <sdds-side-menu-user 
             slot="button-label" 
             heading="Name Namesson" 

--- a/tegel/src/patterns-stories/navigation/navigation-fewitems.stories.tsx
+++ b/tegel/src/patterns-stories/navigation/navigation-fewitems.stories.tsx
@@ -82,7 +82,7 @@ const Template = () =>
         <sdds-header-hamburger id="demo-hamburger" onclick="demoSideMenu.open = true;demoHamburger.setAttribute('aria-expanded', true);" aria-label="Open application drawer" aria-haspopup="true" aria-expanded="false"></sdds-header-hamburger>
 
         <sdds-header-title>
-          Example: Few items with longer text
+          Example: Few items
         </sdds-header-title>
 
         <sdds-header-item>

--- a/tegel/src/patterns-stories/navigation/navigation-manyitems.stories.tsx
+++ b/tegel/src/patterns-stories/navigation/navigation-manyitems.stories.tsx
@@ -89,7 +89,7 @@ const Template = ({ dummyHtml }) =>
         display: none;
       }
 
-      @media (min-width: 375px) {
+      @media (min-width: 992px) {
         .demo-xs-hide {
           display: none;
         }

--- a/tegel/src/patterns-stories/navigation/navigation-user-menu.stories.tsx
+++ b/tegel/src/patterns-stories/navigation/navigation-user-menu.stories.tsx
@@ -55,7 +55,7 @@ const Template = () =>
         display: none;
       }
 
-      @media (min-width: 375px) {
+      @media (min-width: 992px) {
         .demo-xs-hide {
           display: none;
         }


### PR DESCRIPTION
**Describe pull-request**  
Makes the header go to "mobile-version" at 992px (large). And adds a ellipsis to the header title if it overflows.

Based on design: https://www.figma.com/file/hoi8RrFUaqRw28rvHa4KJX/Header-exploration?node-id=512-145824&t=We39OFEaFjBjOJ8C-0

**Solving issue**  
Fixes: https://tegel.atlassian.net/browse/DTS-1543

**How to test**  
1. Go to storybook link below.
2. Check in Patterna -> Navigation -> Few Navigation Items
3. Make the screen smaller.
4. Check the header-title.
