### PR TITLE
fix(modal): increasing max height to 85vh

### DIFF
--- a/components/src/components/modal/_modal-core.scss
+++ b/components/src/components/modal/_modal-core.scss
@@ -85,7 +85,7 @@ $modals: (
   .sdds-modal {
     @include modal-scroll;
 
-    max-height: 60vh;
+    max-height: 85vh;
     overflow-y: auto;
   }
 


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://digitaldesign.scania.com/support/faqs) and/or [Contribution](https://digitaldesign.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Increasing max height to 85vh for modal component

**Solving issue**  
Fixes: DTS-1683

**How to test**  
1. Check the Netlify link below OR branch out on your local
2. Choose a Modal component
3. Try to insert a lot of content
4. Modal should grow in height until it reaches 85% of the viewport height, after that scroll should show up

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [ ] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events


