### PR TITLE
feat(datetime): min & max props

### DIFF
--- a/components/src/components.d.ts
+++ b/components/src/components.d.ts
@@ -105,6 +105,14 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
+          * Sets max value. Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00"
+         */
+        "max": string;
+        /**
+          * Sets min value. Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00"
+         */
+        "min": string;
+        /**
           * Name property
          */
         "name": string;
@@ -121,9 +129,9 @@ export namespace Components {
          */
         "state": string;
         /**
-          * Which input type, text, password or similar
+          * Which input type, 'datetime-local', 'date', 'time'
          */
-        "type": string;
+        "type": 'datetime-local' | 'date' | 'time';
         /**
           * Value of the input text
          */
@@ -966,6 +974,14 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
+          * Sets max value. Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00"
+         */
+        "max"?: string;
+        /**
+          * Sets min value. Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00"
+         */
+        "min"?: string;
+        /**
           * Name property
          */
         "name"?: string;
@@ -986,9 +1002,9 @@ declare namespace LocalJSX {
          */
         "state"?: string;
         /**
-          * Which input type, text, password or similar
+          * Which input type, 'datetime-local', 'date', 'time'
          */
-        "type"?: string;
+        "type"?: 'datetime-local' | 'date' | 'time';
         /**
           * Value of the input text
          */

--- a/components/src/components/datetime/datetime.stories.js
+++ b/components/src/components/datetime/datetime.stories.js
@@ -44,7 +44,22 @@ export default {
         type: 'text',
       },
     },
-
+    minValue: {
+      description:
+        'Sets min value. Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00"',
+      name: 'Min value',
+      control: {
+        type: 'text',
+      },
+    },
+    maxValue: {
+      description:
+        'Sets max value. Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00"',
+      name: 'Max value',
+      control: {
+        type: 'text',
+      },
+    },
     helper: {
       name: 'Helper text',
       description: 'Add helper text for the textfield',
@@ -66,7 +81,9 @@ export default {
     size: 'Default',
     minWidth: 'Default',
     disabled: false,
-    state: 'default',
+    state: 'none',
+    minValue: '2023-01-01T00:00',
+    maxValue: '2024-12-31T00:00',
     label: '',
     helper: '',
   },
@@ -78,6 +95,8 @@ const datetimeTemplate = ({
   minWidth,
   disabled,
   label,
+  minValue,
+  maxValue,
   state,
   helper,
 }) => {
@@ -110,10 +129,13 @@ const datetimeTemplate = ({
       type="${type}"
       size="${sizeValue}"
       state="${state}"
+      min="${minValue}"
+      max="${maxValue}"
       ${disabled ? 'disabled' : ''}
       ${minWidthValue ? 'noMinWidth' : ''} >
       ${label ? `<label slot='sdds-label'>${label}</label>` : ''}
       ${helper ? `<span slot='sdds-helper'>${helper}</span>` : ''}
+   
     </sdds-datetime>
   </div>
   `;

--- a/components/src/components/datetime/datetime.tsx
+++ b/components/src/components/datetime/datetime.tsx
@@ -1,12 +1,4 @@
-import {
-  Component,
-  State,
-  h,
-  Prop,
-  Listen,
-  Event,
-  EventEmitter,
-} from '@stencil/core';
+import { Component, State, h, Prop, Listen, Event, EventEmitter } from '@stencil/core';
 
 @Component({
   tag: 'sdds-datetime',
@@ -17,11 +9,17 @@ export class Datetime {
   /** Textinput for focus state */
   textInput?: HTMLInputElement;
 
-  /** Which input type, text, password or similar */
-  @Prop({ reflect: true }) type: string = 'text';
+  /** Which input type, 'datetime-local', 'date', 'time' */
+  @Prop({ reflect: true }) type: 'datetime-local' | 'date' | 'time' = 'datetime-local';
 
   /** Value of the input text */
   @Prop({ reflect: true }) value = '';
+
+  /** Sets min value. Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00" */
+  @Prop() min: string;
+
+  /** Sets max value. Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00" */
+  @Prop() max: string;
 
   /** Set input in disabled state */
   @Prop() disabled: boolean = false;
@@ -92,19 +90,13 @@ export class Datetime {
       <div
         class={`
         ${this.nominwidth ? 'sdds-form-datetime-nomin' : ''}
-        ${
-          this.focusInput
-            ? 'sdds-form-datetime sdds-datetime-focus'
-            : ' sdds-form-datetime'
-        }
+        ${this.focusInput ? 'sdds-form-datetime sdds-datetime-focus' : ' sdds-form-datetime'}
         ${this.value.length > 0 ? 'sdds-datetime-data' : ''}
         ${this.disabled ? 'sdds-form-datetime-disabled' : ''}
         ${this.size == 'md' ? 'sdds-form-datetime-md' : ''}
         ${this.size == 'sm' ? 'sdds-form-datetime-sm' : ''}
         ${
-          this.state == 'error' || this.state == 'success'
-            ? `sdds-form-datetime-${this.state}`
-            : ''
+          this.state == 'error' || this.state == 'success' ? `sdds-form-datetime-${this.state}` : ''
         }
         `}
       >
@@ -121,6 +113,8 @@ export class Datetime {
               type={this.type}
               disabled={this.disabled}
               value={this.value}
+              min={this.min}
+              max={this.max}
               autofocus={this.autofocus}
               name={this.name}
               onInput={(e) => this.handleInput(e)}
@@ -128,11 +122,7 @@ export class Datetime {
             />
 
             <div class="datetime-icon icon-datetime-local">
-              <svg
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 32 32"
-              >
+              <svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
                 <path
                   fill-rule="evenodd"
                   clip-rule="evenodd"
@@ -143,11 +133,7 @@ export class Datetime {
             </div>
 
             <div class="datetime-icon icon-time">
-              <svg
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 32 32"
-              >
+              <svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
                 <path
                   d="M17 7a1 1 0 1 0-2 0v8a2 2 0 0 0 2 2h6a1 1 0 1 0 0-2h-6V7Z"
                   fill="currentColor"

--- a/components/src/components/datetime/readme.md
+++ b/components/src/components/datetime/readme.md
@@ -5,16 +5,18 @@
 
 ## Properties
 
-| Property     | Attribute    | Description                                 | Type                 | Default     |
-| ------------ | ------------ | ------------------------------------------- | -------------------- | ----------- |
-| `autofocus`  | `autofocus`  | Autofocus for input                         | `boolean`            | `false`     |
-| `disabled`   | `disabled`   | Set input in disabled state                 | `boolean`            | `false`     |
-| `name`       | `name`       | Name property                               | `string`             | `''`        |
-| `nominwidth` | `nominwidth` | With setting                                | `boolean`            | `false`     |
-| `size`       | `size`       | Size of the input                           | `"" \| "md" \| "sm"` | `''`        |
-| `state`      | `state`      | Error state of input                        | `string`             | `undefined` |
-| `type`       | `type`       | Which input type, text, password or similar | `string`             | `'text'`    |
-| `value`      | `value`      | Value of the input text                     | `string`             | `''`        |
+| Property     | Attribute    | Description                                                                                             | Type                                   | Default            |
+| ------------ | ------------ | ------------------------------------------------------------------------------------------------------- | -------------------------------------- | ------------------ |
+| `autofocus`  | `autofocus`  | Autofocus for input                                                                                     | `boolean`                              | `false`            |
+| `disabled`   | `disabled`   | Set input in disabled state                                                                             | `boolean`                              | `false`            |
+| `max`        | `max`        | Sets max value. Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00" | `string`                               | `undefined`        |
+| `min`        | `min`        | Sets min value. Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00" | `string`                               | `undefined`        |
+| `name`       | `name`       | Name property                                                                                           | `string`                               | `''`               |
+| `nominwidth` | `nominwidth` | With setting                                                                                            | `boolean`                              | `false`            |
+| `size`       | `size`       | Size of the input                                                                                       | `"" \| "md" \| "sm"`                   | `''`               |
+| `state`      | `state`      | Error state of input                                                                                    | `string`                               | `undefined`        |
+| `type`       | `type`       | Which input type, 'datetime-local', 'date', 'time'                                                      | `"date" \| "datetime-local" \| "time"` | `'datetime-local'` |
+| `value`      | `value`      | Value of the input text                                                                                 | `string`                               | `''`               |
 
 
 ## Events


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://tegel.scania.com/support/faqs) and/or [Contribution](https://tegel.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  
Props to set min and max value of input

**Solving issue**  
Fixes: DTS-2179

**How to test**  
1. Go to Netlify preview link
2. Try to set different min/max values in Storybook.
3. Check if works as intended for date and datetime. "time" has issues with limitation even in native HTML component.

**Suggested test steps**
- [ ] Browser testing (Chrome, Safari, Firefox) 
- [ ] Keyboard operability
- [ ] Interactive elements have labels.
- [x] Storybook controls
- [ ] Design/controls/props is aligned with other components 
- [ ] Dark/light mode and variants 
- [ ] Input fields – values should be displayed properly 
- [ ] Events

**Additional context**  
Example for different types: datetime="2023-01-31T00:00" date="2023-01-01" time="15:00"
