### PR TITLE
fix(slider): disabled state update in runtime

### DIFF
--- a/components/src/components/slider/slider.tsx
+++ b/components/src/components/slider/slider.tsx
@@ -484,9 +484,14 @@ export class Slider {
         ></input>
 
         <div
-          class={`sdds-slider ${this.disabled ? 'disabled' : ''} ${
-            this.useSmall ? 'sdds-slider-small' : ''
-          }`}
+          // class={`sdds-slider ${this.disabled ? 'disabled' : ''} ${
+          //   this.useSmall ? 'sdds-slider-small' : ''
+          // }`}
+          class={{
+            'sdds-slider': true,
+            'disabled': this.disabled,
+            'sdds-slider-small': this.useSmall,
+          }}
           ref={(el) => (this.wrapperElement = el as HTMLElement)}
         >
           {this.useInput && (

--- a/components/src/components/slider/slider.tsx
+++ b/components/src/components/slider/slider.tsx
@@ -432,7 +432,6 @@ export class Slider {
       this.tickValues.push(this.getMax());
     }
 
-
     if (this.readonly !== null) {
       this.readonlyState = true;
     } else {
@@ -484,9 +483,6 @@ export class Slider {
         ></input>
 
         <div
-          // class={`sdds-slider ${this.disabled ? 'disabled' : ''} ${
-          //   this.useSmall ? 'sdds-slider-small' : ''
-          // }`}
           class={{
             'sdds-slider': true,
             'disabled': this.disabled,


### PR DESCRIPTION
**Describe pull-request**  
Refactoring the way class name for disabled state is set. The use of template literals stops the component updating in runtime. Fixed in Tegel repo as well -> https://github.com/scania-digital-design-system/tegel/pull/211 

**Solving issue**  
Fixes: https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-2064

**How to test**  
This and the Tds component has been tested in local React environment (the exact same changes have been made in both repos), but if you want to test it for yourself:

1. Check out branch
2. Run npm pack
3. Cd into components
4. Copy generated file into local React test environment on root level
5. In package.json, update path to @scania/components to the generated file name (example: "@scania/components": "file:scania-components-4.10.11.tgz",)
6.  Run npm i
7.  Set up states and a trigger to test the disabled prop
8.  Run npm run build
9.  Run npm run start.
10.  Check that the Slider disabled state can be update in runtime.