### PR TITLE
fix(dropdown): faulty logic in label check was fixed

### DIFF
--- a/components/src/components/dropdown/dropdown.tsx
+++ b/components/src/components/dropdown/dropdown.tsx
@@ -319,8 +319,8 @@ export class Dropdown {
             }
               }
               ${
-                (this.labelPosition === 'inside' && this.selectedValue !== '') ||
-                this.selectedLabelsArray.length > 0
+                this.labelPosition === 'inside' && (this.selectedValue !== '' ||
+                this.selectedLabelsArray.length > 0)
                   ? `sdds-dropdown-toggle-label-inside-${this.size}`
                   : ''
               }`}


### PR DESCRIPTION
**Describe pull-request**  
The dropdown had a flicker/change in height when you were using the multiselect version. See video:
https://github.com/scania-digital-design-system/sdds/assets/62651103/e2c337d6-040a-4f2e-a3ec-7ea08578e756

This was due to faulty logic, we were checking if the dropdown had labelposition inside and selected value was not equal to '' OR if the selectedLabelsArray had no items in it. 

What we should check is:
if the labelposition was inside AND selected value was not equal to '' OR if the selectedLabelsArray had no items in it. 

**Solving issue**  
Fixes: -

**How to test**  
1. Go to storybook
2. Check in dropdown -> multiselect
3. Check that it there is no flicker/size diff when selected/unselected.

