### PR TITLE
docs: deprecation message for sdds packages

### DIFF
--- a/components/.storybook/preview.js
+++ b/components/.storybook/preview.js
@@ -100,8 +100,9 @@ export const parameters = {
   options: {
     storySort: {
       method: 'alphabetical',
-      order: ['Foundation', 'Utilities', 'Component', 'Patterns', 'Pre-alpha'],
+      order: ['Intro', 'Foundation', 'Utilities', 'Component', 'Patterns', 'Pre-alpha'],
     },
+    showPanel: true,
   },
 };
 

--- a/components/package-lock.json
+++ b/components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@scania/components",
-  "version": "4.10.13",
+  "version": "4.10.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@scania/components",
-      "version": "4.10.13",
+      "version": "4.10.14",
       "license": "MIT",
       "dependencies": {
         "@storybook/theming": "^6.5.8",

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scania/components",
-  "version": "4.10.13",
+  "version": "4.10.14",
   "description": "In this repository we're developing the next generation components for Scania Digital Design System",
   "repository": {
     "type": "git",

--- a/components/readme.md
+++ b/components/readme.md
@@ -26,7 +26,7 @@ We suggest exploring the Tegel Design System, which is the successor of SDDS and
 
 **What should you do now?**
 
-1. **Migrate to an alternative package**: We strongly encourage you to transition to one of the recommended alternatives mentioned above by following their documentation and migration guides on npm or [official Tegel website](https://tegel.scania.com/development/getting-started-development/installation).
+1. **Migrate to an alternative package**: We strongly encourage you to transition to one of the recommended alternatives mentioned above by following their documentation and migration guides on npm, [SDDS -> TDS migration guide](https://tegel.scania.com/development/migration) and [Tegel installation](https://tegel.scania.com/development/getting-started-development/installation) on the official Tegel website.
 
 2. **Remove the deprecated package**: You can safely remove this package from your project once you have successfully migrated to an alternative solution.
 

--- a/components/readme.md
+++ b/components/readme.md
@@ -4,7 +4,41 @@
 ![](https://img.shields.io/github/license/scania-digital-design-system/sdds)
 [![Getting Started](https://img.shields.io/badge/Available%20components-tegel.scania.com-orange)](https://tegel.scania.com/development/getting-started-development)
 
-# Tegel Design System - Components
+# SDDS - Components
+
+---
+
+# Deprecation Notice
+
+**This package has been deprecated and is no longer actively maintained.**
+
+**Why is this package deprecated?**
+
+This package has reached the end of its development lifecycle, and we have decided to discontinue active support and updates for it. We recommend that you consider alternative solutions for your project to ensure ongoing compatibility, security, and stability.
+
+**Recommended Alternatives**
+
+We suggest exploring the Tegel Design System, which is the successor of SDDS and is actively maintained:
+
+- [@scania/tegel](https://www.npmjs.com/package/@scania/tegel): One package for the entire Tegel design system. Based on Web Components.
+- [@scania/tegel-react](https://www.npmjs.com/package/@scania/tegel-react): Version of @scania/tegel that provides React component wrappers.
+- [@scania/tegel-angular](https://www.npmjs.com/package/@scania/tegel-angular): Version of @scania/tegel that provides Angular component wrappers.
+
+**What should you do now?**
+
+1. **Migrate to an alternative package**: We strongly encourage you to transition to one of the recommended alternatives mentioned above by following their documentation and migration guides on npm or [official Tegel website](https://tegel.scania.com/development/getting-started-development/installation).
+
+2. **Remove the deprecated package**: You can safely remove this package from your project once you have successfully migrated to an alternative solution.
+
+**Thank You!**
+
+We appreciate your support and use of this package. If you have any questions or need further assistance with the deprecation process or migration, feel free to reach out to us by [creating an issue](https://github.com/scania-digital-design-system/tegel/issues/new/choose) in our GitHub repository or contacting [Development support](https://teams.microsoft.com/l/channel/19%3a5e33f67fe502441f914fbcdc6e2548f5%40thread.skype/Development%2520support?groupId=79f9bfeb-73e2-424d-9477-b236191ece5e&tenantId=3bc062e4-ac9d-4c17-b4dd-3aad637ff1ac) channel in Teams.
+
+Again, thank you for being a part of our community, and we hope the recommended alternatives serve your needs effectively.
+
+*Last Updated: October 23rd 2023
+
+---
 
 **Technical documentation**
 

--- a/components/src/components/stories/deprecation.stories.js
+++ b/components/src/components/stories/deprecation.stories.js
@@ -1,0 +1,52 @@
+export default {
+  title: 'Intro/Deprecation',
+  parameters: {
+    layout: 'fullscreen',
+    showPanel: false,
+  },
+};
+
+const DeprecationTemplate = () => `
+  <section class="sdds-u-p3">
+    <h1>Deprecation Notice</h1>
+
+    <p><strong>SDDS and its packages have been deprecated and are no longer actively maintained.</strong></p>
+
+    <p><strong>Why is it deprecated?</strong></p>
+    <p>SDDS has reached the end of its development lifecycle, and we have decided to discontinue active support and updates for it. We recommend that you consider alternative solutions for your project to ensure ongoing compatibility, security, and stability.</p>
+
+    <p><strong>Which are affected packages?</strong></p>
+    <ul>
+      <li>@scania/icons</li>
+      <li>@scania/theme-light</li>
+      <li>@scania/components</li>
+      <li>@scania/grid</li>
+      <li>@scania/colour</li>
+      <li>@scania/tyography</li>
+    </ul>
+
+    <p><strong>Recommended Alternatives</strong></p>
+    <p>We suggest exploring the Tegel Design System, which is the successor of SDDS and is actively maintained:</p>
+    <ul>
+        <li><a href="https://www.npmjs.com/package/@scania/tegel">@scania/tegel</a>: One package for the entire Tegel design system. Based on Web Components.</li>
+        <li><a href="https://www.npmjs.com/package/@scania/tegel-react">@scania/tegel-react</a>: Version of @scania/tegel that provides React component wrappers.</li>
+        <li><a href="https://www.npmjs.com/package/@scania/tegel-angular">@scania/tegel-angular</a>: Version of @scania/tegel that provides Angular component wrappers.</li>
+    </ul>
+
+    <p><strong>What should you do now?</strong></p>
+    <ol>
+        <li><strong>Migrate to an alternative package:</strong> We strongly encourage you to transition to one of the recommended alternatives mentioned above by following their documentation on npm, <a href="https://tegel.scania.com/development/migration">SDDS -> Tegel migration guide</a> and <a href="https://tegel.scania.com/development/getting-started-development/installation">Tegel installation guide</a> on official Tegel website.</li>
+        <li><strong>Remove the deprecated package:</strong> You can safely remove this package from your project once you have successfully migrated to an alternative solution.</li>
+    </ol>
+
+    <p><strong>Thank You!</strong></p>
+    <p>We appreciate your support and use of this package. If you have any questions or need further assistance with the deprecation process or migration, feel free to reach out to us by <a href="https://github.com/scania-digital-design-system/tegel/issues/new/choose">creating an issue</a> in our GitHub repository or contacting <a href="https://teams.microsoft.com/l/channel/19%3a5e33f67fe502441f914fbcdc6e2548f5%40thread.skype/Development%2520support?groupId=79f9bfeb-73e2-424d-9477-b236191ece5e&tenantId=3bc062e4-ac9d-4c17-b4dd-3aad637ff1ac">Development support</a> channel in Teams.</p>
+
+    <p>Again, thank you for being a part of our community, and we hope the recommended alternatives serve your needs effectively.</p>
+
+    <p><em>Last Updated: October 23rd 2023</em></p>
+</section>
+
+  `;
+
+export const Deprecation = DeprecationTemplate.bind({});

--- a/components/src/components/stories/deprecation.stories.js
+++ b/components/src/components/stories/deprecation.stories.js
@@ -28,7 +28,7 @@ const DeprecationTemplate = () => `
     <p><strong>Recommended Alternatives</strong></p>
     <p>We suggest exploring the Tegel Design System, which is the successor of SDDS and is actively maintained:</p>
     <ul>
-        <li><a href="https://www.npmjs.com/package/@scania/tegel">@scania/tegel</a>: One package for the entire Tegel design system. Based on Web Components.</li>
+        <li><a href="https://www.npmjs.com/package/@scania/tegel">@scania/tegel</a>: One package for the entire Tegel design system. Based on web components.</li>
         <li><a href="https://www.npmjs.com/package/@scania/tegel-react">@scania/tegel-react</a>: Version of @scania/tegel that provides React component wrappers.</li>
         <li><a href="https://www.npmjs.com/package/@scania/tegel-angular">@scania/tegel-angular</a>: Version of @scania/tegel that provides Angular component wrappers.</li>
     </ul>

--- a/icons/package-lock.json
+++ b/icons/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@scania/icons",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@scania/icons",
-			"version": "1.1.1",
+			"version": "1.1.2",
 			"devDependencies": {
 				"del": "^6.0.0",
 				"fs-extra": "^10.0.1",

--- a/icons/package.json
+++ b/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scania/icons",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Scania icons package",
   "repository": {
     "type": "git",

--- a/icons/readme.md
+++ b/icons/readme.md
@@ -20,7 +20,7 @@ We suggest exploring the Tegel Design System, which is the successor of SDDS and
 
 **What should you do now?**
 
-1. **Migrate to an alternative package**: We strongly encourage you to transition to one of the recommended alternatives mentioned above by following their documentation and migration guides on npm or [official Tegel website](https://tegel.scania.com/development/getting-started-development/installation).
+1. **Migrate to an alternative package**: We strongly encourage you to transition to one of the recommended alternatives mentioned above by following their documentation and migration guides on npm, [SDDS -> TDS migration guide](https://tegel.scania.com/development/migration) and [Tegel installation](https://tegel.scania.com/development/getting-started-development/installation) on the official Tegel website.
 
 2. **Remove the deprecated package**: You can safely remove this package from your project once you have successfully migrated to an alternative solution.
 

--- a/icons/readme.md
+++ b/icons/readme.md
@@ -1,6 +1,39 @@
-# Tegel Icons package
+# SDDS Icons package
 
 ---
+
+# Deprecation Notice
+
+**This package has been deprecated and is no longer actively maintained.**
+
+**Why is this package deprecated?**
+
+This package has reached the end of its development lifecycle, and we have decided to discontinue active support and updates for it. We recommend that you consider alternative solutions for your project to ensure ongoing compatibility, security, and stability.
+
+**Recommended Alternatives**
+
+We suggest exploring the Tegel Design System, which is the successor of SDDS and is actively maintained:
+
+- [@scania/tegel](https://www.npmjs.com/package/@scania/tegel): One package for the entire Tegel design system. Based on Web Components.
+- [@scania/tegel-react](https://www.npmjs.com/package/@scania/tegel-react): Version of @scania/tegel that provides React component wrappers.
+- [@scania/tegel-angular](https://www.npmjs.com/package/@scania/tegel-angular): Version of @scania/tegel that provides Angular component wrappers.
+
+**What should you do now?**
+
+1. **Migrate to an alternative package**: We strongly encourage you to transition to one of the recommended alternatives mentioned above by following their documentation and migration guides on npm or [official Tegel website](https://tegel.scania.com/development/getting-started-development/installation).
+
+2. **Remove the deprecated package**: You can safely remove this package from your project once you have successfully migrated to an alternative solution.
+
+**Thank You!**
+
+We appreciate your support and use of this package. If you have any questions or need further assistance with the deprecation process or migration, feel free to reach out to us by [creating an issue](https://github.com/scania-digital-design-system/tegel/issues/new/choose) in our GitHub repository or contacting [Development support](https://teams.microsoft.com/l/channel/19%3a5e33f67fe502441f914fbcdc6e2548f5%40thread.skype/Development%2520support?groupId=79f9bfeb-73e2-424d-9477-b236191ece5e&tenantId=3bc062e4-ac9d-4c17-b4dd-3aad637ff1ac) channel in Teams.
+
+Again, thank you for being a part of our community, and we hope the recommended alternatives serve your needs effectively.
+
+*Last Updated: October 23rd 2023
+
+---
+
 
 There are 2 options to use icons package. You can use it as a module or as a webfont. 
 

--- a/icons/readme.md
+++ b/icons/readme.md
@@ -14,7 +14,7 @@ This package has reached the end of its development lifecycle, and we have decid
 
 We suggest exploring the Tegel Design System, which is the successor of SDDS and is actively maintained:
 
-- [@scania/tegel](https://www.npmjs.com/package/@scania/tegel): One package for the entire Tegel design system. Based on Web Components.
+- [@scania/tegel](https://www.npmjs.com/package/@scania/tegel): One package for the entire Tegel design system. Based on web components.
 - [@scania/tegel-react](https://www.npmjs.com/package/@scania/tegel-react): Version of @scania/tegel that provides React component wrappers.
 - [@scania/tegel-angular](https://www.npmjs.com/package/@scania/tegel-angular): Version of @scania/tegel that provides Angular component wrappers.
 

--- a/theme/core/colour/README.md
+++ b/theme/core/colour/README.md
@@ -1,4 +1,36 @@
-# Tegel Design System - Colour package
+# SDDS - Colour package
+
+# Deprecation Notice
+
+**This package has been deprecated and is no longer actively maintained.**
+
+**Why is this package deprecated?**
+
+This package has reached the end of its development lifecycle, and we have decided to discontinue active support and updates for it. We recommend that you consider alternative solutions for your project to ensure ongoing compatibility, security, and stability.
+
+**Recommended Alternatives**
+
+We suggest exploring the Tegel Design System, which is the successor of SDDS and is actively maintained:
+
+- [@scania/tegel](https://www.npmjs.com/package/@scania/tegel): One package for the entire Tegel design system. Based on Web Components.
+- [@scania/tegel-react](https://www.npmjs.com/package/@scania/tegel-react): Version of @scania/tegel that provides React component wrappers.
+- [@scania/tegel-angular](https://www.npmjs.com/package/@scania/tegel-angular): Version of @scania/tegel that provides Angular component wrappers.
+
+**What should you do now?**
+
+1. **Migrate to an alternative package**: We strongly encourage you to transition to one of the recommended alternatives mentioned above by following their documentation and migration guides on npm or [official Tegel website](https://tegel.scania.com/development/getting-started-development/installation). 
+
+2. **Remove the deprecated package**: You can safely remove this package from your project once you have successfully migrated to an alternative solution.
+
+**Thank You!**
+
+We appreciate your support and use of this package. If you have any questions or need further assistance with the deprecation process or migration, feel free to reach out to us by [creating an issue](https://github.com/scania-digital-design-system/tegel/issues/new/choose) in our GitHub repository or contacting [Development support](https://teams.microsoft.com/l/channel/19%3a5e33f67fe502441f914fbcdc6e2548f5%40thread.skype/Development%2520support?groupId=79f9bfeb-73e2-424d-9477-b236191ece5e&tenantId=3bc062e4-ac9d-4c17-b4dd-3aad637ff1ac) channel in Teams.
+
+Again, thank you for being a part of our community, and we hope the recommended alternatives serve your needs effectively.
+
+*Last Updated: October 23rd 2023
+
+
 
 ---
 

--- a/theme/core/colour/README.md
+++ b/theme/core/colour/README.md
@@ -12,7 +12,7 @@ This package has reached the end of its development lifecycle, and we have decid
 
 We suggest exploring the Tegel Design System, which is the successor of SDDS and is actively maintained:
 
-- [@scania/tegel](https://www.npmjs.com/package/@scania/tegel): One package for the entire Tegel design system. Based on Web Components.
+- [@scania/tegel](https://www.npmjs.com/package/@scania/tegel): One package for the entire Tegel design system. Based on web components.
 - [@scania/tegel-react](https://www.npmjs.com/package/@scania/tegel-react): Version of @scania/tegel that provides React component wrappers.
 - [@scania/tegel-angular](https://www.npmjs.com/package/@scania/tegel-angular): Version of @scania/tegel that provides Angular component wrappers.
 

--- a/theme/core/colour/README.md
+++ b/theme/core/colour/README.md
@@ -18,7 +18,7 @@ We suggest exploring the Tegel Design System, which is the successor of SDDS and
 
 **What should you do now?**
 
-1. **Migrate to an alternative package**: We strongly encourage you to transition to one of the recommended alternatives mentioned above by following their documentation and migration guides on npm or [official Tegel website](https://tegel.scania.com/development/getting-started-development/installation). 
+1. **Migrate to an alternative package**: We strongly encourage you to transition to one of the recommended alternatives mentioned above by following their documentation and migration guides on npm, [SDDS -> TDS migration guide](https://tegel.scania.com/development/migration) and [Tegel installation](https://tegel.scania.com/development/getting-started-development/installation) on the official Tegel website.
 
 2. **Remove the deprecated package**: You can safely remove this package from your project once you have successfully migrated to an alternative solution.
 

--- a/theme/core/colour/package-lock.json
+++ b/theme/core/colour/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@scania/colour",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@scania/colour",
-			"version": "2.0.1",
+			"version": "2.0.2",
 			"license": "ISC",
 			"devDependencies": {
 				"sass": "^1.49.9",

--- a/theme/core/colour/package.json
+++ b/theme/core/colour/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scania/colour",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Scania Digital Design System colour package",
   "main": "dist/scss/colour.scss",
   "scripts": {

--- a/theme/core/grid/README.md
+++ b/theme/core/grid/README.md
@@ -1,4 +1,36 @@
-# Tegel Design System - Grid package
+# SDDS - Grid package
+
+---
+
+# Deprecation Notice
+
+**This package has been deprecated and is no longer actively maintained.**
+
+**Why is this package deprecated?**
+
+This package has reached the end of its development lifecycle, and we have decided to discontinue active support and updates for it. We recommend that you consider alternative solutions for your project to ensure ongoing compatibility, security, and stability.
+
+**Recommended Alternatives**
+
+We suggest exploring the Tegel Design System, which is the successor of SDDS and is actively maintained:
+
+- [@scania/tegel](https://www.npmjs.com/package/@scania/tegel): One package for the entire Tegel design system. Based on Web Components.
+- [@scania/tegel-react](https://www.npmjs.com/package/@scania/tegel-react): Version of @scania/tegel that provides React component wrappers.
+- [@scania/tegel-angular](https://www.npmjs.com/package/@scania/tegel-angular): Version of @scania/tegel that provides Angular component wrappers.
+
+**What should you do now?**
+
+1. **Migrate to an alternative package**: We strongly encourage you to transition to one of the recommended alternatives mentioned above by following their documentation and migration guides on npm or [official Tegel website](https://tegel.scania.com/development/getting-started-development/installation).
+
+2. **Remove the deprecated package**: You can safely remove this package from your project once you have successfully migrated to an alternative solution.
+
+**Thank You!**
+
+We appreciate your support and use of this package. If you have any questions or need further assistance with the deprecation process or migration, feel free to reach out to us by [creating an issue](https://github.com/scania-digital-design-system/tegel/issues/new/choose) in our GitHub repository or contacting [Development support](https://teams.microsoft.com/l/channel/19%3a5e33f67fe502441f914fbcdc6e2548f5%40thread.skype/Development%2520support?groupId=79f9bfeb-73e2-424d-9477-b236191ece5e&tenantId=3bc062e4-ac9d-4c17-b4dd-3aad637ff1ac) channel in Teams.
+
+Again, thank you for being a part of our community, and we hope the recommended alternatives serve your needs effectively.
+
+*Last Updated: October 23rd 2023
 
 ---
 

--- a/theme/core/grid/README.md
+++ b/theme/core/grid/README.md
@@ -20,7 +20,7 @@ We suggest exploring the Tegel Design System, which is the successor of SDDS and
 
 **What should you do now?**
 
-1. **Migrate to an alternative package**: We strongly encourage you to transition to one of the recommended alternatives mentioned above by following their documentation and migration guides on npm or [official Tegel website](https://tegel.scania.com/development/getting-started-development/installation).
+1. **Migrate to an alternative package**: We strongly encourage you to transition to one of the recommended alternatives mentioned above by following their documentation and migration guides on npm, [SDDS -> TDS migration guide](https://tegel.scania.com/development/migration) and [Tegel installation](https://tegel.scania.com/development/getting-started-development/installation) on the official Tegel website.
 
 2. **Remove the deprecated package**: You can safely remove this package from your project once you have successfully migrated to an alternative solution.
 

--- a/theme/core/grid/README.md
+++ b/theme/core/grid/README.md
@@ -14,7 +14,7 @@ This package has reached the end of its development lifecycle, and we have decid
 
 We suggest exploring the Tegel Design System, which is the successor of SDDS and is actively maintained:
 
-- [@scania/tegel](https://www.npmjs.com/package/@scania/tegel): One package for the entire Tegel design system. Based on Web Components.
+- [@scania/tegel](https://www.npmjs.com/package/@scania/tegel): One package for the entire Tegel design system. Based on web components.
 - [@scania/tegel-react](https://www.npmjs.com/package/@scania/tegel-react): Version of @scania/tegel that provides React component wrappers.
 - [@scania/tegel-angular](https://www.npmjs.com/package/@scania/tegel-angular): Version of @scania/tegel that provides Angular component wrappers.
 

--- a/theme/core/grid/package-lock.json
+++ b/theme/core/grid/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@scania/grid",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@scania/grid",
-			"version": "2.0.1",
+			"version": "2.0.2",
 			"license": "ISC",
 			"devDependencies": {
 				"sass": "^1.49.9",

--- a/theme/core/grid/package.json
+++ b/theme/core/grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scania/grid",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Scania Digital Design System Grid",
   "scripts": {
     "build": "node compile.js"

--- a/theme/core/typography/README.md
+++ b/theme/core/typography/README.md
@@ -20,7 +20,7 @@ We suggest exploring the Tegel Design System, which is the successor of SDDS and
 
 **What should you do now?**
 
-1. **Migrate to an alternative package**: We strongly encourage you to transition to one of the recommended alternatives mentioned above by following their documentation and migration guides on npm or [official Tegel website](https://tegel.scania.com/development/getting-started-development/installation).
+1. **Migrate to an alternative package**: We strongly encourage you to transition to one of the recommended alternatives mentioned above by following their documentation and migration guides on npm, [SDDS -> TDS migration guide](https://tegel.scania.com/development/migration) and [Tegel installation](https://tegel.scania.com/development/getting-started-development/installation) on the official Tegel website.
 
 2. **Remove the deprecated package**: You can safely remove this package from your project once you have successfully migrated to an alternative solution.
 

--- a/theme/core/typography/README.md
+++ b/theme/core/typography/README.md
@@ -14,7 +14,7 @@ This package has reached the end of its development lifecycle, and we have decid
 
 We suggest exploring the Tegel Design System, which is the successor of SDDS and is actively maintained:
 
-- [@scania/tegel](https://www.npmjs.com/package/@scania/tegel): One package for the entire Tegel design system. Based on Web Components.
+- [@scania/tegel](https://www.npmjs.com/package/@scania/tegel): One package for the entire Tegel design system. Based on web components.
 - [@scania/tegel-react](https://www.npmjs.com/package/@scania/tegel-react): Version of @scania/tegel that provides React component wrappers.
 - [@scania/tegel-angular](https://www.npmjs.com/package/@scania/tegel-angular): Version of @scania/tegel that provides Angular component wrappers.
 

--- a/theme/core/typography/README.md
+++ b/theme/core/typography/README.md
@@ -1,4 +1,36 @@
-# Tegel Design System - Typography package
+# SDDS - Typography package
+
+---
+
+# Deprecation Notice
+
+**This package has been deprecated and is no longer actively maintained.**
+
+**Why is this package deprecated?**
+
+This package has reached the end of its development lifecycle, and we have decided to discontinue active support and updates for it. We recommend that you consider alternative solutions for your project to ensure ongoing compatibility, security, and stability.
+
+**Recommended Alternatives**
+
+We suggest exploring the Tegel Design System, which is the successor of SDDS and is actively maintained:
+
+- [@scania/tegel](https://www.npmjs.com/package/@scania/tegel): One package for the entire Tegel design system. Based on Web Components.
+- [@scania/tegel-react](https://www.npmjs.com/package/@scania/tegel-react): Version of @scania/tegel that provides React component wrappers.
+- [@scania/tegel-angular](https://www.npmjs.com/package/@scania/tegel-angular): Version of @scania/tegel that provides Angular component wrappers.
+
+**What should you do now?**
+
+1. **Migrate to an alternative package**: We strongly encourage you to transition to one of the recommended alternatives mentioned above by following their documentation and migration guides on npm or [official Tegel website](https://tegel.scania.com/development/getting-started-development/installation).
+
+2. **Remove the deprecated package**: You can safely remove this package from your project once you have successfully migrated to an alternative solution.
+
+**Thank You!**
+
+We appreciate your support and use of this package. If you have any questions or need further assistance with the deprecation process or migration, feel free to reach out to us by [creating an issue](https://github.com/scania-digital-design-system/tegel/issues/new/choose) in our GitHub repository or contacting [Development support](https://teams.microsoft.com/l/channel/19%3a5e33f67fe502441f914fbcdc6e2548f5%40thread.skype/Development%2520support?groupId=79f9bfeb-73e2-424d-9477-b236191ece5e&tenantId=3bc062e4-ac9d-4c17-b4dd-3aad637ff1ac) channel in Teams.
+
+Again, thank you for being a part of our community, and we hope the recommended alternatives serve your needs effectively.
+
+*Last Updated: October 23rd 2023
 
 ---
 

--- a/theme/core/typography/package-lock.json
+++ b/theme/core/typography/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@scania/typography",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@scania/typography",
-			"version": "1.2.1",
+			"version": "1.2.2",
 			"license": "ISC",
 			"devDependencies": {
 				"sass": "^1.49.9"

--- a/theme/core/typography/package.json
+++ b/theme/core/typography/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scania/typography",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Scania Digital Design System Typography",
   "scripts": {
     "build": "node compile.js"

--- a/theme/light/package-lock.json
+++ b/theme/light/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@scania/theme-light",
-	"version": "4.4.1",
+	"version": "4.4.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@scania/theme-light",
-			"version": "4.4.1",
+			"version": "4.4.2",
 			"license": "ISC",
 			"devDependencies": {
 				"@babel/core": "^7.17.8",

--- a/theme/light/package.json
+++ b/theme/light/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scania/theme-light",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "description": "Scania theme light is a package to style Scania looks and feel.",
   "main": "dist/module.js",
   "scripts": {

--- a/theme/light/readme.md
+++ b/theme/light/readme.md
@@ -16,7 +16,7 @@ This package has reached the end of its development lifecycle, and we have decid
 
 We suggest exploring the Tegel Design System, which is the successor of SDDS and is actively maintained:
 
-- [@scania/tegel](https://www.npmjs.com/package/@scania/tegel): One package for the entire Tegel design system. Based on Web Components.
+- [@scania/tegel](https://www.npmjs.com/package/@scania/tegel): One package for the entire Tegel design system. Based on web components.
 - [@scania/tegel-react](https://www.npmjs.com/package/@scania/tegel-react): Version of @scania/tegel that provides React component wrappers.
 - [@scania/tegel-angular](https://www.npmjs.com/package/@scania/tegel-angular): Version of @scania/tegel that provides Angular component wrappers.
 

--- a/theme/light/readme.md
+++ b/theme/light/readme.md
@@ -22,7 +22,7 @@ We suggest exploring the Tegel Design System, which is the successor of SDDS and
 
 **What should you do now?**
 
-1. **Migrate to an alternative package**: We strongly encourage you to transition to one of the recommended alternatives mentioned above by following their documentation and migration guides on npm or [official Tegel website](https://tegel.scania.com/development/getting-started-development/installation).
+1. **Migrate to an alternative package**: We strongly encourage you to transition to one of the recommended alternatives mentioned above by following their documentation and migration guides on npm, [SDDS -> TDS migration guide](https://tegel.scania.com/development/migration) and [Tegel installation](https://tegel.scania.com/development/getting-started-development/installation) on the official Tegel website.
 
 2. **Remove the deprecated package**: You can safely remove this package from your project once you have successfully migrated to an alternative solution.
 

--- a/theme/light/readme.md
+++ b/theme/light/readme.md
@@ -1,6 +1,41 @@
 ![npm](https://img.shields.io/npm/v/@scania/theme-light)
 
-# Tegel Design System - Theme light
+# SDDS - Theme light
+
+---
+
+# Deprecation Notice
+
+**This package has been deprecated and is no longer actively maintained.**
+
+**Why is this package deprecated?**
+
+This package has reached the end of its development lifecycle, and we have decided to discontinue active support and updates for it. We recommend that you consider alternative solutions for your project to ensure ongoing compatibility, security, and stability.
+
+**Recommended Alternatives**
+
+We suggest exploring the Tegel Design System, which is the successor of SDDS and is actively maintained:
+
+- [@scania/tegel](https://www.npmjs.com/package/@scania/tegel): One package for the entire Tegel design system. Based on Web Components.
+- [@scania/tegel-react](https://www.npmjs.com/package/@scania/tegel-react): Version of @scania/tegel that provides React component wrappers.
+- [@scania/tegel-angular](https://www.npmjs.com/package/@scania/tegel-angular): Version of @scania/tegel that provides Angular component wrappers.
+
+**What should you do now?**
+
+1. **Migrate to an alternative package**: We strongly encourage you to transition to one of the recommended alternatives mentioned above by following their documentation and migration guides on npm or [official Tegel website](https://tegel.scania.com/development/getting-started-development/installation).
+
+2. **Remove the deprecated package**: You can safely remove this package from your project once you have successfully migrated to an alternative solution.
+
+**Thank You!**
+
+We appreciate your support and use of this package. If you have any questions or need further assistance with the deprecation process or migration, feel free to reach out to us by [creating an issue](https://github.com/scania-digital-design-system/tegel/issues/new/choose) in our GitHub repository or contacting [Development support](https://teams.microsoft.com/l/channel/19%3a5e33f67fe502441f914fbcdc6e2548f5%40thread.skype/Development%2520support?groupId=79f9bfeb-73e2-424d-9477-b236191ece5e&tenantId=3bc062e4-ac9d-4c17-b4dd-3aad637ff1ac) channel in Teams.
+
+Again, thank you for being a part of our community, and we hope the recommended alternatives serve your needs effectively.
+
+*Last Updated: October 23rd 2023
+
+---
+
 
 Scania theme is a package to style Scania looks and feel in the [Tegel Design System setup](https://github.com/scania-digital-design-system/sdds/).
 


### PR DESCRIPTION
<!--

Hello! Before you add a PR, please read the [FAQ](https://tegel.scania.com/support/faqs) and/or [Contribution](https://tegel.scania.com/contribution) information and also check if there is an issue already [reported](https://github.com/scania-digital-design-system/sdds-website/pulls).


After the PR is done, please check so all test is finished and fix all conflicts if needed

-->


**Describe pull-request**  

1. Deprecation message for SDDS packages
2. Bumping version of "patch" number for SDDS packages
3. Adding intro deprecation story to Storybook

Packages that will have deprecation message and patch version bumped:

- @scania/icons
- @scania/theme-light
- @scania/components
- @scania/grid
- @scania/colour
- @scania/tyography


**Solving issue**  
Fixes: https://tegel.atlassian.net/browse/CDEP-2746

**How to test**  
1. Check that all packages from the list have new deprecation message
2. Check that all packages from above have "patch" number bumped as preparation for release
3. Check if when loading Storybook, page initially loaded is deprecation notice story



