### PR TITLE
docs(components-readme): test to drop cache on npm website

### DIFF
--- a/components/readme.md
+++ b/components/readme.md
@@ -8,7 +8,7 @@
 
 **Technical documentation**
 
-Check out [Tegel Design System](https://tegel.scania.com/) for implementation and technical documentation.
+Check out our official [Tegel Design System](https://tegel.scania.com/) page for implementation and technical documentation.
 
 ## Quick start
 


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://tegel.scania.com/support/faqs) and/or [Contribution](https://tegel.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Content update on readme file for components package

**Solving issue**  
Fixes:  DTS-1842
Content is updated long time ago but not reflected on the npm website of the package. I thought that maybe a change like this would trigger npm to frop cache on their side and update it accordion to new changes. 

**How to test**  
1. Needs a release


**Additional context**  
I wrote an e-mail to npm support to see if they can do anything on their side too until we do a release. 
